### PR TITLE
Bump deps and use Parsedown base_url option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-fileinfo": "*",
     "ext-gd": "*",
     "ext-mbstring": "*",
-    "benjaminhoegh/parsedown-toc": "^1.5",
+    "benjaminhoegh/parsedown-toc": "1.6",
     "cecil/resource-watcher": "^4.1",
     "dflydev/dot-access-data": "^3.0",
     "erusev/parsedown-extra": "^0.9",
@@ -43,7 +43,7 @@
     "symfony/filesystem": "^7.4",
     "symfony/finder": "^7.4",
     "symfony/mime": "^7.4",
-    "symfony/polyfill-intl-icu": "^1.34",
+    "symfony/polyfill-intl-icu": "^1.36",
     "symfony/process": "^7.4",
     "symfony/property-access": "^7.4",
     "symfony/serializer": "^7.4",
@@ -62,7 +62,7 @@
     "yosymfony/toml": "^1.0"
   },
   "require-dev": {
-    "ergebnis/composer-normalize": "^2.50",
+    "ergebnis/composer-normalize": "^2.51",
     "friendsofphp/php-cs-fixer": "^3.95",
     "phpmd/phpmd": "^2.15",
     "phpstan/phpstan": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-fileinfo": "*",
     "ext-gd": "*",
     "ext-mbstring": "*",
-    "benjaminhoegh/parsedown-toc": "1.6",
+    "benjaminhoegh/parsedown-toc": "^1.6",
     "cecil/resource-watcher": "^4.1",
     "dflydev/dot-access-data": "^3.0",
     "erusev/parsedown-extra": "^0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "149a4aed124838bbad4451332fa3e1a6",
+    "content-hash": "a84e6af44acd3adcd97251619e442397",
     "packages": [
         {
             "name": "benjaminhoegh/parsedown-toc",

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16b4d56621261cdbc3444a9a91f9954a",
+    "content-hash": "149a4aed124838bbad4451332fa3e1a6",
     "packages": [
         {
             "name": "benjaminhoegh/parsedown-toc",
-            "version": "v1.5.4",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BenjaminHoegh/ParsedownToc.git",
-                "reference": "5495e00273d53a3bf28b98cdfd3e4662eafd0b09"
+                "reference": "0678f709fc984c532a4982814866f659d678e9b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BenjaminHoegh/ParsedownToc/zipball/5495e00273d53a3bf28b98cdfd3e4662eafd0b09",
-                "reference": "5495e00273d53a3bf28b98cdfd3e4662eafd0b09",
+                "url": "https://api.github.com/repos/BenjaminHoegh/ParsedownToc/zipball/0678f709fc984c532a4982814866f659d678e9b5",
+                "reference": "0678f709fc984c532a4982814866f659d678e9b5",
                 "shasum": ""
             },
             "require": {
-                "erusev/parsedown": "^1.7",
+                "erusev/parsedown": "^1.7.4 || ^1.8",
                 "php": ">=7.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "9.6.16",
-                "vimeo/psalm": ">=5.21.1"
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpunit/phpunit": "9.6.33",
+                "vimeo/psalm": "^5.26.1"
             },
             "type": "library",
             "autoload": {
@@ -57,7 +58,7 @@
             ],
             "support": {
                 "issues": "https://github.com/BenjaminHoegh/ParsedownToc/issues",
-                "source": "https://github.com/BenjaminHoegh/ParsedownToc/tree/v1.5.4"
+                "source": "https://github.com/BenjaminHoegh/ParsedownToc/tree/v1.6.0"
             },
             "funding": [
                 {
@@ -69,7 +70,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-07-14T04:55:10+00:00"
+            "time": "2026-04-27T15:13:24+00:00"
         },
         {
             "name": "cecil/resource-watcher",
@@ -2614,7 +2615,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -2673,7 +2674,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -2697,16 +2698,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
                 "shasum": ""
             },
             "require": {
@@ -2755,7 +2756,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -2775,7 +2776,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T16:19:22+00:00"
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -2867,7 +2868,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -2930,7 +2931,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -2954,7 +2955,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -3015,7 +3016,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3039,7 +3040,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -3100,7 +3101,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3124,7 +3125,7 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
@@ -3180,7 +3181,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3204,7 +3205,7 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
@@ -3260,7 +3261,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -9250,7 +9251,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -9310,7 +9311,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -9334,7 +9335,7 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -9390,7 +9391,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
             },
             "funding": [
                 {

--- a/src/Renderer/Extension/Core.php
+++ b/src/Renderer/Extension/Core.php
@@ -902,7 +902,7 @@ class Core extends AbstractExtension
         $selectors = $selectors ?? (array) $this->config->get('pages.body.toc');
 
         try {
-            $parsedown = new Parsedown($this->builder, ['selectors' => $selectors, 'url' => $url]);
+            $parsedown = new Parsedown($this->builder, ['selectors' => $selectors, 'base_url' => $url]);
             $parsedown->body($markdown);
             $return = $parsedown->contentsList($format);
         } catch (\Exception) {


### PR DESCRIPTION
Update composer requirements (bump benjaminhoegh/parsedown-toc to v1.6, symfony polyfill intl-icu, ergebnis/composer-normalize, etc.) and regenerate composer.lock. Adjust Core renderer to pass the new Parsedown option key 'base_url' instead of 'url' to match the updated ParsedownToc API.