### PR TITLE
Fix single quote causing error

### DIFF
--- a/src/Command/NewPage.php
+++ b/src/Command/NewPage.php
@@ -133,7 +133,7 @@ class NewPage extends AbstractCommand
         return <<<'EOT'
 ---
 title: "%title%"
-date: %date%"
+date: %date%
 draft: true
 ---
 _Your content here_


### PR DESCRIPTION
`[ERROR] Expected date format (ie: "2012-10-08") for "date" in .... instead of "2021-02-23""`

Changes proprosed in this pull request:
- Fix single quote causing error

@Narno please review :eyes:
