### PR TITLE
fix: do not ignore dot files

### DIFF
--- a/src/Step/StaticFiles/Copy.php
+++ b/src/Step/StaticFiles/Copy.php
@@ -105,7 +105,8 @@ class Copy extends AbstractStep
         if (Util\File::getFS()->exists($from)) {
             $finder = Finder::create()
                 ->files()
-                ->in($from);
+                ->in($from)
+                ->ignoreDotFiles(false);
             if (is_array($exclude)) {
                 $finder->notPath($exclude);
                 $finder->notName($exclude);


### PR DESCRIPTION
The static files copy step use Symfony Finder that ignore "dot files" by default. This fix that behavior.