### PR TITLE
feat: enhances pagination

### DIFF
--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -267,7 +267,7 @@ _Paginator_ help you to build a navigation for list pages: homepage, sections, a
 | Variable                     | Description                   |
 | ---------------------------- | ----------------------------- |
 | `page.paginator.pages`       | Paginated pages collection.   |
-| `page.paginator.totalpages`  | Paginated total pages.        |
+| `page.paginator.pages_total` | Paginated total pages.        |
 | `page.paginator.count`       | Number of pages.              |
 | `page.paginator.current`     | Position of the current page. |
 | `page.paginator.links.first` | Page ID of the first page.    |
@@ -275,7 +275,7 @@ _Paginator_ help you to build a navigation for list pages: homepage, sections, a
 | `page.paginator.links.self`  | Page ID of the current page.  |
 | `page.paginator.links.next`  | Page ID of the next page.     |
 | `page.paginator.links.last`  | Page ID of the last page.     |
-| `page.paginator.links.path`  | Page ID without counter.      |
+| `page.paginator.links.path`  | Page ID without position.     |
 
 :::important
 Because links entries are Page ID you must use the `url()` function to create working links.  

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -1,7 +1,7 @@
 <!--
 description: "Working with layouts and templates."
 date: 2021-05-07
-updated: 2023-03-15
+updated: 2023-05-22
 alias: documentation/layouts
 -->
 # Templates
@@ -268,31 +268,51 @@ _Paginator_ help you to build a navigation for list pages: homepage, sections, a
 | ---------------------------- | ----------------------------- |
 | `page.paginator.pages`       | Paginated pages collection.   |
 | `page.paginator.totalpages`  | Paginated total pages.        |
-| `page.paginator.current`     | Position of the current page. |
 | `page.paginator.count`       | Number of pages.              |
-| `page.paginator.links.self`  | Page ID of the current page.  |
+| `page.paginator.current`     | Position of the current page. |
 | `page.paginator.links.first` | Page ID of the first page.    |
 | `page.paginator.links.prev`  | Page ID of the previous page. |
+| `page.paginator.links.self`  | Page ID of the current page.  |
 | `page.paginator.links.next`  | Page ID of the next page.     |
 | `page.paginator.links.last`  | Page ID of the last page.     |
+| `page.paginator.links.path`  | Page ID without counter.      |
 
 :::important
-Links entries are Page ID, so you must use the `url()` function to create working links.  
-In a future release, links should be a _Page_.
+Because links entries are Page ID you must use the `url()` function to create working links.  
+e.g: `{{ url(page.paginator.links.next) }}`
 :::
 
 _Example:_
 
 ```twig
 {% if page.paginator %}
-  {% set links = page.paginator.links %}
 <div>
-  {% if links.prev is defined %}
-  <a href="{{ url(links.prev) }}">Previous</a>
+  {% if page.paginator.links.prev is defined %}
+  <a href="{{ url(page.paginator.links.prev) }}">Previous</a>
   {% endif %}
-  {% if links.next is defined %}
-  <a href="{{ url(links.next) }}">Next</a>
+  {% if page.paginator.links.next is defined %}
+  <a href="{{ url(page.paginator.links.next) }}">Next</a>
   {% endif %}
+</div>
+{% endif %}
+```
+
+_Example:_
+
+```twig
+{% if page.paginator %}
+<div>
+  {% for paginator_index in 1..page.paginator.count %}
+    {% if paginator_index != page.paginator.current %}
+      {% if paginator_index == 1 %}
+  <a href="{{ url(pagination.links.first) }}">{{ paginator_index }}</a>
+      {% else %}
+  <a href="{{ url(page.paginator.links.path ~ '/' ~ paginator_index) }}">{{ paginator_index }}</a>
+      {% endif %}
+    {% else %}
+  {{ paginator_index }}
+    {% endif %}
+  {% endfor %}
 </div>
 {% endif %}
 ```
@@ -1134,6 +1154,7 @@ If you need to modify the default templates, you can easily extract them via the
 ```bash
 php cecil.phar util:extract
 ```
+
 :::
 
 ### Default templates

