### PR TITLE
feat: Define responsive images widths

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -227,12 +227,8 @@ return [
             'quality'    => 75,     // Image quality after optimization or resize (`75` by default)
             'responsive' => [
                 'enabled' => false, // creates responsive images with `html` filter (`false` by default)
-                'width'   => [
-                    'steps' => 5,     // number of steps from `min` to `max` (`5` by default)
-                    'min'   => 320,   // minimum width (`320` by default)
-                    'max'   => 1280,  // maximum width (`1280` by default)
-                ],
-                'sizes' => [
+                'widths'  => [480, 640, 768, 1024, 1366, 1600, 1920],
+                'sizes'   => [
                     'default' => '100vw', // `sizes` attribute (`100vw` by default)
                 ],
             ],

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -673,10 +673,7 @@ assets:
     quality: 75          # image quality after optimization or resize (`75` by default)
     responsive:
       enabled: false     # creates responsive images with `html` filter (`false` by default)
-      width:             # `srcset` range
-        steps: 5           # number of steps from `min` to `max` (`5` by default)
-        min: 320           # minimum width (`320` by default)
-        max: 1280          # maximum width (`1280` by default)
+      widths: [480, 640, 768, 1024, 1366, 1600, 1920] # `srcset` widths (`[480, 640, 768, 1024, 1366, 1600, 1920]` by default)
       sizes:
         default: '100vw' # `sizes` attribute (`100vw` by default)
     webp:

--- a/src/Assets/Image.php
+++ b/src/Assets/Image.php
@@ -61,21 +61,19 @@ class Image
      * Build the `srcset` attribute for responsive images.
      * ie: srcset="/img-480.jpg 480w, /img-800.jpg 800w".
      */
-    public static function getSrcset(Asset $asset, int $steps, int $wMin, int $wMax): string
+    public static function buildSrcset(Asset $asset, array $widths): string
     {
         $srcset = '';
-        for ($i = 1; $i <= $steps; $i++) {
-            $w = ceil($wMin * $i);
-            if ($w > $asset->getWidth() || $w > $wMax) {
+        foreach ($widths as $width) {
+            if ($width > $asset->getWidth() || $width > max($widths)) {
                 break;
             }
             $a = clone $asset;
-            $img = $a->resize(intval($w));
-            $srcset .= sprintf('%s %sw', $img, $w);
-            if ($i < $steps) {
-                $srcset .= ', ';
-            }
+            $img = $a->resize($width);
+            $srcset .= sprintf('%s %sw, ', $img, $width);
+            unset($a);
         }
+        rtrim($srcset, ', ');
         // add reference image
         if (!empty($srcset)) {
             $srcset .= sprintf('%s %sw', (string) $asset, $asset->getWidth());

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -92,11 +92,9 @@ class Parsedown extends \ParsedownToC
          * Should be responsive?
          */
         if ($this->builder->getConfig()->get('body.images.responsive.enabled')) {
-            if ($srcset = Image::getSrcset(
+            if ($srcset = Image::buildSrcset(
                 $assetResized ?? $asset,
-                $this->builder->getConfig()->get('assets.images.responsive.width.steps') ?? 5,
-                $this->builder->getConfig()->get('assets.images.responsive.width.min') ?? 320,
-                $this->builder->getConfig()->get('assets.images.responsive.width.max') ?? 1280
+                $this->builder->getConfig()->get('assets.images.responsive.widths') ?? [480, 640, 768, 1024, 1366, 1600, 1920]
             )) {
                 $image['element']['attributes']['srcset'] = $srcset;
                 $image['element']['attributes']['sizes'] = $this->builder->getConfig()->get('assets.images.responsive.sizes.default');
@@ -178,11 +176,9 @@ class Parsedown extends \ParsedownToC
             $assetWebp = Image::convertTopWebp($InlineImage['element']['attributes']['src'], $this->builder->getConfig()->get('assets.images.quality') ?? 75);
             $srcset = '';
             if ($this->builder->getConfig()->get('body.images.responsive.enabled')) {
-                $srcset = Image::getSrcset(
+                $srcset = Image::buildSrcset(
                     $assetWebp,
-                    $this->builder->getConfig()->get('assets.images.responsive.width.steps') ?? 5,
-                    $this->builder->getConfig()->get('assets.images.responsive.width.min') ?? 320,
-                    $this->builder->getConfig()->get('assets.images.responsive.width.max') ?? 1280
+                    $this->builder->getConfig()->get('assets.images.responsive.widths') ?? [480, 640, 768, 1024, 1366, 1600, 1920]
                 );
             }
             if (empty($srcset)) {

--- a/src/Renderer/Twig/Extension.php
+++ b/src/Renderer/Twig/Extension.php
@@ -520,11 +520,9 @@ class Extension extends SlugifyExtension
         /* Image */
         if ($asset['type'] == 'image') {
             // responsive
-            if ($responsive && $srcset = Image::getSrcset(
+            if ($responsive && $srcset = Image::buildSrcset(
                 $asset,
-                $this->config->get('assets.images.responsive.width.steps') ?? 5,
-                $this->config->get('assets.images.responsive.width.min') ?? 320,
-                $this->config->get('assets.images.responsive.width.max') ?? 1280
+                $this->config->get('assets.images.responsive.widths') ?? [480, 640, 768, 1024, 1366, 1600, 1920]
             )) {
                 $htmlAttributes .= \sprintf(' srcset="%s"', $srcset);
                 $htmlAttributes .= \sprintf(' sizes="%s"', $this->config->get('assets.images.responsive.sizes.default') ?? '100vw');
@@ -544,11 +542,9 @@ class Extension extends SlugifyExtension
                 $source = \sprintf('<source type="image/webp" srcset="%s">', $assetWebp);
                 // responsive
                 if ($responsive) {
-                    $srcset = Image::getSrcset(
+                    $srcset = Image::buildSrcset(
                         $assetWebp,
-                        $this->config->get('assets.images.responsive.width.steps') ?? 5,
-                        $this->config->get('assets.images.responsive.width.min') ?? 320,
-                        $this->config->get('assets.images.responsive.width.max') ?? 1280
+                        $this->config->get('assets.images.responsive.widths') ?? [480, 640, 768, 1024, 1366, 1600, 1920]
                     ) ?: (string) $assetWebp;
                     // <source>
                     $source = \sprintf(


### PR DESCRIPTION
Responsive images widths now defined by a list:

```yaml
assets:
  images:
    responsive:
      enabled: false
      widths: [480, 640, 768, 1024, 1366, 1600, 1920]
```