### PR TITLE
feat: disable translation for inline and fenced code

### DIFF
--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -240,6 +240,9 @@ class Parsedown extends \ParsedownToc
         }
 
         // disable translation of code
+        if (!isset($code['element']['attributes'])) {
+            $code['element']['attributes'] = [];
+        }
         $code['element']['attributes']['translate'] = 'no';
 
         return $code;
@@ -598,11 +601,10 @@ class Parsedown extends \ParsedownToc
      */
     protected function blockFencedCodeComplete($block)
     {
-        if (!isset($block['element']['element']['attributes'])) {
-            return $block;
-        }
-
         // disable translation of code
+        if (!isset($block['element']['element']['attributes'])) {
+            $block['element']['element']['attributes'] = [];
+        }
         $block['element']['element']['attributes']['translate'] = 'no';
 
         if (!$this->config->isEnabled('pages.body.highlight')) {

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -231,6 +231,23 @@ class Parsedown extends \ParsedownToc
     /**
      * {@inheritdoc}
      */
+    protected function inlineCode($Excerpt)
+    {
+        $code = parent::inlineCode($Excerpt); // @phpstan-ignore staticMethod.notFound
+
+        if (!isset($code)) {
+            return null;
+        }
+
+        // disable translation of code
+        $code['element']['attributes']['translate'] = 'no';
+
+        return $code;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function inlineImage($Excerpt)
     {
         $InlineImage = parent::inlineImage($Excerpt); // @phpstan-ignore staticMethod.notFound
@@ -581,10 +598,14 @@ class Parsedown extends \ParsedownToc
      */
     protected function blockFencedCodeComplete($block)
     {
-        if (!$this->config->isEnabled('pages.body.highlight')) {
+        if (!isset($block['element']['element']['attributes'])) {
             return $block;
         }
-        if (!isset($block['element']['element']['attributes'])) {
+
+        // disable translation of code
+        $block['element']['element']['attributes']['translate'] = 'no';
+
+        if (!$this->config->isEnabled('pages.body.highlight')) {
             return $block;
         }
 

--- a/tests/IntegrationTests.php
+++ b/tests/IntegrationTests.php
@@ -64,13 +64,16 @@ class IntegrationTests extends \PHPUnit\Framework\TestCase
         $htmlEn = Util\File::fileGetContents(Util::joinFile($this->destination, '_site/markdown/localized-assets/index.html'));
         $htmlFr = Util\File::fileGetContents(Util::joinFile($this->destination, '_site/fr/markdown/localized-assets/index.html'));
         $htmlImages = Util\File::fileGetContents(Util::joinFile($this->destination, '_site/markdown/images/index.html'));
+        $htmlMarkdown = Util\File::fileGetContents(Util::joinFile($this->destination, '_site/markdown/markdown/index.html'));
         self::assertNotFalse($htmlEn);
         self::assertNotFalse($htmlFr);
         self::assertNotFalse($htmlImages);
+        self::assertNotFalse($htmlMarkdown);
         self::assertStringContainsString('/images/cecil-logo.png', $htmlEn);
         self::assertStringContainsString('/images/cecil-logo.fr.png', $htmlFr);
         self::assertStringContainsString('media="(prefers-color-scheme: dark)"', $htmlImages);
         self::assertStringContainsStringIgnoringCase('/images/cecil-logo.dark.png', $htmlImages);
+        self::assertMatchesRegularExpression('/<code[^>]*translate="no"[^>]*>/', $htmlMarkdown);
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the handling of code elements in the `Parsedown.php` Markdown converter to improve accessibility and prevent unwanted translation of code blocks and inline code. The main changes ensure that both inline code and fenced code blocks explicitly set the `translate="no"` attribute, which signals browsers and assistive technologies not to translate code content.

**Accessibility and translation improvements:**

* Added an override for the `inlineCode` method to set the `translate="no"` attribute on inline code elements, preventing them from being translated.
* Updated the `blockFencedCodeComplete` method to always set the `translate="no"` attribute on fenced code blocks, regardless of syntax highlighting configuration.