### PR TITLE
perf: Build translations index

### DIFF
--- a/src/Step/Pages/Render.php
+++ b/src/Step/Pages/Render.php
@@ -87,6 +87,7 @@ class Render extends AbstractStep
         $this->addGlobals();
 
         $subset = $this->subset;
+        $translationsIndex = $this->buildTranslationsIndex();
 
         /** @var Collection $pages */
         $pages = $this->builder->getPages()
@@ -113,14 +114,14 @@ class Render extends AbstractStep
                 return true;
             })
             // enrichs some variables
-            ->map(function (Page $page) {
+            ->map(function (Page $page) use ($translationsIndex) {
                 $formats = $this->getOutputFormats($page);
                 // output formats
                 $page->setVariable('output', $formats);
                 // alternates formats
                 $page->setVariable('alternates', $this->getAlternates($formats));
                 // translations
-                $page->setVariable('translations', $this->getTranslations($page));
+                $page->setVariable('translations', $this->getTranslations($page, $translationsIndex));
 
                 return $page;
             });
@@ -209,7 +210,11 @@ class Render extends AbstractStep
                             $deprecations[] = $msg;
                         }
                     });
-                    $output = $this->builder->getRenderer()->render($layout['file'], ['page' => $page]);
+                    try {
+                        $output = $this->builder->getRenderer()->render($layout['file'], ['page' => $page]);
+                    } finally {
+                        restore_error_handler();
+                    }
                     foreach ($deprecations as $value) {
                         $this->builder->getLogger()->warning($value);
                     }
@@ -365,19 +370,42 @@ class Render extends AbstractStep
     }
 
     /**
-     * Returns the collection of translated pages for a given page.
+     * Builds translation groups once for the current page set.
+     *
+     * @return array<string, array<Page>>
      */
-    protected function getTranslations(Page $refPage): Collection
+    protected function buildTranslationsIndex(): array
     {
-        $pages = $this->builder->getPages()->filter(function (Page $page) use ($refPage) {
-            return $page->getVariable('langref') == $refPage->getVariable('langref')
-                && $page->getType() == $refPage->getType()
-                && $page->getId() !== $refPage->getId()
-                && !empty($page->getVariable('published'))
-                && !$page->getVariable('paginated')
-            ;
+        $translationsIndex = [];
+
+        /** @var Page $page */
+        foreach ($this->builder->getPages() as $page) {
+            if (empty($page->getVariable('published')) || $page->getVariable('paginated')) {
+                continue;
+            }
+
+            $translationsIndex[$this->getTranslationsIndexKey($page)][] = $page;
+        }
+
+        return $translationsIndex;
+    }
+
+    /**
+     * Returns the collection of translated pages for a given page.
+     *
+     * @param array<string, array<Page>> $translationsIndex
+     */
+    protected function getTranslations(Page $refPage, array $translationsIndex = []): Collection
+    {
+        $pages = \array_filter($translationsIndex[$this->getTranslationsIndexKey($refPage)] ?? [], function (Page $page) use ($refPage) {
+            return $page->getId() !== $refPage->getId();
         });
 
-        return $pages;
+        return new Collection('translations', $pages);
+    }
+
+    protected function getTranslationsIndexKey(Page $page): string
+    {
+        return \sprintf('%s::%s', (string) $page->getVariable('langref'), $page->getType());
     }
 }


### PR DESCRIPTION
This pull request optimizes how translations are handled during the page rendering process by building a translations index once and reusing it, instead of recalculating translations for each page. It also ensures error handlers are properly restored after rendering. The main changes are grouped below:

**Translations Handling Improvements:**

* Added a new method `buildTranslationsIndex` to build translation groups for the current set of pages, improving performance by avoiding repeated computation. (`src/Step/Pages/Render.php`, [src/Step/Pages/Render.phpR372-R409](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR372-R409))
* Updated the `getTranslations` method to use the precomputed `translationsIndex`, and changed its signature to accept this index. (`src/Step/Pages/Render.php`, [src/Step/Pages/Render.phpR372-R409](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR372-R409))
* Modified the page processing logic to build the translations index once and pass it to the mapping function that enriches page variables. (`src/Step/Pages/Render.php`, [[1]](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR90) [[2]](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbL116-R124)

**Rendering Robustness:**

* Ensured that the error handler is always restored after attempting to render a page layout, using a `try/finally` block. (`src/Step/Pages/Render.php`, [src/Step/Pages/Render.phpR213-R217](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR213-R217))