### PR TITLE
feat: add layouts.autoescape option

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -179,6 +179,7 @@ return [
     ],
     'layouts' => [ // layouts and templates
         'dir' => 'layouts', // Twig templates directory
+        'autoescape' => false, // Twig autoescape option override (null to use extension-based strategy)
         'images' => [ // how to handle images in templates
             'formats' => [], // used by `html` function: adds alternatives image formats as `source` (e.g.: ['avif', 'webp'])
             'responsive' => false, // used by `html` function: adds responsive images ('width' or 'density') to `srcset` attribute

--- a/docs/4-Configuration.fr.md
+++ b/docs/4-Configuration.fr.md
@@ -1029,9 +1029,9 @@ layouts:
 
 ### layouts.autoescape
 
-Surcharge l’option Twig `autoescape`.
+Surcharge l’option Twig `autoescape` (`false` par défaut).
 
-Si la valeur est `null` (par défaut), Cecil applique une stratégie basée sur l’extension du nom de template :
+Si la valeur est `null`, Cecil applique une stratégie basée sur l’extension du nom de template :
 
 - `*.js.twig` -> `js`
 - `*.css.twig` -> `css`
@@ -1040,10 +1040,10 @@ Si la valeur est `null` (par défaut), Cecil applique une stratégie basée sur 
 
 ```yaml
 layouts:
-  autoescape: null # utilise la stratégie automatique Cecil selon l’extension du template (par défaut)
-  # autoescape: false
-  # autoescape: html
-  # autoescape: js
+  autoescape: false  # désactive l’échappement automatique (par défaut)
+  #autoescape: null   # utilise la stratégie automatique Cecil selon l’extension du template
+  #autoescape: html
+  #autoescape: js
 ```
 
 ### layouts.images

--- a/docs/4-Configuration.fr.md
+++ b/docs/4-Configuration.fr.md
@@ -1027,6 +1027,25 @@ layouts:
   dir: layouts
 ```
 
+### layouts.autoescape
+
+Surcharge l’option Twig `autoescape`.
+
+Si la valeur est `null` (par défaut), Cecil applique une stratégie basée sur l’extension du nom de template :
+
+- `*.js.twig` -> `js`
+- `*.css.twig` -> `css`
+- `*.html.twig` et `*.twig` -> `html`
+- toute autre extension -> `false`
+
+```yaml
+layouts:
+  autoescape: null # utilise la stratégie automatique Cecil selon l’extension du template (par défaut)
+  # autoescape: false
+  # autoescape: html
+  # autoescape: js
+```
+
 ### layouts.images
 
 Options de gestion des images.

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -1025,6 +1025,25 @@ layouts:
   dir: layouts
 ```
 
+### layouts.autoescape
+
+Overrides Twig `autoescape` option.
+
+If set to `null` (default), Cecil uses an extension-based strategy:
+
+- `*.js.twig` -> `js`
+- `*.css.twig` -> `css`
+- `*.html.twig` and `*.twig` -> `html`
+- any other extension -> `false`
+
+```yaml
+layouts:
+  autoescape: null # use Cecil automatic strategy by template filename extension (default)
+  # autoescape: false
+  # autoescape: html
+  # autoescape: js
+```
+
 ### layouts.images
 
 Images handling options.

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -1027,9 +1027,9 @@ layouts:
 
 ### layouts.autoescape
 
-Overrides Twig `autoescape` option.
+Overrides Twig `autoescape` option (`false` by default).
 
-If set to `null` (default), Cecil uses an extension-based strategy:
+If set to `null`, Cecil uses an extension-based strategy:
 
 - `*.js.twig` -> `js`
 - `*.css.twig` -> `css`
@@ -1038,10 +1038,10 @@ If set to `null` (default), Cecil uses an extension-based strategy:
 
 ```yaml
 layouts:
-  autoescape: null # use Cecil automatic strategy by template filename extension (default)
-  # autoescape: false
-  # autoescape: html
-  # autoescape: js
+  autoescape: false  # disables automatic escaping (default) 
+  #autoescape: null   # use Cecil automatic strategy by template filename extension 
+  #autoescape: html
+  #autoescape: js
 ```
 
 ### layouts.images

--- a/src/Renderer/Twig.php
+++ b/src/Renderer/Twig.php
@@ -67,11 +67,26 @@ class Twig implements RendererInterface
         $this->builder = $builder;
         // load layouts
         $loader = new \Twig\Loader\FilesystemLoader($templatesPath);
+        $autoescape = $this->builder->getConfig()->get('layouts.autoescape');
+        if ($autoescape === null) {
+            $autoescape = static function (string $templateName): string|false {
+                // extract the extension before ".twig" (e.g. "template.js.twig" -> "js")
+                $base = \preg_replace('/\.twig$/i', '', $templateName) ?: $templateName;
+                $ext  = \strtolower((string) \pathinfo($base, \PATHINFO_EXTENSION));
+
+                return match ($ext) {
+                    'js'       => 'js',
+                    'css'      => 'css',
+                    'html', '' => 'html',
+                    default    => false,
+                };
+            };
+        }
         // default options
         $loaderOptions = [
             'debug'            => $this->builder->isDebug(),
             'strict_variables' => true,
-            'autoescape'       => false,
+            'autoescape'       => $autoescape,
             'auto_reload'      => true,
             'cache'            => false,
         ];

--- a/src/Renderer/Twig.php
+++ b/src/Renderer/Twig.php
@@ -71,8 +71,8 @@ class Twig implements RendererInterface
         if ($autoescape === null) {
             $autoescape = static function (string $templateName): string|false {
                 // extract the extension before ".twig" (e.g. "template.js.twig" -> "js")
-                $base = \preg_replace('/\.twig$/i', '', $templateName) ?: $templateName;
-                $ext  = \strtolower((string) \pathinfo($base, \PATHINFO_EXTENSION));
+                $base = preg_replace('/\.twig$/i', '', $templateName) ?: $templateName;
+                $ext = strtolower((string) pathinfo($base, \PATHINFO_EXTENSION));
 
                 return match ($ext) {
                     'js'       => 'js',

--- a/src/Renderer/Twig.php
+++ b/src/Renderer/Twig.php
@@ -71,7 +71,10 @@ class Twig implements RendererInterface
         if ($autoescape === null) {
             $autoescape = static function (string $templateName): string|false {
                 // extract the extension before ".twig" (e.g. "template.js.twig" -> "js")
-                $base = preg_replace('/\.twig$/i', '', $templateName) ?: $templateName;
+                $base = preg_replace('/\.twig$/i', '', $templateName);
+                if ($base === null) {
+                    $base = $templateName;
+                }
                 $ext = strtolower((string) pathinfo($base, \PATHINFO_EXTENSION));
 
                 return match ($ext) {


### PR DESCRIPTION
This pull request adds support for configuring the Twig `autoescape` option for layouts, allowing users to set it explicitly or use an automatic strategy based on the template file extension. The documentation is updated in both English and French to explain the new configuration option and its behaviors.

Configuration and rendering improvements:

* Added a new `layouts.autoescape` option to `config/default.php`, allowing users to control Twig's `autoescape` behavior for templates. Setting it to `null` enables an extension-based strategy.
* Updated the `Twig` renderer in `src/Renderer/Twig.php` to use the new `layouts.autoescape` configuration. If set to `null`, it determines the escaping strategy based on the template's extension (`js`, `css`, `html`, or none).

Documentation updates:

* Documented the new `layouts.autoescape` option and its usage in the English configuration guide (`docs/4-Configuration.md`).
* Added equivalent documentation in the French configuration guide (`docs/4-Configuration.fr.md`).