--- a/src/Generator/Pagination.php
+++ b/src/Generator/Pagination.php
@@ -78,10 +78,10 @@ class Pagination extends AbstractGenerator implements GeneratorInterface
             // builds paginator
             $paginatorPagesCount = \intval(ceil($pagesTotal / $paginationPerPage));
             for ($i = 0; $i < $paginatorPagesCount; $i++) {
-                $iteratorPagesInPagination = new \LimitIterator($pages->getIterator(), ($i * $paginationPerPage), $paginationPerPage);
+                $itPagesInPagination = new \LimitIterator($pages->getIterator(), ($i * $paginationPerPage), $paginationPerPage);
                 $pagesInPagination = new PagesCollection(
                     $page->getId() . '-page-' . ($i + 1),
-                    iterator_to_array($iteratorPagesInPagination)
+                    iterator_to_array($itPagesInPagination)
                 );
                 $alteredPage = clone $page;
                 // first page (ie: blog/page/1 -> blog)

--- a/src/Generator/Pagination.php
+++ b/src/Generator/Pagination.php
@@ -27,45 +27,43 @@ class Pagination extends AbstractGenerator implements GeneratorInterface
      */
     public function generate(): void
     {
-        if (false === $this->config->get('pagination.enabled')) {
+        if ($this->config->get('pagination.enabled') === false) {
             return;
         }
 
-        // filters pages: home, sections and terms
+        // filters list pages (home, sections and terms)
         $filteredPages = $this->builder->getPages()->filter(function (Page $page) {
-            return in_array($page->getType(), [Type::HOMEPAGE, Type::SECTION, Type::TERM]);
+            return \in_array($page->getType(), [Type::HOMEPAGE, Type::SECTION, Type::TERM]);
         });
         /** @var Page $page */
         foreach ($filteredPages as $page) {
-            // page config
-            $path = $page->getPath();
-            $pages = $page->getPages();
-            $sortby = $page->getVariable('sortby');
-            // no sub-pages?
+            $pages = $page->getPages()->filter(function (Page $page) {
+                return $page->getVariable('published');
+            });
+            // if no sub-pages: by-pass
             if ($pages === null) {
                 continue;
             }
-            // global pagination config
+            $path = $page->getPath();
+            $sortby = $page->getVariable('sortby');
+            // site pagination configuration
             $paginationPerPage = intval($this->config->get('pagination.max') ?? 5);
             $paginationPath = (string) $this->config->get('pagination.path') ?? 'page';
-            // page pagination config
+            // page pagination configuration
             $pagePagination = $page->getVariable('pagination');
             if ($pagePagination) {
-                if (isset($pagePagination['enabled']) && !$pagePagination['enabled']) {
+                if (isset($pagePagination['enabled']) && $pagePagination['enabled'] == false) {
                     continue;
                 }
                 if (isset($pagePagination['max'])) {
                     $paginationPerPage = intval($pagePagination['max']);
                 }
                 if (isset($pagePagination['path'])) {
-                    $paginationPath = $pagePagination['path'];
+                    $paginationPath = (string) $pagePagination['path'];
                 }
             }
-            $pages = $pages->filter(function (Page $page) {
-                return $page->getVariable('published');
-            });
             $pagesTotal = count($pages);
-            // abords pagination?
+            // is pagination not necessary?
             if ($pagesTotal <= $paginationPerPage) {
                 continue;
             }
@@ -77,99 +75,72 @@ class Pagination extends AbstractGenerator implements GeneratorInterface
                     $pages = $pages->$sortMethod();
                 }
             }
-
             // builds paginator
-            $paginatorPagesCount = intval(ceil($pagesTotal / $paginationPerPage));
+            $paginatorPagesCount = \intval(ceil($pagesTotal / $paginationPerPage));
             for ($i = 0; $i < $paginatorPagesCount; $i++) {
-                $pagesInPagination = new \LimitIterator(
-                    $pages->getIterator(),
-                    ($i * $paginationPerPage),
-                    $paginationPerPage
-                );
+                $iteratorPagesInPagination = new \LimitIterator($pages->getIterator(), ($i * $paginationPerPage), $paginationPerPage);
                 $pagesInPagination = new PagesCollection(
                     $page->getId() . '-page-' . ($i + 1),
-                    iterator_to_array($pagesInPagination)
+                    iterator_to_array($iteratorPagesInPagination)
                 );
                 $alteredPage = clone $page;
-                // first page
-                $firstPath = Page::slugify(\sprintf('%s', $path));
+                // first page (ie: blog/page/1 -> blog)
                 if ($i == 0) {
-                    // ie: blog + blog/page/1 (alias)
-                    $pageId = Page::slugify(\sprintf('%s', $path));
-                    // homepage special case
-                    if ($path == '') {
-                        $pageId = 'index';
-                    }
-                    // i18n
-                    if ($page->getVariable('language') != $this->config->getLanguageDefault()) {
-                        $pageId = \sprintf('%s.%s', $pageId, $page->getVariable('language'));
-                    }
-                    $currentPath = $firstPath;
+                    $pageId = $page->getId();
                     $alteredPage
-                        ->setId($pageId)
-                        ->setPath($firstPath)
                         ->setVariable('alias', [
                             \sprintf('%s/%s/%s', $path, $paginationPath, 1),
                         ]);
+                // others pages (ie: blog/page/X)
                 } else {
-                    // ie: blog/page/2
-                    $pageId = Page::slugify(\sprintf('%s/%s/%s', $path, $paginationPath, $i + 1));
-                    // i18n
-                    if ($page->getVariable('language') != $this->config->getLanguageDefault()) {
-                        $pageId = \sprintf('%s.%s', $pageId, $page->getVariable('language'));
-                    }
-                    $currentPath = $pageId;
+                    $pageId = Page::slugify(\sprintf('%s/%s/%s', $page->getId(), $paginationPath, $i + 1));
                     $alteredPage
                         ->setId($pageId)
                         ->setVirtual(true)
-                        ->setPath($currentPath)
+                        ->setPath(Page::slugify(\sprintf('%s/%s/%s', $path, $paginationPath, $i + 1)))
                         ->unVariable('menu')
                         ->unVariable('alias')
                         ->unVariable('aliases') // backward compatibility
                         ->unVariable('langref')
                         ->setVariable('paginated', true);
                 }
-                // updates 'paginator' variable
+                // set paginator values
                 $paginator = [
                     'totalpages' => $pagesTotal,
                     'pages'      => $pagesInPagination,
-                    'current'    => $i + 1,
                     'count'      => $paginatorPagesCount,
+                    'current'    => $i + 1,
                 ];
                 // adds links
-                $paginator['links'] = ['self' => $currentPath ?: 'index'];
-                $paginator['links'] += ['first' => $firstPath ?: 'index'];
+                $paginator['links'] = ['first' => $page->getId() ?: 'index'];
                 if ($i == 1) {
-                    $paginator['links'] += ['prev' => Page::slugify($path ?: 'index')];
+                    $paginator['links'] += ['prev' => $page->getId() ?: 'index'];
                 }
                 if ($i > 1) {
                     $paginator['links'] += ['prev' => Page::slugify(\sprintf(
                         '%s/%s/%s',
-                        $path,
+                        $page->getId(),
                         $paginationPath,
                         $i
                     ))];
                 }
+                $paginator['links'] += ['self' => $pageId ?: 'index'];
                 if ($i < $paginatorPagesCount - 1) {
                     $paginator['links'] += ['next' => Page::slugify(\sprintf(
                         '%s/%s/%s',
-                        $path,
+                        $page->getId(),
                         $paginationPath,
                         $i + 2
                     ))];
                 }
                 $paginator['links'] += ['last' => Page::slugify(\sprintf(
                     '%s/%s/%s',
-                    $path,
+                    $page->getId(),
                     $paginationPath,
                     $paginatorPagesCount
                 ))];
-                // i18n
-                if ($page->getVariable('language') != $this->config->getLanguageDefault()) {
-                    foreach ($paginator['links'] as $key => $value) {
-                        $paginator['links'][$key] = \sprintf('%s.%s', $value, $page->getVariable('language'));
-                    }
-                }
+                $paginator['links'] += ['path' => Page::slugify(\sprintf('%s/%s', $page->getId(), $paginationPath))];
+                // set paginator to cloned page
                 $alteredPage->setPaginator($paginator);
                 $alteredPage->setVariable('pagination', $paginator); // backward compatibility
                 // updates date with the first element of the collection

--- a/src/Generator/Pagination.php
+++ b/src/Generator/Pagination.php
@@ -106,10 +106,11 @@ class Pagination extends AbstractGenerator implements GeneratorInterface
                 }
                 // set paginator values
                 $paginator = [
-                    'totalpages' => $pagesTotal,
-                    'pages'      => $pagesInPagination,
-                    'count'      => $paginatorPagesCount,
-                    'current'    => $i + 1,
+                    'pages'       => $pagesInPagination,
+                    'pages_total' => $pagesTotal,
+                    'totalpages'  => $pagesTotal, // backward compatibility
+                    'count'       => $paginatorPagesCount,
+                    'current'     => $i + 1,
                 ];
                 // adds links
                 $paginator['links'] = ['first' => $page->getId() ?: 'index'];


### PR DESCRIPTION
New variable `page.paginator.links.path` added: Page ID without position.

Usage example:

```twig
{% if page.paginator %}
<div>
  {% for paginator_index in 1..page.paginator.count %}
    {% if paginator_index != page.paginator.current %}
      {% if paginator_index == 1 %}
  <a href="{{ url(pagination.links.first) }}">{{ paginator_index }}</a>
      {% else %}
  <a href="{{ url(page.paginator.links.path ~ '/' ~ paginator_index) }}">{{ paginator_index }}</a>
      {% endif %}
    {% else %}
  {{ paginator_index }}
    {% endif %}
  {% endfor %}
</div>
{% endif %}
```