### PR TITLE
feature: dedicated directory for assets

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -199,6 +199,7 @@ return [
         'dir' => 'themes',
     ],
     'assets' => [
+        'dir'     => 'assets',
         'compile' => [     // Compile Saas
             'enabled'   => true,
             'style'     => 'expanded', // 'expanded' or 'compressed',

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -596,6 +596,8 @@ static:
   load: false # enables `site.static` collection (`false` by default)
 ```
 
+**You should** put your assets files, used by [`asset()`](3-Templates.md#asset), in [`assets` directory](4-Configuration.md#assets) to avoid unnecessary files copy.
+
 _Example:_
 
 ```yaml
@@ -633,6 +635,7 @@ Assets handling options.
 
 ```yml
 assets:
+  dir: assets            # files directory
   fingerprint:
     enabled: true        # enables fingerprinting
   compile:

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -223,27 +223,31 @@ class Asset implements \ArrayAccess
         $cacheKey = $cache->createKeyFromAsset($this, 'compiled');
         if (!$cache->has($cacheKey)) {
             $scssPhp = new Compiler();
-            // import path
-            $scssPhp->addImportPath(Util::joinPath($this->config->getStaticPath()));
+            $importDir = [];
+            $importDir[] = Util::joinPath($this->config->getStaticPath());
+            $importDir[] = Util::joinPath($this->config->getAssetsPath());
             $scssDir = $this->config->get('assets.compile.import') ?? [];
             $themes = $this->config->getTheme() ?? [];
             foreach ($scssDir as $dir) {
-                $scssPhp->addImportPath(Util::joinPath($this->config->getStaticPath(), $dir));
-                $scssPhp->addImportPath(Util::joinPath(dirname($this->data['file']), $dir));
+                $importDir[] = Util::joinPath($this->config->getStaticPath(), $dir);
+                $importDir[] = Util::joinPath($this->config->getAssetsPath(), $dir);
+                $importDir[] = Util::joinPath(dirname($this->data['file']), $dir);
                 foreach ($themes as $theme) {
-                    $scssPhp->addImportPath(Util::joinPath($this->config->getThemeDirPath($theme, "static/$dir")));
+                    $importDir[] = Util::joinPath($this->config->getThemeDirPath($theme, "static/$dir"));
+                    $importDir[] = Util::joinPath($this->config->getThemeDirPath($theme, "assets/$dir"));
                 }
             }
+            $scssPhp->setImportPaths(array_unique($importDir));
             // source map
             if ($this->builder->isDebug() && (bool) $this->config->get('assets.compile.sourcemap')) {
                 $importDir = [];
-                $staticDir = (string) $this->config->get('static.dir');
-                $staticDirPos = strrpos($this->data['file'], DIRECTORY_SEPARATOR.$staticDir.DIRECTORY_SEPARATOR);
-                $fileRelPath = substr($this->data['file'], $staticDirPos + 8);
-                $filePath = Util::joinFile($this->config->getOutputPath(), $this->config->get('static.target') ?? '', $fileRelPath);
+                $assetDir = (string) $this->config->get('assets.dir');
+                $assetDirPos = strrpos($this->data['file'], DIRECTORY_SEPARATOR.$assetDir.DIRECTORY_SEPARATOR);
+                $fileRelPath = substr($this->data['file'], $assetDirPos + 8);
+                $filePath = Util::joinFile($this->config->getOutputPath(), $fileRelPath);
                 $importDir[] = dirname($filePath);
                 foreach ($scssDir as $dir) {
-                    $importDir[] = Util::joinFile($this->config->getOutputPath(), $this->config->get('static.target') ?? '', $dir);
+                    $importDir[] = Util::joinFile($this->config->getOutputPath(), $dir);
                 }
                 $scssPhp->setImportPaths(array_unique($importDir));
                 $scssPhp->setSourceMap(Compiler::SOURCE_MAP_INLINE);
@@ -282,7 +286,7 @@ class Asset implements \ArrayAccess
      */
     public function minify(): self
     {
-        // disable minify for sourcemap
+        // disable minify to preserve inline source map
         if ($this->builder->isDebug() && (bool) $this->config->get('assets.compile.sourcemap')) {
             return $this;
         }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -614,6 +614,20 @@ class Asset implements \ArrayAccess
             return $filePath;
         }
 
+        // checks in assets/
+        $filePath = Util::joinFile($this->config->getAssetsPath(), $path);
+        if (Util\File::getFS()->exists($filePath)) {
+            return $filePath;
+        }
+
+        // checks in each themes/<theme>/assets/
+        foreach ($this->config->getTheme() as $theme) {
+            $filePath = Util::joinFile($this->config->getThemeDirPath($theme, 'assets'), $path);
+            if (Util\File::getFS()->exists($filePath)) {
+                return $filePath;
+            }
+        }
+
         // checks in static/
         $filePath = Util::joinFile($this->config->getStaticPath(), $path);
         if (Util\File::getFS()->exists($filePath)) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -306,6 +306,14 @@ class Config
     }
 
     /**
+     * Returns the path of assets files directory.
+     */
+    public function getAssetsPath(): string
+    {
+        return Util::joinFile($this->getSourceDir(), (string) $this->get('assets.dir'));
+    }
+
+    /**
      * Is cache dir is absolute to system files
      * or relative to project destination?
      */

--- a/src/Step/StaticFiles/Copy.php
+++ b/src/Step/StaticFiles/Copy.php
@@ -71,6 +71,23 @@ class Copy extends AbstractStep
             $this->config->get('static.exclude')
         );
 
+        // copying assets in debug mode (for source maps)
+        if ($this->builder->isDebug() && (bool) $this->config->get('assets.compile.sourcemap')) {
+            // copying content of '<theme>/assets/' dir if exists
+            if ($this->config->hasTheme()) {
+                $themes = array_reverse($this->config->getTheme());
+                foreach ($themes as $theme) {
+                    $this->copy(
+                        $this->config->getThemeDirPath($theme, 'assets')
+                    );
+                }
+            }
+            // copying content of 'assets/' dir if exists
+            $this->copy(
+                $this->config->getAssetsPath()
+            );
+        }
+
         if ($this->count === 0) {
             $this->builder->getLogger()->info('Nothing to copy');
 
@@ -88,9 +105,7 @@ class Copy extends AbstractStep
             $finder = Finder::create()
                 ->files()
                 ->in($from);
-            // do not apply exclude in debug mode (for source map)
-            if ((!$this->builder->isDebug() || false === (bool) $this->config->get('assets.compile.sourcemap'))
-            && is_array($exclude)) {
+            if (is_array($exclude)) {
                 $finder->notPath($exclude);
                 $finder->notName($exclude);
             }


### PR DESCRIPTION
**You should** put your assets files, used by `asset()`, in `assets` directory to avoid unnecessary files copy.

```yaml
assets:
  dir: assets
```