### PR TITLE
feat: add total duration row with diff to metrics

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -16,7 +16,6 @@ namespace Cecil\Command;
 use Cecil\Builder;
 use Cecil\Util;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -16,7 +16,9 @@ namespace Cecil\Command;
 use Cecil\Builder;
 use Cecil\Util;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -194,6 +196,26 @@ EOF
                 $rows[] = [$step['name'], $durationDisplay, $step['memory']];
                 $currentMetricsToSave['steps'][$step['name']] = $step['duration_raw'];
             }
+
+            // add total row with optional diff against previous run
+            $totalDuration = (float) $metrics['total']['duration_raw'];
+            $totalDurationDisplay = $totalDuration < 1000
+                ? \sprintf('%s ms', round($totalDuration, 0))
+                : \sprintf('%s s', round($totalDuration / 1000, 2));
+            if (isset($previousMetrics['total'])) {
+                $totalDiff = $totalDuration - (float) $previousMetrics['total'];
+                if (abs($totalDiff) >= 1) {
+                    $totalDiffAbs = abs($totalDiff);
+                    $totalDiffStr = $totalDiffAbs < 1000
+                        ? \sprintf('%s ms', round($totalDiffAbs, 0))
+                        : \sprintf('%s s', round($totalDiffAbs / 1000, 2));
+                    $sign = $totalDiff > 0 ? '+' : '-';
+                    $color = $totalDiff > 0 ? 'red' : 'green';
+                    $totalDurationDisplay .= \sprintf(' (<fg=%s>%s%s</>)', $color, $sign, $totalDiffStr);
+                }
+            }
+            $rows[] = new TableSeparator();
+            $rows[] = ['Total', $totalDurationDisplay, $metrics['total']['memory']];
 
             // save current metrics for next comparison
             Util\File::getFS()->dumpFile($metricsFile, (string) json_encode($currentMetricsToSave, JSON_PRETTY_PRINT));


### PR DESCRIPTION
This pull request enhances the build command by improving the display of build metrics, specifically by adding a summary row for total duration and memory usage, and by highlighting any differences from the previous run. The changes focus on making performance tracking more visible and user-friendly.

**Build metrics display improvements:**

* Added a summary "Total" row to the build metrics table, showing the total duration and memory usage of the build.
* If previous run metrics are available, the total duration now displays the difference compared to the previous run, with color-coded highlighting (red for slower, green for faster).
* Imported `TableSeparator` from Symfony Console to visually separate the total row from the individual step rows in the metrics table.