### PR TITLE
feat: Markdown Note block-level element

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -174,6 +174,9 @@ return [
                 'enabled' => false, // creates WebP images (`false` by default)
             ],
         ],
+        'notes' => [
+            'enabled' => false,  // enables Notes blocks (`false` by default)
+        ],
     ],
     // data files
     'data' => [

--- a/docs/2-Content.md
+++ b/docs/2-Content.md
@@ -99,7 +99,7 @@ customvar: "Value of customvar"
 
 _Body_ is the main content of a _Page_, it could be written in [Markdown](http://daringfireball.net/projects/markdown/syntax), in **[Markdown Extra](https://michelf.ca/projects/php-markdown/extra/)** or in plain text.
 
-_Cecil_ provides extra features to enhance your content (image caption, image lazy loading, image resizing, responsive image, text excerpt, table of contents).  
+Also Cecil provides **extra features** to enhance your content: table of contents, text excerpt, image manipulation (caption, lazy loading, resizing, responsive) and notes).  
 See below for more details.
 
 _Example:_
@@ -118,6 +118,12 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
 ## Sub-Header 2
 
 ![Description](/image.jpg 'Title')
+
+## Sub-Header 3
+
+:::tip
+**Tip**: Advice here.
+:::
 ```
 
 #### Table of contents
@@ -209,6 +215,30 @@ If `resize` and `responsive` options are enabled, then this Markdown line will b
   sizes="100vw"
 >
 ```
+
+#### Notes
+
+Create a _Note_ block (info, tips, important, etc.).
+
+```markdown
+:::tip
+**Tip:** Advice here.
+:::
+```
+
+Is converted to:
+
+```html
+<div class="note note-tip">
+  <p>
+    <strong>Tip:</strong> Advice here.
+  </p>
+</div>
+```
+
+:::info
+**Info:** To enable _Notes_ converting the [`body.notes.enabled` option](4-Configuration.md#body) must be set to `true` in the config file.
+:::
 
 ## Variables
 

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -115,9 +115,9 @@ Can be displayed in a template with:
 | `site.taxonomies`     | Collection of vocabularies.                           |
 | `site.time`           | [_Timestamp_](https://wikipedia.org/wiki/Unix_time) of the last generation. |
 
-<div markdown="1" class="note note-tip">
+:::tip
 **Tip:** You can get any page with `site.pages['id']` where `id` is the _ID_ of a page (e.g.: `index` for home page).
-</div>
+:::
 
 #### site.menus
 

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -565,6 +565,8 @@ body:
       enabled: false     # creates responsive images (`false` by default)
     webp:
       enabled: false     # creates WebP images (`false` by default)
+  notes:
+    enabled: false       # enables Notes blocks (`false` by default)
 ```
 
 See _[Content > Page > Body](2-Content.md#body)_ documentation to know how those options impacts your content.

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -244,10 +244,10 @@ class Parsedown extends \ParsedownToC
     {
         if (preg_match('/:::(.*)/', $block['text'], $matches)) {
             return [
-                'char' => ':',
+                'char'    => ':',
                 'element' => [
-                    'name' => 'div',
-                    'text' => '',
+                    'name'       => 'div',
+                    'text'       => '',
                     'attributes' => [
                         'class' => "note note-{$matches[1]}",
                     ],
@@ -255,6 +255,7 @@ class Parsedown extends \ParsedownToC
             ];
         }
     }
+
     protected function blockNoteContinue($line, $block)
     {
         if (isset($block['complete'])) {
@@ -265,10 +266,11 @@ class Parsedown extends \ParsedownToC
 
             return $block;
         }
-        $block['element']['text'] .= $line['text'] . "\n";
+        $block['element']['text'] .= $line['text']."\n";
 
         return $block;
     }
+
     protected function blockNoteComplete($block)
     {
         $block['element']['rawHtml'] = $this->text($block['element']['text']);

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -261,7 +261,7 @@ class Parsedown extends \ParsedownToC
         if (isset($block['complete'])) {
             return;
         }
-        if (preg_match('/:::/', $line['text'], $matches)) {
+        if (preg_match('/:::/', $line['text'])) {
             $block['complete'] = true;
 
             return $block;


### PR DESCRIPTION
```markdown
:::tip
**Tip:** Advice here.
:::
```
Is converted to:

```html
<div class="note note-tip">
  <p>
    <strong>Tip:</strong> Advice here.
  </p>
</div>
```
