### PR TITLE
feat: show progress bar during build

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Cecil\Command;
 
 use Cecil\Builder;
+use Cecil\Logger\ConsoleLogger;
+use Cecil\Logger\ProgressConsoleLogger;
 use Cecil\Util;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -140,7 +142,24 @@ EOF
             }
         }
 
+        // start build
         $output->writeln(\sprintf('Building website%s...', $messageOpt));
+        $progressBar = null;
+        if ($output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
+            $progressBar = new ProgressBar($output);
+            $progressBar->setFormat("%current%/%max% %bar% %message%");
+            $progressBar->setEmptyBarCharacter('░');
+            $progressBar->setBarCharacter('<fg=green>▓</>');
+            $progressBar->setProgressCharacter('<fg=green>▓</>');
+            $progressBar->setMessage('Starting build');
+            $progressBar->start();
+
+            $builder->setLogger(new ProgressConsoleLogger($output, $progressBar));
+        } else {
+            $builder->setLogger(new ConsoleLogger($output));
+        }
+
+        // show build configuration in very verbose mode
         $output->writeln(\sprintf('<comment>Path:   %s</comment>', $this->getPath()), OutputInterface::VERBOSITY_VERY_VERBOSE);
         if (!empty($this->getConfigFiles())) {
             $output->writeln(\sprintf('<comment>Config: %s</comment>', implode(', ', $this->getConfigFiles())), OutputInterface::VERBOSITY_VERY_VERBOSE);
@@ -152,6 +171,13 @@ EOF
 
         // build
         $builder->build($options);
+
+        // end build
+        if ($progressBar !== null) {
+            $progressBar->setMessage('');
+            $progressBar->finish();
+            $output->writeln('');
+        }
         $output->writeln('<info>Build done.</info>');
 
         // notification

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -18,6 +18,7 @@ use Cecil\Logger\ConsoleLogger;
 use Cecil\Logger\ProgressConsoleLogger;
 use Cecil\Util;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Logger/ProgressConsoleLogger.php
+++ b/src/Logger/ProgressConsoleLogger.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Logger;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Console logger with progress bar support.
+ */
+class ProgressConsoleLogger extends ConsoleLogger
+{
+    private ProgressBar $progressBar;
+    private int $lastAdvancedStep = 0;
+
+    public function __construct(OutputInterface $output, ProgressBar $progressBar, array $verbosityLevelMap = [], array $formatLevelMap = [])
+    {
+        parent::__construct($output, $verbosityLevelMap, $formatLevelMap);
+
+        $this->progressBar = $progressBar;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        if (isset($context['step']) && \is_array($context['step'])) {
+            $step = (int) ($context['step'][0] ?? 0);
+            $stepsTotal = (int) ($context['step'][1] ?? 0);
+            if (0 < $stepsTotal && 0 === $this->progressBar->getMaxSteps()) {
+                $this->progressBar->setMaxSteps($stepsTotal);
+            }
+            if ($step > $this->lastAdvancedStep) {
+                $this->progressBar->setMessage((string) $message);
+                $this->progressBar->setProgress($step);
+                $this->lastAdvancedStep = $step;
+            }
+        }
+
+        parent::log($level, $message, $context);
+    }
+}

--- a/src/Logger/ProgressConsoleLogger.php
+++ b/src/Logger/ProgressConsoleLogger.php
@@ -49,15 +49,15 @@ class ProgressConsoleLogger extends ConsoleLogger
             }
         }
 
-$shouldWrite = isset($this->verbosityLevelMap[$level]) && $this->verbosityLevelMap[$level] <= $this->output->getVerbosity();
-if ($shouldWrite) {
-    $this->progressBar->clear();
-}
+        $shouldWrite = isset($this->verbosityLevelMap[$level]) && $this->verbosityLevelMap[$level] <= $this->output->getVerbosity();
+        if ($shouldWrite) {
+            $this->progressBar->clear();
+        }
 
-parent::log($level, $message, $context);
+        parent::log($level, $message, $context);
 
-if ($shouldWrite) {
-    $this->progressBar->display();
-}
+        if ($shouldWrite) {
+            $this->progressBar->display();
+        }
     }
 }

--- a/src/Logger/ProgressConsoleLogger.php
+++ b/src/Logger/ProgressConsoleLogger.php
@@ -49,6 +49,15 @@ class ProgressConsoleLogger extends ConsoleLogger
             }
         }
 
-        parent::log($level, $message, $context);
+$shouldWrite = isset($this->verbosityLevelMap[$level]) && $this->verbosityLevelMap[$level] <= $this->output->getVerbosity();
+if ($shouldWrite) {
+    $this->progressBar->clear();
+}
+
+parent::log($level, $message, $context);
+
+if ($shouldWrite) {
+    $this->progressBar->display();
+}
     }
 }

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -40,6 +40,17 @@ class IntegrationCliTests extends IntegrationTests
         self::assertTrue($retval < 1);
     }
 
+    public function testBuildDefaultVerbosity()
+    {
+        echo "\n";
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil build tests/demo', $output, $retval);
+        echo implode("\n", $output);
+        self::assertTrue($retval < 1);
+    }
+
     public function testDoctor(): void
     {
         echo "\n";


### PR DESCRIPTION
This pull request enhances the build command's user experience by introducing a progress bar during the build process when running with default verbosity. It also adds a new logger to support progress bar updates and extends integration tests to cover this functionality.

**Build Command Improvements:**

* Added a progress bar to the `build` command when run with normal verbosity, providing real-time feedback on build progress. The progress bar is initialized and configured with custom formatting, and is updated throughout the build process. (`src/Command/Build.php`) [[1]](diffhunk://#diff-7da763cf51b7fe35d72081b1f102ebb75a5c9b1fbf155f00e085715d4aa32c1aR146-R163) [[2]](diffhunk://#diff-7da763cf51b7fe35d72081b1f102ebb75a5c9b1fbf155f00e085715d4aa32c1aR175-R181)
* Integrated the new `ProgressConsoleLogger` to handle progress bar updates, falling back to the standard logger for other verbosity levels. (`src/Command/Build.php`)

**Logger Enhancements:**

* Introduced `ProgressConsoleLogger`, a logger that extends `ConsoleLogger` and manages progress bar updates based on build steps, ensuring synchronized output and progress updates. (`src/Logger/ProgressConsoleLogger.php`)

**Testing:**

* Added an integration test to verify the build process with default verbosity, ensuring the progress bar and build output behave as expected. (`tests/IntegrationCliTests.php`)