### PR TITLE
refactor: fix thumb path

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -327,7 +327,7 @@ class Asset implements \ArrayAccess
                 (string) $this->config->get('assets.target'),
                 'thumbnails',
                 (string) $width,
-                $assetResized->data['path']
+                $this->deduplicateThumbPath($assetResized->data['path'])
             );
             $assetResized->data['height'] = $assetResized->getHeight();
             $assetResized->data['size'] = \strlen($assetResized->data['content']);
@@ -909,5 +909,15 @@ class Asset implements \ArrayAccess
             ],
             (string) $this->config->get('assets.images.cdn.url')
         );
+    }
+
+    /**
+     * Remove the '/thumbnails/<width>/' part of the path if already exists.
+     */
+    private function deduplicateThumbPath(string $path): string
+    {
+        $pattern = '/\/(thumbnails)\/(\d+)(.*)/i';
+        $replacement = '$3';
+        return preg_replace($pattern, $replacement, $path);
     }
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -28,6 +28,8 @@ use wapmorgan\Mp3Info\Mp3Info;
 
 class Asset implements \ArrayAccess
 {
+    public const IMAGE_THUMB = 'thumbnails';
+
     /** @var Builder */
     protected $builder;
 
@@ -325,7 +327,7 @@ class Asset implements \ArrayAccess
             $assetResized->data['content'] = Image::resize($assetResized, $width, $quality);
             $assetResized->data['path'] = '/' . Util::joinPath(
                 (string) $this->config->get('assets.target'),
-                'thumbnails',
+                self::IMAGE_THUMB,
                 (string) $width,
                 $this->deduplicateThumbPath($assetResized->data['path'])
             );
@@ -916,7 +918,7 @@ class Asset implements \ArrayAccess
      */
     private function deduplicateThumbPath(string $path): string
     {
-        $pattern = '/\/(thumbnails)\/(\d+)(.*)/i';
+        $pattern = '/(' . self::IMAGE_THUMB . ')\/(\d+)\/(.*)/i';
         $replacement = '$3';
         return preg_replace($pattern, $replacement, $path);
     }


### PR DESCRIPTION
Remove duplicated `/thumbnails/<width>` in path of responsive images (resized from a resized image).