### PR TITLE
feat: multiple image formats support (webp, avif)

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -84,7 +84,7 @@ return [
                 'resize' => [
                     'enabled' => false, // enables image resizing by using the `width` extra attribute (`false` by default)
                 ],
-                'formats' => ['webp'], // creates and adds formats images as `source` (`webp` by default)
+                'formats' => [], // creates and adds formats images as `source` (empty by default)
                 'responsive' => [
                     'enabled' => false, // creates responsive images and adds them to the `srcset` attribute (`false` by default)
                 ],
@@ -231,7 +231,7 @@ return [
                 ],
                 'enabled' => false, // `html` filter: creates responsive images (`false` by default)
             ],
-            'formats' => ['avif', 'webp'], // `html` filter: creates and adds formats images as `source` (`webp` by default)
+            'formats' => [], // `html` filter: creates and adds formats images as `source` (empty by default)
             'cdn' => [
                 'enabled'   => false,  // enables Image CDN (`false` by default)
                 'canonical' => true,   // is `image_url` must be canonical or not (`true` by default)

--- a/config/default.php
+++ b/config/default.php
@@ -84,9 +84,7 @@ return [
                 'resize' => [
                     'enabled' => false, // enables image resizing by using the `width` extra attribute (`false` by default)
                 ],
-                'webp' => [
-                    'enabled' => false, // creates and adds a WebP image as a `source` (`false` by default)
-                ],
+                'formats' => ['webp'], // creates and adds formats images as `source` (`webp` by default)
                 'responsive' => [
                     'enabled' => false, // creates responsive images and adds them to the `srcset` attribute (`false` by default)
                 ],
@@ -233,9 +231,7 @@ return [
                 ],
                 'enabled' => false, // `html` filter: creates responsive images (`false` by default)
             ],
-            'webp' => [
-                'enabled' => false, // `html` filter: creates and adds a WebP image as a `source` (`false` by default)
-            ],
+            'formats' => ['avif', 'webp'], // `html` filter: creates and adds formats images as `source` (`webp` by default)
             'cdn' => [
                 'enabled'   => false,  // enables Image CDN (`false` by default)
                 'canonical' => true,   // is `image_url` must be canonical or not (`true` by default)
@@ -418,7 +414,7 @@ return [
         ],
         'images' => [
             'enabled' => true, // enables images files optimization
-            'ext'     => ['jpeg', 'jpg', 'png', 'gif', 'webp', 'svg'], // supported files extensions
+            'ext'     => ['jpeg', 'jpg', 'png', 'gif', 'webp', 'svg', 'avif'], // supported files extensions
         ],
     ],
 ];

