### PR TITLE
feat: support of Markdown in `figcaption` (title) of an image

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6366,25 +6366,30 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
+                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
+                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
@@ -6410,9 +6415,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.2"
             },
-            "time": "2022-03-15T21:29:03+00:00"
+            "time": "2022-10-14T12:47:21+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -6499,16 +6504,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.8",
+            "version": "1.8.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "08310ce271984587e2a4cda94e1ac66510a6ea07"
+                "reference": "3a72d9d9f2528fbd50c2d8fcf155fd9f74ade3f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/08310ce271984587e2a4cda94e1ac66510a6ea07",
-                "reference": "08310ce271984587e2a4cda94e1ac66510a6ea07",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a72d9d9f2528fbd50c2d8fcf155fd9f74ade3f2",
+                "reference": "3a72d9d9f2528fbd50c2d8fcf155fd9f74ade3f2",
                 "shasum": ""
             },
             "require": {
@@ -6538,7 +6543,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.8"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.9"
             },
             "funding": [
                 {
@@ -6554,7 +6559,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-06T12:51:57+00:00"
+            "time": "2022-10-13T13:40:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -94,7 +94,7 @@ class Parsedown extends \ParsedownToC
         $image['element']['attributes']['src'] = $this->cleanUrl($image['element']['attributes']['src']);
 
         // should be lazy loaded?
-        if ($this->builder->getConfig()->get('body.images.lazy.enabled')) {
+        if ($this->builder->getConfig()->get('body.images.lazy.enabled') && !isset($image['element']['attributes']['loading'])) {
             $image['element']['attributes']['loading'] = 'lazy';
         }
 

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -269,6 +269,11 @@ class Parsedown extends \ParsedownToC
                     ],
                 ];
                 $PictureBlock['element']['text'][] = $source['element'];
+                // clean title (and preserve raw HTML)
+                if (isset($InlineImage['element']['attributes']['title'])) {
+                    $titleRawHtml = $this->line($InlineImage['element']['attributes']['title']);
+                    $InlineImage['element']['attributes']['title'] = strip_tags($this->line($InlineImage['element']['attributes']['title']));
+                }
                 $PictureBlock['element']['text'][] = $InlineImage['element'];
                 $block = $PictureBlock;
             } catch (\Exception $e) {
@@ -290,7 +295,8 @@ class Parsedown extends \ParsedownToC
             $InlineFigcaption = [
                 'element' => [
                     'name' => 'figcaption',
-                    'text' => $InlineImage['element']['attributes']['title'],
+                    'allowRawHtmlInSafeMode' => true,
+                    'rawHtml' => $this->line($titleRawHtml),
                 ],
             ];
             $FigureBlock['element']['text'][] = $InlineFigcaption['element'];

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -270,9 +270,10 @@ class Parsedown extends \ParsedownToC
                 ];
                 $PictureBlock['element']['text'][] = $source['element'];
                 // clean title (and preserve raw HTML)
+                $titleRawHtml = '';
                 if (isset($InlineImage['element']['attributes']['title'])) {
                     $titleRawHtml = $this->line($InlineImage['element']['attributes']['title']);
-                    $InlineImage['element']['attributes']['title'] = strip_tags($this->line($InlineImage['element']['attributes']['title']));
+                    $InlineImage['element']['attributes']['title'] = strip_tags($titleRawHtml);
                 }
                 $PictureBlock['element']['text'][] = $InlineImage['element'];
                 $block = $PictureBlock;
@@ -282,7 +283,7 @@ class Parsedown extends \ParsedownToC
         }
 
         // if there is a title: put the <img> (or <picture>) in a <figure> element to use the <figcaption>
-        if ($this->builder->getConfig()->get('body.images.caption.enabled') && !empty($InlineImage['element']['attributes']['title'])) {
+        if ($this->builder->getConfig()->get('body.images.caption.enabled') && !empty($titleRawHtml)) {
             $FigureBlock = [
                 'element' => [
                     'name'    => 'figure',


### PR DESCRIPTION
Example:

```markdown
![Alternative description](/image.jpg "Photo about [Cecil](https://cecil.app)")
```

```html
<figure>
  <img src="/image.jpg" alt="Alternative description" title="Photo about Cecil">
  <figcaption>Photo about <a href="https://cecil.app">Cecil</a></figcaption>
</figure>
```