### PR TITLE
feat: fetch the dominant color of an image

### DIFF
--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -819,6 +819,15 @@ Returns the [data URL](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTT
 {{ asset(image_path)|dataurl }}
 ```
 
+### dominant_color
+
+Returns the dominant hex color of an image.
+
+```twig
+{{ asset(image_path)|dominant_color }}
+# #F2D07F
+```
+
 ### inline
 
 Outputs the content of an _Asset_.

--- a/src/Assets/Image.php
+++ b/src/Assets/Image.php
@@ -124,4 +124,24 @@ class Image
 
         return $count > 1;
     }
+
+    /**
+     * Returns the dominant hex color of an image asset.
+     *
+     * @throws RuntimeException
+     */
+    public static function getDominantColor(Asset $asset): string
+    {
+        if ($asset['type'] !== 'image') {
+            throw new RuntimeException(\sprintf('Can not get dominant color of "%s": it\'s not an image file.', $asset['path']));
+        }
+
+        $assetColor = clone $asset;
+        $assetColor = $assetColor->resize(100);
+        $image = ImageManager::make($assetColor['content']);
+        $color = $image->limitColors(1)->pickColor(0, 0, 'hex');
+        $image->destroy();
+
+        return $color;
+    }
 }

--- a/src/Renderer/Twig/Extension.php
+++ b/src/Renderer/Twig/Extension.php
@@ -90,6 +90,7 @@ class Extension extends SlugifyExtension
             new \Twig\TwigFilter('sass_to_css', [$this, 'scssToCss']),
             new \Twig\TwigFilter('resize', [$this, 'resize']),
             new \Twig\TwigFilter('dataurl', [$this, 'dataurl']),
+            new \Twig\TwigFilter('dominant_color', [$this, 'dominantColor']),
             // content
             new \Twig\TwigFilter('slugify', [$this, 'slugifyFilter']),
             new \Twig\TwigFilter('excerpt', [$this, 'excerpt']),
@@ -792,6 +793,22 @@ class Extension extends SlugifyExtension
     public function isAsset($variable): bool
     {
         return $variable instanceof Asset;
+    }
+
+    /**
+     * Returns the dominant hex color of an image asset.
+     *
+     * @param string|Asset $path
+     *
+     * @return string
+     */
+    public function dominantColor($asset): string
+    {
+        if (!$asset instanceof Asset) {
+            $asset = new Asset($this->builder, $asset);
+        }
+
+        return Image::getDominantColor($asset);
     }
 
     /**

--- a/tests/fixtures/website/layouts/assets.html.twig
+++ b/tests/fixtures/website/layouts/assets.html.twig
@@ -205,4 +205,12 @@ pre {
     <pre>asset('css/styleA.css')|html({test: 'test'}, {preload: true, canonical: true})</pre>
     <pre>{{ asset('css/styleA.css')|html({test: 'test'}, {preload: true, canonical: true})|e }}</pre>
   </p>
+
+  <h2>Dominant color</h2>
+  <p>
+    <pre>asset('images/cecil-logo.png')|dominant_color</pre>
+    <blockquote>
+      {{- asset('images/cecil-logo.png')|dominant_color -}}
+    </blockquote>
+  </p>
 {% endblock content %}


### PR DESCRIPTION
```twig
{{ asset(image_path)|dominant_color }}
```

```
#F2D07F
```