--- a/docs/2-Content.md
+++ b/docs/2-Content.md
@@ -330,9 +330,9 @@ Ratio is preserved (`height` attribute is calculated automatically), the origina
 This feature requires [GD extension](https://www.php.net/manual/book.image.php) (otherwise it only add a `width` HTML attribute to the `img` tag).
 :::
 
-#### WebP
+#### Formats
 
-If the [`webp` option](4-Configuration.md#body) is enabled, an alterative image in the [WebP](https://developers.google.com/speed/webp) format is created.
+If the [`formats` option](4-Configuration.md#body) is defined, alternatives images are created and added.
 
 _Example:_
 
@@ -344,13 +344,14 @@ Is converted to:
 
 ```html
 <picture>
+  <source srcset="/image.avif" type="image/avif">
   <source srcset="/image.webp" type="image/webp">
   <img src="/image.jpg">
 </picture>
 ```
 
 :::important
-This feature requires [WebP](https://developers.google.com/speed/webp) be supported by PHP installation.
+Please note that **not all image formats** are always included in the PHP image extensions.
 :::
 
 #### Responsive
@@ -396,7 +397,7 @@ assets:
 ```
 
 :::info
-You can combine `webp` and `responsive` options.
+You can combine `formats` and `responsive` options.
 :::
 
 #### CSS class

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -995,13 +995,26 @@ _Example:_
 
 ### webp
 
-Converts an image to WebP format.
+Converts an image to [WebP](https://developers.google.com/speed/webp) format.
 
 _Example:_
 
 ```twig
 <picture>
     <source type="image/webp" srcset="{{ asset(image_path)|webp }}">
+    <img src="{{ url(asset(image_path)) }}" width="{{ asset(image_path).width }}" height="{{ asset(image_path).height }}" alt="">
+</picture>
+```
+
+### avif
+
+Converts an image to [AVIF](https://github.com/AOMediaCodec/libavif) format.
+
+_Example:_
+
+```twig
+<picture>
+    <source type="image/avif" srcset="{{ asset(image_path)|avif }}">
     <img src="{{ url(asset(image_path)) }}" width="{{ asset(image_path).width }}" height="{{ asset(image_path).height }}" alt="">
 </picture>
 ```
@@ -1054,10 +1067,10 @@ Converts an asset into an HTML element.
 {{ asset(path)|html({attributes, options}) }}
 ```
 
-| Option     | Description                                     | Type  | Default |
-| ---------- | ----------------------------------------------- | ----- | ------- |
-| attributes | Adds `name="value"` couple to the HTML element. | array |         |
-| options    | `{preload: true}`: preloads CSS.<br>`{responsive: true}`: creates responsives images.<br>`{webp: true}`: creates WebP versions of the image. | array |         |
+| Option     | Description                                     | Type  |
+| ---------- | ----------------------------------------------- | ----- |
+| attributes | Adds `name="value"` couple to the HTML element. | array |
+| options    | `{preload: boolean}`: preloads CSS.<br>`{responsive: boolean}`: creates responsives images.<br>`{formats: array}`: creates image alternative formats. | array |
 
 _Examples:_
 
@@ -1068,7 +1081,7 @@ _Examples:_
 
 ```twig
 {# image with specific attributes and options #}
-{{ asset('image.jpg')|html({alt: 'Description', loading: 'lazy'}, {responsive: true, webp: true}) }}
+{{ asset('image.jpg')|html({alt: 'Description', loading: 'lazy'}, {responsive: true, formats: ['avif','webp']}) }}
 ```
 
 ```twig

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -635,8 +635,7 @@ pages:
         enabled: true   # adds `decoding="async"` attribute (`true` by default)
       resize:
         enabled: false  # enables image resizing by using the `width` extra attribute (`false` by default)
-      webp:
-        enabled: false  # adds a WebP image as a `source` (`false` by default)
+      formats: [] # creates and adds formats images as `source` (empty by default)
       responsive:
         enabled: false  # creates responsive images and add them to the `srcset` attribute (`false` by default)
       class: ''         # put default class to each image (empty by default)
@@ -828,8 +827,7 @@ assets:
       sizes:
         default: '100vw' # default `sizes` attribute (`100vw` by default)
       enabled: false     # used by `html` filter: creates responsive images by default (`false` by default)
-    webp:
-      enabled: false     # used by `html` filter: creates and adds a WebP image as a `source` by default (`false` by default)
+    formats: []          # used by `html` filter: creates and adds formats images as `source` (empty by default)
 ```
 
 :::

--- a/src/Assets/Image.php
+++ b/src/Assets/Image.php
@@ -51,7 +51,7 @@ class Image
             // resizes to $width with constraint the aspect-ratio and unwanted upsizing
             $image->scaleDown(width: $width);
             // return image data
-            return (string) $image->encodeByMediaType($asset['subtype'], /** @scrutinizer ignore-type */ progressive: true, /** @scrutinizer ignore-type */ interlaced: true, quality: $quality);
+            return (string) $image->encodeByMediaType($asset['subtype'], /** @scrutinizer ignore-type */ progressive: true, /** @scrutinizer ignore-type */ interlaced: false, quality: $quality);
         } catch (\Exception $e) {
             throw new RuntimeException(sprintf('Not able to resize "%s": %s', $asset['path'], $e->getMessage()));
         }
@@ -74,7 +74,7 @@ class Image
                 throw new RuntimeException(sprintf('Function "image%s" is not available.', $format));
             }
 
-            return (string) $image->encodeByExtension($format, /** @scrutinizer ignore-type */ progressive: true, /** @scrutinizer ignore-type */ interlaced: true, quality: $quality);
+            return (string) $image->encodeByExtension($format, /** @scrutinizer ignore-type */ progressive: true, /** @scrutinizer ignore-type */ interlaced: false, quality: $quality);
         } catch (\Exception $e) {
             throw new RuntimeException(sprintf('Not able to convert "%s": %s', $asset['path'], $e->getMessage()));
         }
@@ -100,7 +100,7 @@ class Image
     }
 
     /**
-     * Returns the dominant hexadecimal color of an image asset.
+     * Returns the dominant RGB color of an image asset.
      *
      * @throws RuntimeException
      */
