### PR TITLE
feat: local fallback for remote images

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -204,6 +204,10 @@ return [
             ],
             'remote' => [
                 'enabled' => true,  // turns remote images to Asset to handling them (`true` by default)
+                'fallback' => [
+                    'enabled' => false, // enables a fallback if image is not found (`false` by default)
+                    'path'    => ''     // path to the fallback image, stored in assets dir (`` by default)
+                ],
             ],
         ],
         'links' => [

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -623,6 +623,9 @@ body:
       enabled: true  # puts the image in a <figure> element and adds a <figcaption> containing the title (`false` by default)
     remote:
       enabled: true  # enables remote image handling (`true` by default)
+      fallback:
+        enabled: false # enables a fallback if image is not found (`false` by default)
+        path: ''       # path to the fallback image, stored in assets dir (`` by default)
   links:
     embed:
       enabled: false # turns links in embedded content if possible (`false` by default)

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -166,7 +166,11 @@ class Parsedown extends \ParsedownToC
         }
 
         // create asset
-        $asset = new Asset($this->builder, $image['element']['attributes']['src'], ['force_slash' => false]);
+        $assetOptions = ['force_slash' => false];
+        if ($this->builder->getConfig()->get('body.images.remote.fallback.enabled')) {
+            $assetOptions += ['remote_fallback' => $this->builder->getConfig()->get('body.images.remote.fallback.path')];
+        }
+        $asset = new Asset($this->builder, $image['element']['attributes']['src'], $assetOptions);
         $image['element']['attributes']['src'] = $asset;
         $width = $asset->getWidth();
 


### PR DESCRIPTION
```yaml
body:
  images:
    remote:
      enabled: true
      fallback:
        enabled: true # enables a fallback if image is not found (`false` by default)
        path: 'images/no-image.png' # path to the fallback image, stored in assets dir (`` by default)
```