### PR TITLE
refactor: ID of localized pages

### DIFF
--- a/src/Assets/Url.php
+++ b/src/Assets/Url.php
@@ -113,7 +113,7 @@ class Url
                 // force language?
                 $lang = '';
                 if ($language !== null && $language != $this->config->getLanguageDefault()) {
-                    $pageId = "$pageId.$language";
+                    $pageId = "$language/$pageId";
                     $lang = "$language/";
                 }
                 switch (true) {

--- a/src/Collection/Page/Page.php
+++ b/src/Collection/Page/Page.php
@@ -110,27 +110,36 @@ class Page extends Item
     {
         $relativePath = self::slugify(str_replace(DIRECTORY_SEPARATOR, '/', $file->getRelativePath()));
         $basename = self::slugify(PrefixSuffix::subPrefix($file->getBasename('.' . $file->getExtension())));
-        // case of "README" -> index
+        // if file is "README.md", ID is "index"
         $basename = (string) str_ireplace('readme', 'index', $basename);
-        // case of section's index: "section/index" -> "section"
+        // if file is section's index: "section/index.md", ID is "section"
         if (!empty($relativePath) && PrefixSuffix::sub($basename) == 'index') {
-            // case of a localized section: "section/index.fr" -> "section.fr"
+            // case of a localized section's index: "section/index.fr.md", ID is "fr/section"
             if (PrefixSuffix::hasSuffix($basename)) {
-                return $relativePath . '.' . PrefixSuffix::getSuffix($basename);
+                return PrefixSuffix::getSuffix($basename) . '/' . $relativePath;
             }
 
             return $relativePath;
+        }
+        // localized page
+        if (PrefixSuffix::hasSuffix($basename)) {
+            return trim(Util::joinPath(PrefixSuffix::getSuffix($basename), $relativePath, PrefixSuffix::sub($basename)), '/');
         }
 
         return trim(Util::joinPath($relativePath, $basename), '/');
     }
 
     /**
-     * Returns the ID of a page without language suffix.
+     * Returns the ID of a page without language.
      */
     public function getIdWithoutLang(): string
     {
-        return PrefixSuffix::sub($this->getId());
+        $langPrefix = $this->getVariable('language') . '/';
+        if ($this->hasVariable('language') && Util\Str::startsWith($this->getId(), $langPrefix)) {
+            return substr($this->getId(), strlen($langPrefix));
+        }
+
+        return $this->getId();
     }
 
     /**

--- a/src/Generator/Alias.php
+++ b/src/Generator/Alias.php
@@ -35,7 +35,7 @@ class Alias extends AbstractGenerator implements GeneratorInterface
                     $pageId = $path = Page::slugify($alias);
                     // i18n
                     if ($page->getVariable('language') != $this->config->getLanguageDefault()) {
-                        $pageId = sprintf('%s.%s', $pageId, $page->getVariable('language'));
+                        $pageId = sprintf('%s/%s', $page->getVariable('language'), $pageId);
                     }
                     $aliasPage = (new Page($pageId))
                         ->setPath($path)

--- a/src/Generator/Homepage.php
+++ b/src/Generator/Homepage.php
@@ -31,7 +31,7 @@ class Homepage extends AbstractGenerator implements GeneratorInterface
             $language = $lang['code'];
             $pageId = 'index';
             if ($language != $this->config->getLanguageDefault()) {
-                $pageId = sprintf('index.%s', $language);
+                $pageId = "$language/$pageId";
             }
             // creates a new index page...
             $page = (new Page($pageId))->setPath('')->setVariable('title', 'Home');

--- a/src/Generator/Pagination.php
+++ b/src/Generator/Pagination.php
@@ -84,16 +84,13 @@ class Pagination extends AbstractGenerator implements GeneratorInterface
                     iterator_to_array($itPagesInPagination)
                 );
                 $alteredPage = clone $page;
-                // first page (ie: blog/page/1 -> blog)
-                if ($i == 0) {
+                if ($i == 0) { // first page (ie: blog/page/1 -> blog)
                     $pageId = $page->getId();
                     $alteredPage
                         ->setVariable('alias', [
                             sprintf('%s/%s/%s', $path, $paginationPath, 1),
                         ]);
-                }
-                // others pages (ie: blog/page/X)
-                else {
+                } else { // others pages (ie: blog/page/X)
                     $pageId = Page::slugify(sprintf('%s/%s/%s', $page->getId(), $paginationPath, $i + 1));
                     $alteredPage
                         ->setId($pageId)

--- a/src/Generator/Section.php
+++ b/src/Generator/Section.php
@@ -53,7 +53,7 @@ class Section extends AbstractGenerator implements GeneratorInterface
                 foreach ($languages as $language => $pagesAsArray) {
                     $pageId = $path = Page::slugify($section);
                     if ($language != $this->config->getLanguageDefault()) {
-                        $pageId = sprintf('%s.%s', $pageId, $language);
+                        $pageId = "$language/$pageId";
                     }
                     $page = (new Page($pageId))->setVariable('title', ucfirst($section))
                         ->setPath($path);

--- a/src/Generator/VirtualPages.php
+++ b/src/Generator/VirtualPages.php
@@ -46,7 +46,7 @@ class VirtualPages extends AbstractGenerator implements GeneratorInterface
             foreach ($this->config->getLanguages() as $language) {
                 $pageId = !empty($path) ? $path : 'index';
                 if ($language['code'] !== $this->config->getLanguageDefault()) {
-                    $pageId .= '.' . $language['code'];
+                    $pageId = sprintf('%s/%s', $language['code'], $pageId);
                     // disable multilingual support
                     if (isset($frontmatter['multilingual']) && $frontmatter['multilingual'] === false) {
                         continue;

--- a/src/Renderer/Site.php
+++ b/src/Renderer/Site.php
@@ -82,7 +82,7 @@ class Site implements \ArrayAccess
             case 'language':
                 return new Language($this->config, $this->language);
             case 'home':
-                return $this->language != $this->config->getLanguageDefault() ? sprintf('index.%s', $this->language) : 'index';
+                return $this->language != $this->config->getLanguageDefault() ? sprintf('%s/index', $this->language) : 'index';
         }
 
         return $this->config->get($offset, $this->language);
@@ -122,10 +122,10 @@ class Site implements \ArrayAccess
     {
         $pageId = $id;
         if ($language === null && $this->language != $this->config->getLanguageDefault()) {
-            $pageId = sprintf('%s.%s', $id, $this->language);
+            $pageId = sprintf('%s/%s', $this->language, $id);
         }
         if ($language !== null && $language != $this->config->getLanguageDefault()) {
-            $pageId = sprintf('%s.%s', $id, $language);
+            $pageId = "$language/$id";
         }
 
         return $this->builder->getPages()->get($pageId);

--- a/src/Step/Menus/Create.php
+++ b/src/Step/Menus/Create.php
@@ -70,11 +70,11 @@ class Create extends AbstractStep
             if ($menusConfig = (array) $this->config->get('menus', $language['code'], false)) {
                 $totalConfig = array_sum(array_map('count', $menusConfig));
                 $countConfig = 0;
-                $suffix = '';
+                $langPrefix = '';
                 $page404 = '404.html';
 
                 if ($language['code'] !== $this->config->getLanguageDefault()) {
-                    $suffix = '.' . $language['code'];
+                    $langPrefix = $language['code'] . '/';
                     $page404 = $language['code'] . '/404.html';
                 }
 
@@ -95,10 +95,10 @@ class Create extends AbstractStep
                             throw new RuntimeException(sprintf('"id" is required for entry at position %s in "%s" menu', $key, $menu));
                         }
                         // enabled?
-                        if (isset($property['enabled']) && false === $property['enabled']) {
+                        if (isset($property['enabled']) && $property['enabled'] === false) {
                             $enabled = false;
                             if (!$menu->has($property['id'])) {
-                                $message = sprintf('Config menu entry "%s > %s%s" disabled', (string) $menu, $property['id'], $suffix);
+                                $message = sprintf('Config menu entry "%s > %s%s" disabled', (string) $menu, $langPrefix, $property['id']);
                                 $this->builder->getLogger()->info($message, ['progress' => [$countConfig, $totalConfig]]);
                             }
                         }
@@ -108,7 +108,7 @@ class Create extends AbstractStep
                             if (!$enabled) {
                                 $menu->remove($property['id']);
 
-                                $message = sprintf('Config menu entry "%s > %s%s" removed', (string) $menu, $property['id'], $suffix);
+                                $message = sprintf('Config menu entry "%s > %s%s" removed', (string) $menu, $langPrefix, $property['id']);
                                 $this->builder->getLogger()->info($message, ['progress' => [$countConfig, $totalConfig]]);
                                 continue;
                             }
@@ -117,7 +117,7 @@ class Create extends AbstractStep
                             $current = $menu->get($property['id'])->toArray();
                             $property = array_merge($current, $property);
 
-                            $message = sprintf('Config menu entry "%s > %s%s" updated', (string) $menu, $property['id'], $suffix);
+                            $message = sprintf('Config menu entry "%s > %s%s" updated', (string) $menu, $langPrefix, $property['id']);
                             $this->builder->getLogger()->info($message, ['progress' => [$countConfig, $totalConfig]]);
                         }
                         // adds/replaces entry
@@ -129,7 +129,7 @@ class Create extends AbstractStep
                             $menu->add($item);
 
                             if (!$updated) {
-                                $message = sprintf('Config menu entry "%s > %s%s" created', (string) $menu, $property['id'], $suffix);
+                                $message = sprintf('Config menu entry "%s > %s%s" created', (string) $menu, $langPrefix, $property['id']);
                                 $this->builder->getLogger()->info($message, ['progress' => [$countConfig, $totalConfig]]);
                             }
                         }


### PR DESCRIPTION
The way to define a page ID have been refactored: the language code of a translated page is no more a suffix (`page.code`) and is now a prefix (`code/page`).

Example: `blog/post-1.fr` -> `fr/blog/post-1`.