### PR TITLE
Fix "serve" command not applying template changes

### DIFF
--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -21,6 +21,7 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Yosymfony\ResourceWatcher\Crc32ContentHash;
 use Yosymfony\ResourceWatcher\ResourceCacheMemory;
 use Yosymfony\ResourceWatcher\ResourceWatcher;
@@ -71,8 +72,13 @@ class Serve extends AbstractCommand
         $postprocess = $input->getOption('postprocess');
 
         $this->setUpServer($host, $port);
+
+        $phpFinder = new PhpExecutableFinder();
+        $php = $phpFinder->find();
+
         $command = sprintf(
-            'php -S %s:%d -t %s %s',
+            '%s -S %s:%d -t %s %s',
+            $php,
             $host,
             $port,
             $this->getPath().'/'.(string) $this->getBuilder()->getConfig()->get('output.dir'),

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -116,8 +116,8 @@ class Serve extends AbstractCommand
         }
 
         $buildProcess = new Process($buildProcessArguments, $this->getPath());
-        $buildProcess->setTty(true);
-        $buildProcess->setPty(true);
+        $buildProcess->setTty(Process::isTtySupported());
+        $buildProcess->setPty(Process::isPtySupported());
 
         $processOutputCallback = function ($type, $data) use ($output) {
             $output->write($data, false, OutputInterface::OUTPUT_RAW);

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -10,6 +10,7 @@
 
 namespace Cecil\Command;
 
+use Cecil\Exception\Exception;
 use Cecil\Util;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -74,6 +75,9 @@ class Serve extends AbstractCommand
 
         $phpFinder = new PhpExecutableFinder();
         $php = $phpFinder->find();
+        if ($php === false) {
+            throw new Exception('Can\'t find a local PHP executable.');
+        }
 
         $command = sprintf(
             '%s -S %s:%d -t %s %s',

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -126,7 +126,7 @@ class Serve extends AbstractCommand
         // (re)builds before serve
         $buildProcess->run($processOutputCallback);
         $ret = $buildProcess->getExitCode();
-        if ($ret != 0) {
+        if ($ret !== 0) {
             return 1;
         }
 

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -115,7 +115,7 @@ class Serve extends AbstractCommand
             $buildProcessArguments[] = $this->getConfigFile();
         }
 
-        $buildProcess = new Process($buildProcessArguments, $this->getPath());
+        $buildProcess = new Process(array_merge($buildProcessArguments, [$this->getPath()]));
         $buildProcess->setTty(Process::isTtySupported());
         $buildProcess->setPty(Process::isPtySupported());
 


### PR DESCRIPTION
Fixes #321.

Changes to templates were not applied after a rebuild when using the "serve" command. The cause is Twig's internal template caching that does not refresh as the rebuild command is running in the same process that created the cache.

As no public Twig API is available to refresh the cache this fix uses a separate process for rebuilding.

Changes proposed in this pull request:
- Use PhpExecutableFinder
- Use separate process for running build command to fix templates updates

@Narno please review :eyes:
