### PR TITLE
feat: translations config + clear cache cmd

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -230,6 +230,10 @@ return [
     'themes' => [
         'dir' => 'themes',
     ],
+    // i18n
+    'translations' => [
+        'dir' => 'translations',
+    ],
     'assets' => [
         'dir'     => 'assets',
         'compile' => [     // Compile Saas
@@ -291,6 +295,10 @@ return [
         ],
         'assets' => [
             'dir' => 'assets/remote',
+        ],
+        'translations' => [
+            'dir'     => 'translations',
+            'enabled' => true,
         ],
     ],
     'generators' => [

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -1,7 +1,7 @@
 <!--
 description: "Working with templates and use variables."
 date: 2021-05-07
-updated: 2022-08-30
+updated: 2022-09-08
 alias: documentation/layouts
 -->
 

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -879,7 +879,7 @@ Uses the `trans` _tag_ or _filter_ to translate texts in templates.
 Include variables:
 
 ```twig
-{% trans with {'%name%': 'Arnaud'} %}Hello "%name%"!{% endtrans %}
+{% trans with {'%name%': 'Arnaud'} %}Hello %name%!{% endtrans %}
 ```
 
 ```twig

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -898,7 +898,7 @@ Pluralize:
 {% trans with {'%count%': 42}%}{0}I don't have apples|{1}I have one apple|]1,Inf[I have %count% apples{% endtrans %}
 ```
 
-Translation files must be named `messages.<locale>.mo` and stored in the `translations` directory.
+Translation files must be named `messages.<locale>.mo` and stored in the [`translations`](4-Configuration.md#translations) directory.
 
 ```plaintext
 <mywebsite>
@@ -908,6 +908,10 @@ Translation files must be named `messages.<locale>.mo` and stored in the `transl
 ```
 
 [_Poedit Pro_](https://poedit.net/pro) is recommended to easily translate your templates.
+
+:::important
+Be carreful about the cache ([enabled by default](4-Configuration.md#cache)) when you update translations files.  Cache can be cleared with with the following command: `php cecil.phar cache:clear:translations`.
+:::
 
 ### Date localization
 

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -679,6 +679,15 @@ themes:
   dir: themes # themes directory
 ```
 
+### translations
+
+Where translations files are stored.
+
+```yaml
+translations:
+  dir: translations # translations directory
+```
+
 ### assets
 
 Assets handling options.
@@ -754,6 +763,9 @@ cache:
     enabled: true  # enables templates cache
   assets:       # assets cache
     dir: 'assets/remote' # the subdirectory of remote assets cache
+  translations:
+    dir: 'translations' # translations cache directory
+    enabled: true       # enables translations cache
 ```
 
 ### generators

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -1,7 +1,7 @@
 <!--
 description: "Configure your website."
 date: 2021-05-07
-updated: 2022-08-27
+updated: 2022-09-08
 -->
 
 # Configuration

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -1,7 +1,7 @@
 <!--
 description: "List of available commands."
 date: 2020-12-19
-updated: 2021-12-08
+updated: 2022-09-08
 -->
 
 # Commands
@@ -13,7 +13,7 @@ Available commands:
   build                     Builds the website
   clear                     Removes generated files
   help                      Display help for a command
-  open                      Open content directory with the editor
+  open                      Open pages directory with the editor
   self-update               Updates Cecil to the latest version
   serve                     Starts the built-in server
  cache

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -10,22 +10,23 @@ List of all available commands.
 
 ```plaintext
 Available commands:
-  build                  Builds the website
-  clear                  [clean] Removes generated files
-  help                   Display help for a command
-  open                   Open content directory with the editor
-  self-update            Updates Cecil to the latest version
-  serve                  Starts the built-in server
+  build                     Builds the website
+  clear                     Removes generated files
+  help                      Display help for a command
+  open                      Open content directory with the editor
+  self-update               Updates Cecil to the latest version
+  serve                     Starts the built-in server
  cache
-  cache:clear            Removes all caches
-  cache:clear:assets     Removes assets cache
-  cache:clear:templates  Removes templates cache
+  cache:clear               Removes all caches
+  cache:clear:assets        Removes assets cache
+  cache:clear:templates     Removes templates cache
+  cache:clear:translations  Removes translations cache
  new
-  new:page               Creates a new page
-  new:site               Creates a new website
+  new:page                  Creates a new page
+  new:site                  Creates a new website
  show
-  show:config            Shows the configuration
-  show:content           Shows content as tree
+  show:config               Shows the configuration
+  show:content              Shows content as tree
 ```
 
 ## Main commands

--- a/src/Application.php
+++ b/src/Application.php
@@ -51,6 +51,7 @@ class Application extends BaseApplication
             new Command\CacheClear(),
             new Command\CacheClearAssets(),
             new Command\CacheClearTemplates(),
+            new Command\CacheClearTranslations(),
             new Command\ShowContent(),
             new Command\ShowConfig(),
             new Command\ListCommand(),

--- a/src/Command/CacheClearTemplates.php
+++ b/src/Command/CacheClearTemplates.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Cecil\Command;
 
-use Cecil\Util;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,17 +44,17 @@ class CacheClearTemplates extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$this->fs->exists(Util::joinFile($this->getBuilder()->getConfig()->getCachePath(), 'templates'))) {
+        if (!$this->fs->exists($this->getBuilder()->getConfig()->getCacheTemplatesPath())) {
             $output->writeln('<info>No templates cache.</info>');
 
             return 0;
         }
         $output->writeln('Removing templates cache directory...');
         $output->writeln(
-            \sprintf('<comment>Path %s</comment>', Util::joinFile($this->getBuilder()->getConfig()->getCachePath(), 'templates')),
+            \sprintf('<comment>Path %s</comment>', $this->getBuilder()->getConfig()->getCacheTemplatesPath()),
             OutputInterface::VERBOSITY_VERBOSE
         );
-        $this->fs->remove(Util::joinFile($this->getBuilder()->getConfig()->getCachePath(), 'templates'));
+        $this->fs->remove($this->getBuilder()->getConfig()->getCacheTemplatesPath());
         $output->writeln('<info>Templates cache is clear.</info>');
 
         return 0;

--- a/src/Command/CacheClearTranslations.php
+++ b/src/Command/CacheClearTranslations.php
@@ -19,9 +19,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Removes assets cache files.
+ * Removes translations cache files.
  */
-class CacheClearAssets extends AbstractCommand
+class CacheClearTranslations extends AbstractCommand
 {
     /**
      * {@inheritdoc}
@@ -29,14 +29,14 @@ class CacheClearAssets extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setName('cache:clear:assets')
-            ->setDescription('Removes assets cache')
+            ->setName('cache:clear:translations')
+            ->setDescription('Removes translations cache')
             ->setDefinition(
                 new InputDefinition([
                     new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
                 ])
             )
-            ->setHelp('Removes cached assets files');
+            ->setHelp('Removes cached translations files');
     }
 
     /**
@@ -44,18 +44,18 @@ class CacheClearAssets extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$this->fs->exists($this->getBuilder()->getConfig()->getCacheAssetsPath())) {
-            $output->writeln('<info>No assets cache.</info>');
+        if (!$this->fs->exists($this->getBuilder()->getConfig()->getCacheTranslationsPath())) {
+            $output->writeln('<info>No translations cache.</info>');
 
             return 0;
         }
-        $output->writeln('Removing assets cache directory...');
+        $output->writeln('Removing translations cache directory...');
         $output->writeln(
-            \sprintf('<comment>Path %s</comment>', $this->getBuilder()->getConfig()->getCacheAssetsPath()),
+            \sprintf('<comment>Path %s</comment>', $this->getBuilder()->getConfig()->getCacheTranslationsPath()),
             OutputInterface::VERBOSITY_VERBOSE
         );
-        $this->fs->remove($this->getBuilder()->getConfig()->getCacheAssetsPath());
-        $output->writeln('<info>Assets cache is clear.</info>');
+        $this->fs->remove($this->getBuilder()->getConfig()->getCacheTranslationsPath());
+        $output->writeln('<info>Translations cache is clear.</info>');
 
         return 0;
     }

--- a/src/Command/OpenWith.php
+++ b/src/Command/OpenWith.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Open content with an editor.
+ * Open pages with an editor.
  */
 class OpenWith extends AbstractCommand
 {
@@ -33,14 +33,14 @@ class OpenWith extends AbstractCommand
     {
         $this
             ->setName('open')
-            ->setDescription('Open content directory with the editor')
+            ->setDescription('Open pages directory with the editor')
             ->setDefinition(
                 new InputDefinition([
                     new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
                     new InputOption('editor', null, InputOption::VALUE_REQUIRED, 'Editor to use'),
                 ])
             )
-            ->setHelp('Open content directory with the editor defined in the configuration file.');
+            ->setHelp('Open pages directory with the editor defined in the configuration file.');
     }
 
     /**
@@ -59,7 +59,7 @@ class OpenWith extends AbstractCommand
                 }
                 $editor = (string) $this->getBuilder()->getConfig()->get('editor');
             }
-            $output->writeln(\sprintf('<info>Opening content directory with %s...</info>', ucfirst($editor)));
+            $output->writeln(\sprintf('<info>Opening pages directory with %s...</info>', ucfirst($editor)));
             $this->openEditor(Util::joinFile($this->getPath(), (string) $this->getBuilder()->getConfig()->get('pages.dir')), $editor);
         } catch (\Exception $e) {
             throw new RuntimeException(\sprintf($e->getMessage()));

--- a/src/Config.php
+++ b/src/Config.php
@@ -290,7 +290,7 @@ class Config
      */
     public function getTranslationsPath(): string
     {
-        return Util::joinFile($this->getSourceDir(), 'translations');
+        return Util::joinFile($this->getSourceDir(), (string) $this->get('translations.dir'));
     }
 
     /**
@@ -364,6 +364,22 @@ class Config
         }
 
         return Util::joinFile($this->getDestinationDir(), (string) $this->get('cache.dir'));
+    }
+
+    /**
+     * Returns cache path of templates.
+     */
+    public function getCacheTemplatesPath(): string
+    {
+        return Util::joinFile($this->getCachePath(), (string) $this->get('cache.templates.dir'));
+    }
+
+    /**
+     * Returns cache path of translations.
+     */
+    public function getCacheTranslationsPath(): string
+    {
+        return Util::joinFile($this->getCachePath(), (string) $this->get('cache.translations.dir'));
     }
 
     /**

--- a/src/Renderer/Twig.php
+++ b/src/Renderer/Twig.php
@@ -86,7 +86,7 @@ class Twig implements RendererInterface
         $this->translator = new Translator(
             $builder->getConfig()->getLanguageProperty('locale'),
             new MessageFormatter(new IdentityTranslator()),
-            $builder->getConfig()->get('cache.templates.enabled') ? $builder->getConfig()->getCacheTranslationsPath() : false,
+            $builder->getConfig()->get('cache.templates.enabled') ? $builder->getConfig()->getCacheTranslationsPath() : null,
             $builder->isDebug()
         );
         if (count($builder->getConfig()->getLanguages()) > 1) {

--- a/src/Renderer/Twig.php
+++ b/src/Renderer/Twig.php
@@ -54,11 +54,7 @@ class Twig implements RendererInterface
         ];
         // use Twig cache?
         if ($builder->getConfig()->get('cache.templates.enabled')) {
-            $templatesCachePath = \Cecil\Util::joinFile(
-                $builder->getConfig()->getCachePath(),
-                (string) $builder->getConfig()->get('cache.templates.dir')
-            );
-            $loaderOptions = array_replace($loaderOptions, ['cache' => $templatesCachePath]);
+            $loaderOptions = array_replace($loaderOptions, ['cache' => $builder->getConfig()->getCacheTemplatesPath()]);
         }
         // create the Twig instance
         $this->twig = new \Twig\Environment($loader, $loaderOptions);
@@ -87,13 +83,13 @@ class Twig implements RendererInterface
             return false;
         });
         // l10n
+        $this->translator = new Translator(
+            $builder->getConfig()->getLanguageProperty('locale'),
+            new MessageFormatter(new IdentityTranslator()),
+            $builder->getConfig()->get('cache.templates.enabled') ? $builder->getConfig()->getCacheTranslationsPath() : false,
+            $builder->isDebug()
+        );
         if (count($builder->getConfig()->getLanguages()) > 1) {
-            $this->translator = new Translator(
-                $builder->getConfig()->getLanguageProperty('locale'),
-                new MessageFormatter(new IdentityTranslator()),
-                Util::joinFile($builder->getConfig()->getCachePath(), 'translations'),
-                $builder->isDebug()
-            );
             $this->translator->addLoader('mo', new MoFileLoader());
             foreach ($builder->getConfig()->getLanguages() as $lang) {
                 // themes
@@ -105,8 +101,8 @@ class Twig implements RendererInterface
                 // site
                 $this->addTransResource($builder->getConfig()->getTranslationsPath(), $lang['locale']);
             }
-            $this->twig->addExtension(new TranslationExtension($this->translator));
         }
+        $this->twig->addExtension(new TranslationExtension($this->translator));
         // debug
         if ($builder->isDebug()) {
             // dump()


### PR DESCRIPTION
- feat: config option to define translations dir
- feat: config option to disable translations cache
- feat: new comand to clear translations cache
- fix: create a default translator to always support `trans`
