### PR TITLE
feat: new "toc" filter

### DIFF
--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -552,6 +552,21 @@ _Examples:_
 {% endapply %}
 ```
 
+### toc
+
+Extracts table of content from a Markdown string, in the given format ("html" or "json", "html" by default).
+
+```twig
+{{ markdown|toc(format) }}
+```
+
+_Examples:_
+
+```twig
+{{ page.body|toc }}
+{{ page.body|toc('json') }}
+```
+
 ### json_decode
 
 Converts a JSON string to an array.

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -34,7 +34,7 @@ class Parsedown extends \ParsedownToC
     /** @var Highlighter */
     protected $highlighter;
 
-    public function __construct(Builder $builder)
+    public function __construct(Builder $builder, ?array $options = null)
     {
         $this->builder = $builder;
 
@@ -52,8 +52,10 @@ class Parsedown extends \ParsedownToC
         // code highlight
         $this->highlighter = new Highlighter();
 
-        // Table of Content
-        parent::__construct(['selectors' => $this->builder->getConfig()->get('body.toc')]);
+        // options
+        $options = array_merge(['selectors' => $this->builder->getConfig()->get('body.toc')], $options ?? []);
+
+        parent::__construct($options);
     }
 
     /**

--- a/src/Renderer/Twig/Extension.php
+++ b/src/Renderer/Twig/Extension.php
@@ -95,6 +95,7 @@ class Extension extends SlugifyExtension
             new \Twig\TwigFilter('excerpt', [$this, 'excerpt']),
             new \Twig\TwigFilter('excerpt_html', [$this, 'excerptHtml']),
             new \Twig\TwigFilter('markdown_to_html', [$this, 'markdownToHtml']),
+            new \Twig\TwigFilter('toc', [$this, 'markdownToToc']),
             new \Twig\TwigFilter('json_decode', [$this, 'jsonDecode']),
             new \Twig\TwigFilter('yaml_parse', [$this, 'yamlParse']),
             new \Twig\TwigFilter('preg_split', [$this, 'pregSplit']),
@@ -656,6 +657,25 @@ class Extension extends SlugifyExtension
         }
 
         return $html;
+    }
+
+    /**
+     * Extract table of content of a Markdown string,
+     * in the given format ("html" or "json", "html" by default).
+     */
+    public function markdownToToc(?string $markdown, $format = 'html'): ?string
+    {
+        $markdown = $markdown ?? '';
+
+        try {
+            $parsedown = new Parsedown($this->builder, ['selectors' => ['h2']]);
+            $parsedown->body($markdown);
+            $return = $parsedown->contentsList($format);
+        } catch (\Exception $e) {
+            throw new RuntimeException('"toc" filter can not convert supplied Markdown.');
+        }
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
Extracts table of content from a Markdown string, in the given format ("html" or "json", "html" by default).

```twig
{{ page.body|toc }}
{{ page.body|toc('html') }}
{{ page.body|toc('json') }}
```