### PR TITLE
feat: add `fediverse:creator` meta support

### DIFF
--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -309,8 +309,10 @@ This template adds the following meta tags:
 - Pagination links (first, previous, next, last)
 - Canonical URL
 - Links to alternate versions (i.e.: RSS feed, others languages)
+- `rel=me` support
 - Open Graph
 - Twitter Card
+- Mastodon meta
 - Structured data (JSON-LD)
 
 #### metatags options and front matter
@@ -331,11 +333,16 @@ social:
   twitter:
     site: username
     creator: username
+    url: URL
+  mastodon:
+    creator: handle
+    url: URL
   facebook:
     id: 123456789
     firstname: Firstname
     lastname: Lastname
     username: username
+    url: URL
 ```
 
 :::tip

--- a/resources/layouts/partials/metatags.html.twig
+++ b/resources/layouts/partials/metatags.html.twig
@@ -115,6 +115,17 @@
     {%- set twitter = twitter|merge(page.social.twitter|default(site.social.twitter)) %}
   {%- endif %}
 {% endif %}
+{# Mastodon #}
+{% set mastodon = {
+  'creator': '',
+} %}
+{% if page.social.mastodon is defined or site.social.mastodon is defined %}
+  {%- if page.social.mastodon|default(site.social.mastodon) is not iterable %}
+    {%- set mastodon = mastodon|merge({'creator': page.social.mastodon|default(site.social.mastodon)}) %}
+  {%- else %}
+    {%- set mastodon = mastodon|merge(page.social.mastodon|default(site.social.mastodon)) %}
+  {%- endif %}
+{% endif %}
 {%- block content %}
     {#~ template ~#}
     <title>{% block title %}{{ title_html }}{% endblock %}</title>
@@ -225,6 +236,10 @@
 {%- endif -%}
 {%- if twitter.creator ~%}
     <meta name="twitter:creator" content="@{{ twitter.creator }}" />
+{%- endif ~%}
+{#- template: Mastodon ~#}
+{%- if mastodon.creator ~%}
+    <meta name="fediverse:creator" content="{{ mastodon.creator }}">
 {%- endif ~%}
 {#- template: json-ld ~#}
 {%- include 'partials/jsonld.js.twig' with {'author': author, 'favicon_asset': favicon_asset|default} ~%}


### PR DESCRIPTION
Config:

```yaml
social:
  mastodon:
    creator: "@arnaud@gazuji.com"
    url: https://gazuji.com/@arnaud
```

Output:

```html
<link rel="me" href="https://gazuji.com/@arnaud" />
<meta name="fediverse:creator" content="@arnaud@gazuji.com">
```