### PR TITLE
fix: Core::imageSizes method

### DIFF
--- a/src/Renderer/Extension/Core.php
+++ b/src/Renderer/Extension/Core.php
@@ -614,7 +614,7 @@ class Core extends SlugifyExtension
      */
     public function imageSizes(string $class): string
     {
-        return Image::getSizes($class, $this->config->getAssetsImagesWidths());
+        return Image::getSizes($class, $this->config->getAssetsImagesSizes());
     }
 
     /**


### PR DESCRIPTION
Previously, images widths (simple array) were passed to Image::getSizes instead of images sizes (associative array), which were leading always to default sizes array.

