### PR TITLE
refactor: serve command and router baseurl handling

### DIFF
--- a/resources/server/router.php
+++ b/resources/server/router.php
@@ -108,11 +108,6 @@ $content = file_get_contents($filename);
 $pathInfo = getPathInfo($path);
 // text content
 if ($pathInfo['media_maintype'] == 'text' || \in_array($pathInfo['media_subtype'], $mediaSubtypeText)) {
-    // replaces the "live" baseurl by the "local" baseurl
-    $baseurl = explode(';', trim(file_get_contents(__DIR__ . '/baseurl')));
-    if (strstr($baseurl[0], 'http') !== false || $baseurl[0] != '/') {
-        $content = str_replace($baseurl[0], $baseurl[1], $content);
-    }
     // HTML content: injects live reload script
     if ($pathInfo['media_subtype'] == 'html') {
         if (file_exists(__DIR__ . '/livereload.js')) {

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -37,6 +37,7 @@ class AbstractCommand extends Command
     public const CONFIG_FILE = ['cecil.yml', 'config.yml'];
     public const TMP_DIR = '.cecil';
     public const EXCLUDED_CMD = ['about', 'new:site', 'self-update'];
+    public const SERVE_OUTPUT = '_preview';
 
     /** @var InputInterface */
     protected $input;

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -97,7 +97,9 @@ EOF
         }
         if ($input->getOption('output')) {
             $config['output']['dir'] = $input->getOption('output');
-            Util\File::getFS()->dumpFile(Util::joinFile($this->getPath(), self::TMP_DIR, 'output'), (string) $input->getOption('output'));
+            if ($input->getOption('output') != self::SERVE_OUTPUT) {
+                Util\File::getFS()->dumpFile(Util::joinFile($this->getPath(), self::TMP_DIR, 'output'), (string) $input->getOption('output'));
+            }
         }
         if ($input->getOption('optimize') === true) {
             $config['optimize']['enabled'] = true;

--- a/src/Command/Clear.php
+++ b/src/Command/Clear.php
@@ -63,6 +63,11 @@ EOF
      */
     private function removeOutputDir(OutputInterface $output): void
     {
+        // serve directory
+        if (Util\File::getFS()->exists(Util::joinFile($this->getPath(), self::SERVE_OUTPUT))) {
+            $output->writeln('Removing serve directory...');
+            Util\File::getFS()->remove(Util::joinFile($this->getPath(), self::SERVE_OUTPUT));
+        }
         $outputDir = (string) $this->getBuilder()->getConfig()->get('output.dir');
         // if custom output directory
         if (Util\File::getFS()->exists(Util::joinFile($this->getPath(), self::TMP_DIR, 'output'))) {

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -125,7 +125,7 @@ EOF
         }
 
         // setup server
-        $this->setUpServer($host, $port);
+        $this->setUpServer();
         $command = \sprintf(
             '"%s" -S %s:%d -t "%s" "%s"',
             $php,

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -37,8 +37,6 @@ use Yosymfony\ResourceWatcher\ResourceWatcher;
  */
 class Serve extends AbstractCommand
 {
-    public const SERVE_OUTPUT = '_preview';
-
     /** @var boolean */
     protected $watcherEnabled;
 

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -37,6 +37,8 @@ use Yosymfony\ResourceWatcher\ResourceWatcher;
  */
 class Serve extends AbstractCommand
 {
+    public const SERVE_OUTPUT = '_preview';
+
     /** @var boolean */
     protected $watcherEnabled;
 
@@ -129,7 +131,7 @@ EOF
             $php,
             $host,
             $port,
-            $this->getBuilder()->getConfig()->getOutputPath(),
+            Util::joinFile($this->getPath(), self::SERVE_OUTPUT),
             Util::joinFile($this->getPath(), self::TMP_DIR, 'router.php')
         );
         $process = Process::fromShellCommandline($command);
@@ -171,6 +173,10 @@ EOF
         if (!empty($metrics)) {
             $buildProcessArguments[] = '--metrics';
         }
+        $buildProcessArguments[] = '--baseurl';
+        $buildProcessArguments[] = "http://$host:$port/";
+        $buildProcessArguments[] = '--output';
+        $buildProcessArguments[] = self::SERVE_OUTPUT;
         $buildProcess = new Process(
             $buildProcessArguments,
             null,
@@ -316,7 +322,7 @@ EOF
      *
      * @throws RuntimeException
      */
-    private function setUpServer(string $host, string $port): void
+    private function setUpServer(): void
     {
         try {
             // define root path
@@ -339,15 +345,6 @@ EOF
                     true
                 );
             }
-            // copying baseurl text file
-            Util\File::getFS()->dumpFile(
-                Util::joinFile($this->getPath(), self::TMP_DIR, 'baseurl'),
-                \sprintf(
-                    '%s;%s',
-                    (string) $this->getBuilder()->getConfig()->get('baseurl'),
-                    \sprintf('http://%s:%s/', $host, $port)
-                )
-            );
         } catch (IOExceptionInterface $e) {
             throw new RuntimeException(\sprintf('An error occurred while copying server\'s files to "%s".', $e->getPath()));
         }


### PR DESCRIPTION
Removed baseurl replacement logic from router.php and updated Serve.php to pass baseurl and output directory as arguments instead of using a temporary baseurl file. This simplifies local server setup and improves configuration clarity.