### PR TITLE
feat: better `serve` command feedback

### DIFF
--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -179,7 +179,7 @@ class Serve extends AbstractCommand
                 $output->writeln(sprintf('Starting server (<href=http://%s:%d>%s:%d</>)...', $host, $port, $host, $port));
                 $process->start(function ($type, $buffer) use (&$output) {
                     if ($type === Process::ERR) {
-                        $output->writeln($buffer, OutputInterface::VERBOSITY_DEBUG);
+                        error_log($buffer, 3, Util::joinFile($this->getPath(), self::TMP_DIR, 'errors.log'));
                     }
                 });
                 if ($open) {
@@ -287,7 +287,7 @@ class Serve extends AbstractCommand
     public function tearDownServer(): void
     {
         $this->output->writeln('');
-        $this->output->writeln('<comment>Server stopped.</comment>');
+        $this->output->writeln('<info>Server stopped.</info>');
 
         try {
             Util\File::getFS()->remove(Util::joinFile($this->getPath(), self::TMP_DIR));

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -224,7 +224,7 @@ class Serve extends AbstractCommand
                     }
                 }
                 if ($process->getExitCode() > 0) {
-                    $output->writeln(sprintf('<comment>Server stopped: %s.</comment>', trim($process->getErrorOutput())));
+                    $output->writeln(sprintf('<comment>%s</comment>', trim($process->getErrorOutput())));
                 }
             } catch (ProcessFailedException $e) {
                 $this->tearDownServer();

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -137,14 +137,12 @@ class Serve extends AbstractCommand
         $buildProcess->setPty(Process::isPtySupported());
         $buildProcess->setTimeout(3600 * 2); // timeout = 2 minutes
 
-        $processOutputCallback = function ($type, $data) use ($output) {
-            $output->write($data, false, OutputInterface::OUTPUT_RAW);
+        $processOutputCallback = function ($type, $buffer) use ($output) {
+            $output->write($buffer, false, OutputInterface::OUTPUT_RAW);
         };
 
         // (re)builds before serve
-        if ($this->getBuilder()->isDebug()) {
-            $output->writeln(sprintf('<comment>Build process: %s</comment>', implode(' ', $buildProcessArguments)));
-        }
+        $output->writeln(sprintf('<comment>Build process: %s</comment>', implode(' ', $buildProcessArguments)), OutputInterface::VERBOSITY_DEBUG);
         $buildProcess->run($processOutputCallback);
         if ($buildProcess->isSuccessful()) {
             Util\File::getFS()->dumpFile(Util::joinFile($this->getPath(), self::TMP_DIR, 'changes.flag'), time());
@@ -177,7 +175,7 @@ class Serve extends AbstractCommand
                 }
                 $output->writeln(sprintf('<comment>Server process: %s</comment>', $command), OutputInterface::VERBOSITY_DEBUG);
                 $output->writeln(sprintf('Starting server (<href=http://%s:%d>%s:%d</>)...', $host, $port, $host, $port));
-                $process->start(function ($type, $buffer) use (&$output) {
+                $process->start(function ($type, $buffer) {
                     if ($type === Process::ERR) {
                         error_log($buffer, 3, Util::joinFile($this->getPath(), self::TMP_DIR, 'errors.log'));
                     }

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -182,7 +182,7 @@ class Serve extends AbstractCommand
                 if ($this->getBuilder()->isDebug()) {
                     $output->writeln(sprintf('<comment>Process: %s</comment>', $command));
                 }
-                $process->start(function ($type, $buffer) use(&$output) {
+                $process->start(function ($type, $buffer) use (&$output) {
                     if ($this->getBuilder()->isDebug() && $type === Process::ERR) {
                         $output->writeln($buffer);
                     }

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -179,7 +179,14 @@ class Serve extends AbstractCommand
                 $output->writeln(
                     sprintf('Starting server (<href=http://%s:%d>%s:%d</>)...', $host, $port, $host, $port)
                 );
-                $process->start();
+                if ($this->getBuilder()->isDebug()) {
+                    $output->writeln(sprintf('<comment>Process: %s</comment>', $command));
+                }
+                $process->start(function ($type, $buffer) use(&$output) {
+                    if ($this->getBuilder()->isDebug() && $type === Process::ERR) {
+                        $output->writeln($buffer);
+                    }
+                });
                 if ($open) {
                     $output->writeln('Opening web browser...');
                     Util\Plateform::openBrowser(sprintf('http://%s:%s', $host, $port));
@@ -216,6 +223,9 @@ class Serve extends AbstractCommand
 
                         $output->writeln('<info>Server is runnning...</info>');
                     }
+                }
+                if ($process->getExitCode() > 0) {
+                    $output->writeln('<info>Server is failing...</info>');
                 }
             } catch (ProcessFailedException $e) {
                 $this->tearDownServer();


### PR DESCRIPTION
- The PHP server errors are now logged in `.cecil/errors.log`
- Cecil checks if the host is available when the server is running
- If the PHP server process exit with a code > 0 the error output is printed
- The PHP server process command line is now printed in debug mode