### PR TITLE
feat: enhance prev/next navigation in section

### DIFF
--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -1,7 +1,7 @@
 <!--
 description: "Working with templates and use variables."
 date: 2021-05-07
-updated: 2022-09-08
+updated: 2022-09-18
 alias: documentation/layouts
 -->
 
@@ -215,11 +215,16 @@ Contains built-in variables of a page **and** those set in the [front matter](2-
 
 Navigation between pages in a same _Section_.
 
-| Variable                 | Description                                             |
-| ------------------------ | ------------------------------------------------------- |
-| `page.<prev/next>.id`    | ID of the previous / next page (e.g.: `blog/post-2`).   |
-| `page.<prev/next>.path`  | Path of the previous / next page (e.g.: `blog/post-2`). |
-| `page.<prev/next>.title` | Title of the previous / next page (e.g.: `Post 2`).     |
+| Variable              | Description                                            | Example                    |
+| --------------------- | ------------------------------------------------------ | -------------------------- |
+| `page.prev`           | Previous page.                                         | _Page_                     |
+| `page.next`           | Next page.                                             | _Page_                     |
+
+_Example:_
+
+```twig
+<a href="{{ url(page.prev) }}">{{ page.prev.title }}</a>
+```
 
 #### page.pagination
 

--- a/src/Generator/Section.php
+++ b/src/Generator/Section.php
@@ -121,52 +121,28 @@ class Section extends AbstractGenerator implements GeneratorInterface
                     case 0:
                         if ($circular) {
                             $page->setVariables([
-                                'prev' => [
-                                    'id'    => $pagesAsArray[$count - 1]->getId(),
-                                    'path'  => $pagesAsArray[$count - 1]->getPath(),
-                                    'title' => $pagesAsArray[$count - 1]->getVariable('title'),
-                                ],
+                                'prev' => $pagesAsArray[$count - 1],
                             ]);
                         }
                         $page->setVariables([
-                            'next' => [
-                                'id'    => $pagesAsArray[$position + 1]->getId(),
-                                'path'  => $pagesAsArray[$position + 1]->getPath(),
-                                'title' => $pagesAsArray[$position + 1]->getVariable('title'),
-                            ],
+                            'next' => $pagesAsArray[$position + 1],
                         ]);
                         break;
                     // last
                     case $count - 1:
                         $page->setVariables([
-                            'prev' => [
-                                'id'    => $pagesAsArray[$position - 1]->getId(),
-                                'path'  => $pagesAsArray[$position - 1]->getPath(),
-                                'title' => $pagesAsArray[$position - 1]->getVariable('title'),
-                            ],
+                            'prev' => $pagesAsArray[$position - 1],
                         ]);
                         if ($circular) {
                             $page->setVariables([
-                                'next' => [
-                                    'id'    => $pagesAsArray[0]->getId(),
-                                    'path'  => $pagesAsArray[0]->getPath(),
-                                    'title' => $pagesAsArray[0]->getVariable('title'),
-                                ],
+                                'next' => $pagesAsArray[0],
                             ]);
                         }
                         break;
                     default:
                         $page->setVariables([
-                            'prev' => [
-                                'id'    => $pagesAsArray[$position - 1]->getId(),
-                                'path'  => $pagesAsArray[$position - 1]->getPath(),
-                                'title' => $pagesAsArray[$position - 1]->getVariable('title'),
-                            ],
-                            'next' => [
-                                'id'    => $pagesAsArray[$position + 1]->getId(),
-                                'path'  => $pagesAsArray[$position + 1]->getPath(),
-                                'title' => $pagesAsArray[$position + 1]->getVariable('title'),
-                            ],
+                            'prev' => $pagesAsArray[$position - 1],
+                            'next' => $pagesAsArray[$position + 1],
                         ]);
                         break;
                 }


### PR DESCRIPTION
Variables `page.prev` and `page.next` now contains the page item, so it's easier to access of all properties of the page.

For example:

```twig
<a href="{{ url(page.prev) }}">{{ page.prev.title }}</a>
```