### PR TITLE
feat: support of custom (localized) `path` for section

### DIFF
--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -462,6 +462,7 @@ Defines a custom [`path`](2-Content.md#variables) for all pages of a _Section_.
 ```yaml
 paths:
   - section: <section’s name>
+    language: <language> # optional
     path: <path of pages, with palceholders>
 ```
 
@@ -479,6 +480,9 @@ _Example:_
 paths:
   - section: Blog
     path: :section/:year/:month/:day/:slug/ # e.g.: blog/2020/12/01/my-post/
+  - section: Blog
+    language: fr
+    path: blogue/:year/:month/:day/:slug/ # e.g.: blogue/2020/12/01/mon-billet/
 ```
 
 ### debug

--- a/src/Generator/Section.php
+++ b/src/Generator/Section.php
@@ -55,7 +55,8 @@ class Section extends AbstractGenerator implements GeneratorInterface
                     if ($language != $this->config->getLanguageDefault()) {
                         $pageId = \sprintf('%s.%s', $pageId, $language);
                     }
-                    $page = (new Page($pageId))->setVariable('title', ucfirst($section));
+                    $page = (new Page($pageId))->setVariable('title', ucfirst($section))
+                        ->setPath($path);
                     if ($this->builder->getPages()->has($pageId)) {
                         $page = clone $this->builder->getPages()->get($pageId);
                     }
@@ -86,8 +87,8 @@ class Section extends AbstractGenerator implements GeneratorInterface
                         $this->addNavigationLinks($pages, $page->getVariable('sortby'), $page->getVariable('circular'));
                     }
                     // creates page for each section
-                    $page->setPath($path)
-                        ->setType(Type::SECTION)
+                    $page->setType(Type::SECTION)
+                        ->setSection($path)
                         ->setPages($pages)
                         ->setVariable('language', $language)
                         ->setVariable('date', $pages->first()->getVariable('date'))

--- a/src/Renderer/Layout.php
+++ b/src/Renderer/Layout.php
@@ -110,7 +110,7 @@ class Layout
                     "_default/list.$format.$ext",
                 ];
                 if ($page->getPath()) {
-                    $section = explode('/', $page->getPath())[0];
+                    $section = $page->getSection();
                     $layouts = array_merge(
                         [sprintf('section/%s.%s.%s', $section, $format, $ext)],
                         $layouts

--- a/src/Step/Pages/Convert.php
+++ b/src/Step/Pages/Convert.php
@@ -86,6 +86,7 @@ class Convert extends AbstractStep
                  * ie:
                  * paths:
                  * - section: Blog
+                 *   language: fr # optional
                  *   path: :section/:year/:month/:day/:slug
                  */
                 if (is_array($this->config->get('paths'))) {
@@ -93,6 +94,9 @@ class Convert extends AbstractStep
                         if (isset($entry['section'])) {
                             /** @var Page $page */
                             if ($page->getSection() == Page::slugify($entry['section'])) {
+                                if ((isset($entry['language']) && $entry['language'] != $page->getVariable('language'))) {
+                                    break;
+                                }
                                 if (isset($entry['path'])) {
                                     $path = str_replace(
                                         [
@@ -111,7 +115,7 @@ class Convert extends AbstractStep
                                         ],
                                         $entry['path']
                                     );
-                                    $page->setPath($path);
+                                    $page->setPath(trim($path, '/'));
                                 }
                             }
                         }


### PR DESCRIPTION
Section's pages (i.e.: `section/index.md`) now support custom `path` (set in front matter).

And custom `path` of pages' section can be different by language:

```yaml
paths:
  - section: <section’s name>
    language: <language> # optional
    path: <path of pages, with palceholders>
```