### PR TITLE
fix absolute cache path

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -599,7 +599,7 @@ class Config
     public function isCacheDirIsAbsolute(): bool
     {
         $path = (string) $this->get('cache.dir');
-        if (Util::joinFile($path) == realpath(Util::joinFile($path))) {
+        if (Util\File::getFS()->isAbsolutePath($path)) {
             return true;
         }
 


### PR DESCRIPTION
This pull request updates the logic for determining if the cache directory path is absolute in the `Config` class. Instead of comparing joined file paths with their real paths, it now uses the `isAbsolutePath` method from the filesystem utility for a clearer and more reliable check.

- Refactored the `isCacheDirIsAbsolute` method in `src/Config.php` to use `Util\File::getFS()->isAbsolutePath($path)` for checking if the cache directory path is absolute, improving clarity and reliability.