@@ -114,7 +114,7 @@ class Image
             $assetColor = $assetColor->resize(100);
             $image = self::manager()->read($assetColor['content']);
 
-            return $image->reduceColors(1)->pickColor(0, 0)->toHex();
+            return $image->pickColor(0, 0)->toString();
         } catch (\Exception $e) {
             throw new RuntimeException(sprintf('Can\'t get dominant color of "%s": %s', $asset['path'], $e->getMessage()));
         }

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -388,7 +388,7 @@ class Parsedown extends \ParsedownToc
 
         // converts image to formats and put them in picture > source
         if (
-            \count($formats = ((array) $this->config->get('pages.body.images.formats') ?? ['webp'])) > 0
+            \count($formats = ((array) $this->config->get('pages.body.images.formats') ?? [])) > 0
             && \in_array($InlineImage['element']['attributes']['src']['subtype'], ['image/jpeg', 'image/png', 'image/gif'])
         ) {
             try {
@@ -427,20 +427,22 @@ class Parsedown extends \ParsedownToc
                         ],
                     ];
                 }
-                $picture = [
-                    'extent'  => $InlineImage['extent'],
-                    'element' => [
-                        'name'       => 'picture',
-                        'handler'    => 'elements',
-                        'attributes' => [
-                            'title' => $image['element']['attributes']['title'],
+                if (count($sources) > 0) {
+                    $picture = [
+                        'extent'  => $InlineImage['extent'],
+                        'element' => [
+                            'name'       => 'picture',
+                            'handler'    => 'elements',
+                            'attributes' => [
+                                'title' => $image['element']['attributes']['title'],
+                            ],
                         ],
-                    ],
-                ];
-                $picture['element']['text'] = $sources;
-                unset($image['element']['attributes']['title']); // @phpstan-ignore unset.offset
-                $picture['element']['text'][] = $image['element'];
-                $image = $picture;
+                    ];
+                    $picture['element']['text'] = $sources;
+                    unset($image['element']['attributes']['title']); // @phpstan-ignore unset.offset
+                    $picture['element']['text'][] = $image['element'];
+                    $image = $picture;
+                }
             } catch (\Exception $e) {
                 $this->builder->getLogger()->debug($e->getMessage());
             }

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -388,7 +388,7 @@ class Parsedown extends \ParsedownToc
 
         // converts image to formats and put them in picture > source
         if (
-            count($formats = ((array) $this->config->get('pages.body.images.formats') ?? ['webp'])) > 0
+            \count($formats = ((array) $this->config->get('pages.body.images.formats') ?? ['webp'])) > 0
             && \in_array($InlineImage['element']['attributes']['src']['subtype'], ['image/jpeg', 'image/png', 'image/gif'])
         ) {
             try {

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -400,6 +400,7 @@ class Parsedown extends \ParsedownToc
                 if (Image::isAnimatedGif($InlineImage['element']['attributes']['src'])) {
                     throw new RuntimeException(sprintf('Asset "%s" is an animated GIF.', $InlineImage['element']['attributes']['src']));
                 }
+                $sources = [];
                 foreach ($formats as $format) {
                     $assetConverted = $InlineImage['element']['attributes']['src']->$format();
                     $srcset = '';

--- a/src/Renderer/Extension/Core.php
+++ b/src/Renderer/Extension/Core.php
@@ -479,7 +479,7 @@ class Core extends SlugifyExtension
         $htmlAttributes = '';
         $preload = false;
         $responsive = (bool) $this->config->get('assets.images.responsive.enabled') ?? false;
-        $formats = (array) $this->config->get('assets.images.formats') ?? ['webp'];
+        $formats = (array) $this->config->get('assets.images.formats') ?? [];
         extract($options, EXTR_IF_EXISTS);
 
         // builds HTML attributes

--- a/src/Renderer/Extension/Core.php
+++ b/src/Renderer/Extension/Core.php
@@ -535,7 +535,7 @@ class Core extends SlugifyExtension
             );
 
             // multiple <source>?
-            if (count($formats) > 0) {
+            if (\count($formats) > 0) {
                 $source = '';
                 foreach ($formats as $format) {
                     if ($asset['subtype'] != "image/$format" && !Image::isAnimatedGif($asset)) {

--- a/src/Renderer/Extension/Core.php
+++ b/src/Renderer/Extension/Core.php
@@ -469,7 +469,7 @@ class Core extends SlugifyExtension
      * $options[
      *     'preload'    => false,
      *     'responsive' => false,
-     *     'formats'    => ['webp'],
+     *     'formats'    => [],
      * ];
      *
      * @throws RuntimeException

--- a/src/Renderer/Extension/Core.php
+++ b/src/Renderer/Extension/Core.php
@@ -132,6 +132,7 @@ class Core extends SlugifyExtension
             new \Twig\TwigFilter('dominant_color', [$this, 'dominantColor']),
             new \Twig\TwigFilter('lqip', [$this, 'lqip']),
             new \Twig\TwigFilter('webp', [$this, 'webp']),
+            new \Twig\TwigFilter('avif', [$this, 'avif']),
             // content
             new \Twig\TwigFilter('slugify', [$this, 'slugifyFilter']),
             new \Twig\TwigFilter('excerpt', [$this, 'excerpt']),
@@ -468,7 +469,7 @@ class Core extends SlugifyExtension
      * $options[
      *     'preload'    => false,
      *     'responsive' => false,
-     *     'webp'       => false,
+     *     'formats'    => ['webp'],
      * ];
      *
      * @throws RuntimeException
@@ -478,7 +479,7 @@ class Core extends SlugifyExtension
         $htmlAttributes = '';
         $preload = false;
         $responsive = (bool) $this->config->get('assets.images.responsive.enabled') ?? false;
-        $webp = (bool) $this->config->get('assets.images.webp.enabled') ?? false;
+        $formats = (array) $this->config->get('assets.images.formats') ?? ['webp'];
         extract($options, EXTR_IF_EXISTS);
 
         // builds HTML attributes
@@ -533,26 +534,32 @@ class Core extends SlugifyExtension
                 $htmlAttributes
             );
 
-            // WebP conversion?
-            if ($webp && $asset['subtype'] != 'image/webp' && !Image::isAnimatedGif($asset)) {
-                try {
-                    $assetWebp = $asset->webp();
-                    // <source> element
-                    $source = sprintf('<source type="image/webp" srcset="%s">', $assetWebp);
-                    // responsive
-                    if ($responsive && $srcset = Image::buildSrcset($assetWebp, $this->config->getAssetsImagesWidths())) {
-                        // <source> element
-                        $source = sprintf(
-                            '<source type="image/webp" srcset="%s" sizes="%s">',
-                            $srcset,
-                            $sizes
-                        );
+            // multiple <source>?
+            if (count($formats) > 0) {
+                $source = '';
+                foreach ($formats as $format) {
+                    if ($asset['subtype'] != "image/$format" && !Image::isAnimatedGif($asset)) {
+                        try {
+                            $assetConverted = $asset->convert($format);
+                            // responsive?
+                            if ($responsive && $srcset = Image::buildSrcset($assetConverted, $this->config->getAssetsImagesWidths())) {
+                                // <source> element
+                                $source .= sprintf(
+                                    "\n  <source type=\"image/$format\" srcset=\"%s\" sizes=\"%s\">",
+                                    $srcset,
+                                    $sizes
+                                );
+                                continue;
+                            }
+                            // <source> element
+                            $source .= sprintf("\n  <source type=\"image/$format\" srcset=\"%s\">", $assetConverted);
+                        } catch (\Exception $e) {
+                            $this->builder->getLogger()->error($e->getMessage());
+                        }
                     }
-
-                    return sprintf("<picture>\n  %s\n  %s\n</picture>", $source, $img);
-                } catch (\Exception $e) {
-                    $this->builder->getLogger()->debug($e->getMessage());
                 }
+
+                return sprintf("<picture>%s\n  %s\n</picture>", $source, $img);
             }
 
             return $img;
@@ -581,22 +588,38 @@ class Core extends SlugifyExtension
 
     /**
      * Converts an image Asset to WebP format.
-     *
-     * @throws RuntimeException
      */
     public function webp(Asset $asset, ?int $quality = null): Asset
     {
-        if ($asset['subtype'] == 'image/webp') {
+        return $this->convert($asset, 'webp', $quality);
+    }
+
+    /**
+     * Converts an image Asset to AVIF format.
+     */
+    public function avif(Asset $asset, ?int $quality = null): Asset
+    {
+        return $this->convert($asset, 'avif', $quality);
+    }
+
+    /**
+     * Converts an image Asset to the given format.
+     *
+     * @throws RuntimeException
+     */
+    private function convert(Asset $asset, string $format, ?int $quality = null): Asset
+    {
+        if ($asset['subtype'] == "image/$format") {
             return $asset;
         }
         if (Image::isAnimatedGif($asset)) {
-            throw new RuntimeException(sprintf('Can\'t convert the animated GIF "%s" to WebP.', $asset['path']));
+            throw new RuntimeException(sprintf('Can\'t convert the animated GIF "%s" to %s.', $asset['path'], $format));
         }
 
         try {
-            return $asset->webp($quality);
+            return $asset->$format($quality);
         } catch (\Exception $e) {
-            throw new RuntimeException(sprintf('Can\'t convert "%s" to WebP (%s).', $asset['path'], $e->getMessage()));
+            throw new RuntimeException(sprintf('Can\'t convert "%s" to %s (%s).', $asset['path'], $format, $e->getMessage()));
         }
     }
 

--- a/tests/fixtures/website/config.php
+++ b/tests/fixtures/website/config.php
@@ -128,9 +128,7 @@ return [
                 'responsive' => [
                     'enabled' => true,
                 ],
-                'webp' => [
-                    'enabled' => true,
-                ],
+                'formats' => ['avif', 'webp'],
                 'caption' => [
                     'enabled' => true,
                 ],
@@ -202,9 +200,7 @@ return [
                     'img' => '100vw',
                 ],
             ],
-            'webp' => [
-                'enabled' => true,
-            ],
+            'formats' => ['avif', 'webp'],
             'caption' => [
                 'enabled' => true,
             ],


### PR DESCRIPTION
- breaking change: `webp` boolean options have been repalce by `formats`, an array list of alternatives image formats (ie: "avif", "webp")
- new `avif` method to convert an image asset to AVIF format. ie: `{{ asset.avif }}`
- new `avif` filter to convert an image to AVIF format. ie: `{{ asset|avif }}`
- disable "interlaced" by default
- fix dominant color method and, BC, return RGB instead of hexadecimal value