### PR TITLE
feature: multiple configuration files

### DIFF
--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -41,8 +41,8 @@ class AbstractCommand extends Command
     /** @var string */
     protected $path;
 
-    /** @var string */
-    protected $configFile;
+    /** @var array */
+    protected $configFiles;
 
     /** @var Builder */
     protected $builder;
@@ -67,16 +67,25 @@ class AbstractCommand extends Command
                 $this->fs->mkdir($this->getPath());
             }
             $this->path = realpath($this->getPath());
-            // config file
+            // config file(s)
             if (!in_array($this->getName(), ['new:site'])) {
-                $this->configFile = realpath(Util::joinFile($this->getPath(), self::CONFIG_FILE));
+                // default
+                $this->configFiles[self::CONFIG_FILE] = realpath(Util::joinFile($this->getPath(), self::CONFIG_FILE));
+                // from --config=<file>
                 if ($input->hasOption('config') && $input->getOption('config') !== null) {
-                    $this->configFile = realpath((string) $input->getOption('config'));
+                    foreach (explode(',', (string) $input->getOption('config')) as $configFile) {
+                        $this->configFiles[$configFile] = realpath($configFile);
+                        if (!Util\File::getFS()->isAbsolutePath($configFile)) {
+                            $this->configFiles[$configFile] = realpath(Util::joinFile($this->getPath(), $configFile));
+                        }
+                    }
                 }
-                // checks config file
-                if ($this->getConfigFile() === false) {
-                    $this->getBuilder()->getLogger()->warning('Could not find configuration file: uses default.');
-                    $this->configFile = null;
+                // checks file(s)
+                foreach ($this->configFiles as $fileName => $filePath) {
+                    if (!file_exists($filePath)) {
+                        $this->getBuilder()->getLogger()->error(\sprintf('Could not find configuration file "%s": uses others/default.', $fileName));
+                        unset($this->configFiles[$fileName]);
+                    }
                 }
             }
         }
@@ -116,11 +125,11 @@ class AbstractCommand extends Command
     }
 
     /**
-     * Returns the config file path.
+     * Returns config file(s) path.
      */
-    protected function getConfigFile(): ?string
+    protected function getConfigFiles(): array
     {
-        return $this->configFile;
+        return $this->configFiles;
     }
 
     /**
@@ -129,14 +138,18 @@ class AbstractCommand extends Command
     protected function getBuilder(array $config = []): Builder
     {
         try {
-            if (is_file($this->getConfigFile())) {
-                $configContent = Util\File::fileGetContents($this->getConfigFile());
-                if ($configContent === false) {
-                    throw new \Exception('Can\'t read the configuration file.');
+            $siteConfig = [];
+            foreach ($this->getConfigFiles() as $fileName => $filePath) {
+                if (is_file($filePath)) {
+                    $configContent = Util\File::fileGetContents($filePath);
+                    if ($configContent === false) {
+                        throw new \Exception(\sprintf('Can\'t read configuration file "%s".', $fileName));
+                    }
+                    $siteConfig = array_replace_recursive($siteConfig, Yaml::parse($configContent));
                 }
-                $siteConfig = Yaml::parse($configContent);
-                $config = array_replace_recursive($siteConfig, $config);
             }
+            $config = array_replace_recursive($siteConfig, $config);
+
             $this->builder = (new Builder($config, new ConsoleLogger($this->output)))
                 ->setSourceDir($this->getPath())
                 ->setDestinationDir($this->getPath());

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -83,7 +83,7 @@ class AbstractCommand extends Command
                 // checks file(s)
                 foreach ($this->configFiles as $fileName => $filePath) {
                     if (!file_exists($filePath)) {
-                        $this->getBuilder()->getLogger()->error(\sprintf('Could not find configuration file "%s": uses others/default.', $fileName));
+                        $this->getBuilder()->getLogger()->error(\sprintf('Could not find configuration file "%s": uses default/others.', $fileName));
                         unset($this->configFiles[$fileName]);
                     }
                 }
@@ -129,7 +129,7 @@ class AbstractCommand extends Command
      */
     protected function getConfigFiles(): array
     {
-        return $this->configFiles;
+        return array_unique($this->configFiles);
     }
 
     /**

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -33,7 +33,7 @@ class Build extends AbstractCommand
             ->setDefinition(
                 new InputDefinition([
                     new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
-                    new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set the path to the config file'),
+                    new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set the path to the config file(s) (comma-separated)'),
                     new InputOption('drafts', 'd', InputOption::VALUE_NONE, 'Include drafts'),
                     new InputOption('dry-run', null, InputOption::VALUE_NONE, 'Build without saving'),
                     new InputOption('baseurl', null, InputOption::VALUE_REQUIRED, 'Set the base URL'),

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -96,9 +96,9 @@ class Build extends AbstractCommand
             sprintf('<comment>Path: %s</comment>', $this->getPath()),
             OutputInterface::VERBOSITY_VERBOSE
         );
-        if ($this->getConfigFile() !== null) {
+        if (!empty($this->getConfigFiles())) {
             $output->writeln(
-                sprintf('<comment>Config: %s</comment>', $this->getConfigFile()),
+                sprintf('<comment>Config: %s</comment>', implode(',', $this->getConfigFiles())),
                 OutputInterface::VERBOSITY_VERBOSE
             );
         }

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -96,9 +96,9 @@ class Serve extends AbstractCommand
             $_SERVER['argv'][0],
         ];
         $buildProcessArguments[] = 'build';
-        if ($this->getConfigFile() !== null) {
+        if (!empty($this->getConfigFiles())) {
             $buildProcessArguments[] = '--config';
-            $buildProcessArguments[] = $this->getConfigFile();
+            $buildProcessArguments[] = implode(',', $this->getConfigFiles());
         }
         if ($drafts) {
             $buildProcessArguments[] = '--drafts';

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -42,7 +42,7 @@ class Serve extends AbstractCommand
             ->setDefinition(
                 new InputDefinition([
                     new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
-                    new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set the path to the config file'),
+                    new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set the path to the config file(s) (comma-separated)'),
                     new InputOption('drafts', 'd', InputOption::VALUE_NONE, 'Include drafts'),
                     new InputOption('open', 'o', InputOption::VALUE_NONE, 'Open browser automatically'),
                     new InputOption('host', null, InputOption::VALUE_REQUIRED, 'Server host'),


### PR DESCRIPTION
Multiple configuration files can be specified as a comma-separated string to the `--config` option:

```bash
cecil build --config=config_base.yml,config_production.yml
```
Each entry in a file replaces the one in the previous one if it exists.