### PR TITLE
fix: empty attribute in html filter

### DIFF
--- a/src/Renderer/Extension/Core.php
+++ b/src/Renderer/Extension/Core.php
@@ -526,7 +526,7 @@ class Core extends SlugifyExtension
         // builds HTML attributes
         foreach ($attributes as $name => $value) {
             $attribute = sprintf(' %s="%s"', $name, $value);
-            if (empty($value)) {
+            if (!isset($value)) {
                 $attribute = sprintf(' %s', $name);
             }
             $htmlAttributes .= $attribute;


### PR DESCRIPTION
```twig
{{ asset('asset')|html({attr: ''}) }}   # attr=""
{{ asset('asset')|html({attr: '0'}) }}  # attr="0"
{{ asset('asset')|html({attr: null}) }} # attr
```