### PR TITLE
feat: enable pages path prefix for the main language

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -136,11 +136,15 @@ return [
             'term'       => ['html', 'atom'],
         ],
     ],
-    'language'  => 'en', // main language code (`en` by default)
+    'language'  => 'en',  // main language code (`en` by default)
+    //'language'  => [
+    //    'code'   => 'en',
+    //    'prefix' => true, // prefix main language pages path with language code (`false` by default)
+    //],
     'languages' => [
         [
             'code'   => 'en',
-            'name'   => 'English',
+            'name'   => 'English', // should use `language_name ` filter instead (https://twig.symfony.com/doc/filters/language_name.html)
             'locale' => 'en_US',
         ],
     ],

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -283,11 +283,21 @@ languages:
 ```
 
 :::info
-The language code is used to define the path to pages in a different language of the default one (e.g.: `/fr/a-propos/`).  
+The language code is used to prefix the path of others languages pages (e.g.: `/fr/a-propos/`).  
+You can check [locales code page](configuration/locale-codes.md) if needed.
 :::
 
+You can also prefix the path of the main language pages with the following option:
+
+```yaml
+#language: <code>
+language:
+  code: <code>
+  prefix: true
+```
+
 :::info
-A list of [locales code](configuration/locale-codes.md) is available.
+An alias is automatically created for the home page that redirect from `/` to `/<code>/`.
 :::
 
 #### Localize configuration options

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -401,11 +401,11 @@ class Builder implements LoggerAwareInterface
             $this->getLogger()->error('Config: `baseurl` is required in production (e.g.: "baseurl: https://example.com/").');
         }
         // default language
-        if (!preg_match('/^' . Config::LANG_CODE_PATTERN . '$/', (string) $this->config->get('language'))) {
-            throw new RuntimeException(sprintf('Config: default language code "%s" is not valid (e.g.: "language: fr-FR").', $this->config->get('language')));
+        if (!preg_match('/^' . Config::LANG_CODE_PATTERN . '$/', $this->config->getLanguageDefault())) {
+            throw new RuntimeException(sprintf('Config: default language code "%s" is not valid (e.g.: "language: fr-FR").', $this->config->getLanguageDefault()));
         }
         // locales
-        foreach ((array) $this->config->get('languages') as $lang) {
+        foreach ($this->config->getLanguages() as $lang) {
             if (!isset($lang['locale'])) {
                 throw new RuntimeException('Config: a language locale is not defined.');
             }

--- a/src/Config.php
+++ b/src/Config.php
@@ -540,6 +540,10 @@ class Config
             throw new RuntimeException('There is no default "language" key in configuration.');
         }
 
+        if ($this->get('language.code')) {
+            return $this->get('language.code');
+        }
+
         return $this->get('language');
     }
 
@@ -560,7 +564,7 @@ class Config
     }
 
     /**
-     * Returns the property value of a (specified or default) language.
+     * Returns the property value of a (specified or the default) language.
      *
      * @throws RuntimeException
      */

--- a/src/Generator/Homepage.php
+++ b/src/Generator/Homepage.php
@@ -72,6 +72,10 @@ class Homepage extends AbstractGenerator implements GeneratorInterface
             if (!$page->getVariable('menu')) {
                 $page->setVariable('menu', ['main' => ['weight' => 0]]);
             }
+            // add an alias redirection from the root if language path prefix is forced for the default language
+            if ($language == $this->config->getLanguageDefault() && $this->config->get('language.prefix')) {
+                $page->setVariable('alias', '../');
+            }
             $this->generatedPages->add($page);
         }
     }

--- a/src/Generator/Pagination.php
+++ b/src/Generator/Pagination.php
@@ -37,6 +37,9 @@ class Pagination extends AbstractGenerator implements GeneratorInterface
         });
         /** @var Page $page */
         foreach ($filteredPages as $page) {
+            if ($page->getPages() === null) {
+                return;
+            }
             $pages = $page->getPages()->filter(function (Page $page) {
                 return $page->getVariable('published');
             });

--- a/src/Renderer/Page.php
+++ b/src/Renderer/Page.php
@@ -62,12 +62,8 @@ class Page
         if (empty($path) && empty($filename)) {
             $path = 'index';
         }
-        // do not prefix path with language code for the default language
-        if ($language === null || ($language == $this->config->getLanguageDefault() && !$this->config->get('language.prefix'))) {
-            $language = '';
-        }
-        // do not prefix path of the home page with language code for the default language
-        if ($language == $this->config->getLanguageDefault() && $page->getType() == 'homepage') {
+        // do not prefix path with language code for the default language (and default language home page)
+        if ($language === null || ($language == $this->config->getLanguageDefault() && (!$this->config->get('language.prefix') || $page->getType() == 'homepage'))) {
             $language = '';
         }
 

--- a/src/Renderer/Page.php
+++ b/src/Renderer/Page.php
@@ -34,15 +34,15 @@ class Page
      *
      * Use cases:
      *   - default: path + filename + extension (e.g.: 'blog/post-1/index.html')
-     *   - subpath: path + subpath + filename + extension (e.g.: 'blog/post-1/amp/index.html')
-     *   - ugly: path + extension (e.g.: '404.html', 'sitemap.xml', 'robots.txt')
+     *   - with subpath: path + subpath + filename + extension (e.g.: 'blog/post-1/amp/index.html')
+     *   - ugly URL: path + extension (e.g.: '404.html', 'sitemap.xml', 'robots.txt')
      *   - path only (e.g.: '_redirects')
-     *   - language (e.g.: 'fr/blog/page/index.html')
+     *   - i18n: language code + default (e.g.: 'fr/blog/page/index.html')
      *
      * @param PageItem $page
      * @param string   $format Output format (ie: 'html', 'amp', 'json', etc.)
      */
-    public function getOutputFile(PageItem $page, string $format): string
+    public function getOutputFilePath(PageItem $page, string $format): string
     {
         $path = $page->getPath();
         $subpath = (string) $this->config->getOutputFormatProperty($format, 'subpath');
@@ -50,7 +50,7 @@ class Page
         $extension = (string) $this->config->getOutputFormatProperty($format, 'extension');
         $uglyurl = (bool) $page->getVariable('uglyurl');
         $language = $page->getVariable('language');
-        // if ugly URL
+        // is ugly URL?
         if ($uglyurl) {
             $filename = '';
         }
@@ -58,12 +58,16 @@ class Page
         if ($extension) {
             $extension = sprintf('.%s', $extension);
         }
-        // homepage special case
+        // homepage special case (need "index")
         if (empty($path) && empty($filename)) {
             $path = 'index';
         }
-        // do not prefix URL for the default language
-        if ($language == $this->config->getLanguageDefault() || $language === null) {
+        // do not prefix path with language code for the default language
+        if ($language === null || ($language == $this->config->getLanguageDefault() && !$this->config->get('language.prefix'))) {
+            $language = '';
+        }
+        // do not prefix path of the home page with language code for the default language
+        if ($language == $this->config->getLanguageDefault() && $page->getType() == 'homepage') {
             $language = '';
         }
 
@@ -78,7 +82,9 @@ class Page
      */
     public function getUrl(PageItem $page, string $format = 'html'): string
     {
-        $output = $this->getOutputFile($page, $format);
+        $output = $this->getOutputFilePath($page, $format);
+
+        // remove "index.html" if not uglyurl
         if (!($page->getVariable('uglyurl') ?? false)) {
             $output = str_replace('index.html', '', $output);
         }

--- a/src/Renderer/Page.php
+++ b/src/Renderer/Page.php
@@ -63,7 +63,11 @@ class Page
             $path = 'index';
         }
         // do not prefix path with language code for the default language (and default language home page)
-        if ($language === null || ($language == $this->config->getLanguageDefault() && (!$this->config->get('language.prefix') || $page->getType() == 'homepage'))) {
+        if ($language === null || ($language == $this->config->getLanguageDefault() && !$this->config->get('language.prefix'))) {
+            $language = '';
+        }
+        // do not prefix "not multilingual" virtual pages
+        if ($page->getVariable('multilingual') === false) {
             $language = '';
         }
 

--- a/src/Step/Pages/Save.php
+++ b/src/Step/Pages/Save.php
@@ -67,7 +67,7 @@ class Save extends AbstractStep
             $files = [];
 
             foreach ($page->getRendered() as $format => $rendered) {
-                if (false === $pathname = (new PageRenderer($this->config))->getOutputFile($page, $format)) {
+                if (false === $pathname = (new PageRenderer($this->config))->getOutputFilePath($page, $format)) {
                     throw new RuntimeException(sprintf("Can't get pathname of page '%s' (format: '%s')", $page->getId(), $format));
                 }
                 $pathname = $this->cleanPath(Util::joinFile($this->config->getOutputPath(), $pathname));


### PR DESCRIPTION
New option to "force" main language code as prefix in pages path:

```yaml
#language: en
language:
  code: en
  prefix: true
```
