### PR TITLE
fix: Added script tags to live reload script

### DIFF
--- a/resources/server/router.php
+++ b/resources/server/router.php
@@ -104,7 +104,7 @@ if ($pathInfo['media_maintype'] == 'text' || in_array($pathInfo['media_subtype']
             $script = file_get_contents(__DIR__ . '/livereload.js');
             $content = str_ireplace('</body>', "  <script>$script    </script>\n  </body>", $content);
             if (stristr($content, '</body>') === false) {
-                $content .= "\n$script";
+                $content .= "\n<script>$script    </script>";
             }
         }
     }


### PR DESCRIPTION
Fixes issue #1673 

Changes proposed in this pull request:

Wrap live reload script in `<script>...</script>` tags when faced with a missing `</body>`

