### PR TITLE
fix: log and skip unsupported/empty data files

### DIFF
--- a/src/Step/Data/Load.php
+++ b/src/Step/Data/Load.php
@@ -99,6 +99,7 @@ class Load extends AbstractStep
             $data = $file->getContents();
             restore_error_handler();
 
+            $dataAsArray = [];
             switch ($file->getExtension()) {
                 case 'yml':
                 case 'yaml':
@@ -114,7 +115,17 @@ class Load extends AbstractStep
                     $dataAsArray = $serializerXml->decode($data, 'xml');
                     break;
                 default:
-                    return;
+                    $message = \sprintf('File "%s" has an unsupported extension', $file->getRelativePathname());
+                    $this->builder->getLogger()->warning($message, ['progress' => [$count, $total]]);
+                    continue;
+            }
+
+            // If the file is empty or contains invalid data, skip it and log a warning
+            if (!\is_array($dataAsArray)) {
+                $message = \sprintf('File "%s" is empty or contains invalid data', $file->getRelativePathname());
+                $this->builder->getLogger()->warning($message, ['progress' => [$count, $total]]);
+
+                continue;
             }
 
             $lang = $this->config->getLanguageDefault();

--- a/src/Step/Data/Load.php
+++ b/src/Step/Data/Load.php
@@ -117,7 +117,7 @@ class Load extends AbstractStep
                 default:
                     $message = \sprintf('File "%s" has an unsupported extension', $file->getRelativePathname());
                     $this->builder->getLogger()->warning($message, ['progress' => [$count, $total]]);
-                    continue;
+                    continue 2;
             }
 
             // If the file is empty or contains invalid data, skip it and log a warning


### PR DESCRIPTION
This pull request improves the robustness and logging of the data loading process in `src/Step/Data/Load.php` by adding better handling for unsupported file extensions and invalid or empty data files. Now, instead of silently skipping problematic files, the system logs warnings with helpful context.

Error handling and logging improvements:

* Added a warning log when a file with an unsupported extension is encountered, including the file name and progress information. The file is then skipped instead of returning early.
* Added a warning log when a file is empty or contains invalid data (i.e., cannot be decoded into an array), again including the file name and progress. Such files are also skipped.

Code robustness:

* Introduced the `$dataAsArray` variable to standardize data handling and make subsequent checks for valid array data possible.