### PR TITLE
doc: update references to now missing command util:extract

### DIFF
--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -1234,7 +1234,7 @@ Cecil comes with a set of [built-in templates](https://github.com/Cecilapp/Cecil
 If you need to modify built-in templates, you can easily extract them via the following command: they will be copied in the "layouts" directory of your site.
 
 ```bash
-php cecil.phar util:extract
+php cecil.phar util:templates:extract
 ```
 
 :::

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -27,7 +27,7 @@ Available commands:
   show:config               Shows the configuration
   show:content              Shows content as tree
  util
-  util:extract              Extracts built-in templates
+  util:templates:extract    Extracts built-in templates
 ```
 
 ## new:site


### PR DESCRIPTION
Fixes issue # N/A

Changes proposed in this pull request:

Cecil's documentation references a non-existing `util:extract` command in pages _Templates_ and _Commands_, I assume this was previously the name for the now named `util:templates:extract` command, both references are updated in this PR.

PS: I read the contributing guide but since this is a documentation change I assumed it wasn't necessary to create an issue first, if my assumption was incorrect I'd be happy to resubmit after first creating an issue.