### PR TITLE
feat: enhance Doctor checks and diagnostics

### DIFF
--- a/src/Command/Doctor.php
+++ b/src/Command/Doctor.php
@@ -256,12 +256,18 @@ EOF
             return [false, 'Directory path is empty'];
         }
 
-        if (is_dir($directory)) {
-            return [is_writable($directory), is_writable($directory) ? 'Writable' : 'Not writable'];
+        if (\file_exists($directory) && !\is_dir($directory)) {
+            return [false, 'Path exists and is not a directory'];
+        }
+
+        if (\is_dir($directory)) {
+            $writable = \is_writable($directory);
+
+            return [$writable, $writable ? 'Writable' : 'Not writable'];
         }
 
         $parent = $directory;
-        while (!is_dir($parent)) {
+        while (!\is_dir($parent)) {
             $nextParent = \dirname($parent);
             if ($nextParent === $parent) {
                 return [false, 'Cannot determine parent directory'];
@@ -269,8 +275,9 @@ EOF
             $parent = $nextParent;
         }
 
-        return [is_writable($parent), is_writable($parent) ? 'Creatable (parent writable)' : 'Not creatable (parent not writable)'];
-    }
+        $parentWritable = \is_writable($parent);
+
+        return [$parentWritable, $parentWritable ? 'Creatable (parent writable)' : 'Not creatable (parent not writable)'];
 
     /**
      * Checks that page type formats reference existing output formats.

--- a/src/Command/Doctor.php
+++ b/src/Command/Doctor.php
@@ -261,18 +261,18 @@ EOF
             return [false, 'Directory path is empty'];
         }
 
-        if (\file_exists($directory) && !\is_dir($directory)) {
+        if (file_exists($directory) && !is_dir($directory)) {
             return [false, 'Path exists and is not a directory'];
         }
 
-        if (\is_dir($directory)) {
-            $writable = \is_writable($directory);
+        if (is_dir($directory)) {
+            $writable = is_writable($directory);
 
             return [$writable, $writable ? 'Writable' : 'Not writable'];
         }
 
         $parent = $directory;
-        while (!\is_dir($parent)) {
+        while (!is_dir($parent)) {
             $nextParent = \dirname($parent);
             if ($nextParent === $parent) {
                 return [false, 'Cannot determine parent directory'];
@@ -280,9 +280,10 @@ EOF
             $parent = $nextParent;
         }
 
-        $parentWritable = \is_writable($parent);
+        $parentWritable = is_writable($parent);
 
         return [$parentWritable, $parentWritable ? 'Creatable (parent writable)' : 'Not creatable (parent not writable)'];
+    }
 
     /**
      * Checks that page type formats reference existing output formats.

--- a/src/Command/Doctor.php
+++ b/src/Command/Doctor.php
@@ -142,8 +142,13 @@ EOF
         $this->addCheck($checks, 'Output directory', $outputWritable, $outputDetails, $outputDetails, 'error', $warnings, $errors);
 
         if ($config->isEnabled('cache')) {
-            [$cacheWritable, $cacheDetails] = $this->checkDirectoryWritable($this->getCachePathDisplay($config));
-            $this->addCheck($checks, 'Cache directory', $cacheWritable, $cacheDetails, $cacheDetails, 'error', $warnings, $errors);
+            $cachePath = $this->getCachePathDisplay($config);
+            if ($cachePath === 'Undefined') {
+                $this->addCheck($checks, 'Cache directory', false, 'Configured', 'The cache directory (`cache.dir`) is not defined.', 'error', $warnings, $errors);
+            } else {
+                [$cacheWritable, $cacheDetails] = $this->checkDirectoryWritable($cachePath);
+                $this->addCheck($checks, 'Cache directory', $cacheWritable, $cacheDetails, $cacheDetails, 'error', $warnings, $errors);
+            }
         } else {
             $this->addCheck($checks, 'Cache directory', true, 'Not required (cache is disabled)', 'Not required (cache is disabled)', 'warning', $warnings, $errors);
         }

--- a/src/Command/Doctor.php
+++ b/src/Command/Doctor.php
@@ -69,7 +69,7 @@ EOF
         $table = new Table($output);
         $table
             ->setHeaderTitle('Environment')
-            ->setHeaders(['Check', 'Value'])
+            ->setHeaders(['Item', 'Value'])
             ->setRows([
                 ['Cecil version', Builder::getVersion()],
                 ['PHP version', PHP_VERSION],
@@ -84,14 +84,13 @@ EOF
             ->setHeaderTitle('Paths')
             ->setHeaders(['Item', 'Value'])
             ->setRows([
-                ['Source', $config->getSourceDir()],
-                ['Destination', $config->getDestinationDir()],
+                ['Config files', $this->formatConfigFiles()],
                 ['Pages', $config->getPagesPath()],
                 ['Layouts', $config->getLayoutsPath()],
                 ['Assets', $config->getAssetsPath()],
                 ['Static', $config->getStaticPath()],
+                ['Output', $config->getOutputPath()],
                 ['Cache', $this->getCachePathDisplay($config)],
-                ['Config files', $this->formatConfigFiles()],
             ])
         ;
         $table->setStyle('box')->render();
@@ -100,8 +99,28 @@ EOF
         $warnings = 0;
         $errors = 0;
 
-        $this->addCheck($checks, 'Base URL', trim((string) $config->get('baseurl'), '/') !== '', 'Configured', 'Not set', 'warning', $warnings, $errors);
+        $baseUrlRaw = trim((string) $config->get('baseurl'));
+        $baseUrlValid = false;
+        if ($baseUrlRaw === '') {
+            $this->addCheck($checks, 'Base URL', false, 'Configured', 'Not set', 'warning', $warnings, $errors);
+        } else {
+            try {
+                $baseUrlNormalized = self::validateUrl($baseUrlRaw);
+                $baseUrlValid = true;
+                $this->addCheck($checks, 'Base URL', true, $baseUrlNormalized, 'Invalid URL', 'error', $warnings, $errors);
+            } catch (\Exception $e) {
+                $this->addCheck($checks, 'Base URL', false, 'Configured', $e->getMessage(), 'error', $warnings, $errors);
+            }
+        }
+
+        $this->addCheck($checks, 'Canonical URL mode', !$config->isEnabled('canonicalurl') || $baseUrlValid, $config->isEnabled('canonicalurl') ? 'Enabled (base URL is valid)' : 'Disabled', 'Enabled but base URL is missing or invalid', 'error', $warnings, $errors);
+
         $this->addCheck($checks, 'Pages directory', is_dir($config->getPagesPath()), 'Found', 'Missing', 'warning', $warnings, $errors);
+
+        $this->addCheck($checks, 'Data directory', is_dir($config->getDataPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
+        $this->addCheck($checks, 'Assets directory', is_dir($config->getAssetsPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
+        $this->addCheck($checks, 'Static directory', is_dir($config->getStaticPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
+
         $themeConfigured = false;
         $themeStatus = true;
         $themeDetails = 'None configured';
@@ -118,15 +137,37 @@ EOF
         }
 
         $this->addCheck($checks, 'Layouts directory', is_dir($config->getLayoutsPath()) || ($themeConfigured && $themeStatus), 'Found or provided by a theme', 'Missing and no theme configured', 'error', $warnings, $errors);
+
+        [$outputWritable, $outputDetails] = $this->checkDirectoryWritable($config->getOutputPath());
+        $this->addCheck($checks, 'Output directory', $outputWritable, $outputDetails, $outputDetails, 'error', $warnings, $errors);
+
+        if ($config->isEnabled('cache')) {
+            [$cacheWritable, $cacheDetails] = $this->checkDirectoryWritable($this->getCachePathDisplay($config));
+            $this->addCheck($checks, 'Cache directory', $cacheWritable, $cacheDetails, $cacheDetails, 'error', $warnings, $errors);
+        } else {
+            $this->addCheck($checks, 'Cache directory', true, 'Not required (cache is disabled)', 'Not required (cache is disabled)', 'warning', $warnings, $errors);
+        }
+
         $this->addCheck($checks, 'Cache', $config->isEnabled('cache'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
         $this->addCheck($checks, 'Templates cache', $config->isEnabled('cache.templates'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
         $this->addCheck($checks, 'Translations cache', $config->isEnabled('cache.translations'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
+
+        $this->addCheck($checks, 'PHP extension: fileinfo', \extension_loaded('fileinfo'), 'Loaded', 'Missing', 'error', $warnings, $errors);
+        $this->addCheck($checks, 'PHP extension: gd', \extension_loaded('gd'), 'Loaded', 'Missing', 'error', $warnings, $errors);
+        $this->addCheck($checks, 'PHP extension: mbstring', \extension_loaded('mbstring'), 'Loaded', 'Missing', 'error', $warnings, $errors);
+
+        [$formatsStatus, $formatsDetails] = $this->checkOutputFormatsMapping($config);
+        $this->addCheck($checks, 'Output formats mapping', $formatsStatus, $formatsDetails, $formatsDetails, 'error', $warnings, $errors);
+
+        [$languagesStatus, $languagesDetails] = $this->checkLanguagesConfiguration($config);
+        $this->addCheck($checks, 'Languages configuration', $languagesStatus, $languagesDetails, $languagesDetails, 'error', $warnings, $errors);
+
         $this->addCheck($checks, 'Theme(s)', $themeStatus, $themeDetails, $themeDetails, 'error', $warnings, $errors);
 
         $table = new Table($output);
         $table
             ->setHeaderTitle('Checks')
-            ->setHeaders(['Check', 'Status', 'Details'])
+            ->setHeaders(['Item', 'Status', 'Details'])
             ->setRows($checks)
         ;
         $table->setStyle('box')->render();
@@ -184,7 +225,7 @@ EOF
             return 'None';
         }
 
-        return implode(', ', $configFiles);
+        return implode(",\n", $configFiles);
     }
 
     /**
@@ -202,5 +243,89 @@ EOF
         }
 
         return Util::joinFile($config->getDestinationDir(), $cacheDir);
+    }
+
+    /**
+     * Checks if a directory exists or can be created and is writable.
+     *
+     * @return array{0: bool, 1: string}
+     */
+    private function checkDirectoryWritable(string $directory): array
+    {
+        if ($directory === '') {
+            return [false, 'Directory path is empty'];
+        }
+
+        if (is_dir($directory)) {
+            return [is_writable($directory), is_writable($directory) ? 'Writable' : 'Not writable'];
+        }
+
+        $parent = $directory;
+        while (!is_dir($parent)) {
+            $nextParent = \dirname($parent);
+            if ($nextParent === $parent) {
+                return [false, 'Cannot determine parent directory'];
+            }
+            $parent = $nextParent;
+        }
+
+        return [is_writable($parent), is_writable($parent) ? 'Creatable (parent writable)' : 'Not creatable (parent not writable)'];
+    }
+
+    /**
+     * Checks that page type formats reference existing output formats.
+     *
+     * @return array{0: bool, 1: string}
+     */
+    private function checkOutputFormatsMapping(Config $config): array
+    {
+        $available = [];
+        foreach ((array) $config->get('output.formats') as $format) {
+            if (\is_array($format) && isset($format['name']) && \is_string($format['name']) && trim($format['name']) !== '') {
+                $available[] = $format['name'];
+            }
+        }
+
+        if (empty($available)) {
+            return [false, 'No output format defined'];
+        }
+
+        $available = array_values(array_unique($available));
+        $missing = [];
+        foreach ((array) $config->get('output.pagetypeformats') as $pageType => $formats) {
+            foreach ((array) $formats as $format) {
+                if (!\in_array($format, $available, true)) {
+                    $missing[] = \sprintf('%s:%s', (string) $pageType, (string) $format);
+                }
+            }
+        }
+
+        if (!empty($missing)) {
+            return [false, \sprintf('Unknown format reference(s): %s', implode(', ', array_unique($missing)))];
+        }
+
+        return [true, \sprintf('%d format(s), mapping is coherent', \count($available))];
+    }
+
+    /**
+     * Checks language configuration consistency.
+     *
+     * @return array{0: bool, 1: string}
+     */
+    private function checkLanguagesConfiguration(Config $config): array
+    {
+        try {
+            $default = $config->getLanguageDefault();
+            $languages = $config->getLanguages();
+            $codes = array_column($languages, 'code');
+
+            if (\count($codes) !== \count(array_unique($codes))) {
+                return [false, 'Duplicate language codes found'];
+            }
+
+            return [true, \sprintf('%d language(s), default: %s', \count($languages), $default)];
+        } catch (\Exception $e) {
+            return [false, $e->getMessage()];
+        }
     }
 }


### PR DESCRIPTION
This pull request improves the diagnostics and reporting in the `Doctor` command by enhancing environment and configuration checks, improving output formatting, and adding new validation logic for directories and configuration consistency. The changes make the output more informative and robust, helping users better identify and resolve issues in their setup.

**Enhancements to checks and validation:**

* Added detailed checks for the validity of the base URL, canonical URL mode, and required directories (`data`, `assets`, `static`, `output`, `cache`), including whether directories are writable or creatable. Also added checks for essential PHP extensions and improved error reporting for missing or misconfigured items. [[1]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18L103-R123) [[2]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18R140-R170)
* Introduced new private methods: `checkDirectoryWritable`, `checkOutputFormatsMapping`, and `checkLanguagesConfiguration` to validate directory writability, output formats mapping coherence, and language configuration consistency, respectively.

**Improvements to output formatting:**

* Changed table headers from "Check" to "Item" for clarity and consistency in the environment and checks tables. [[1]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18L72-R72) [[2]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18R140-R170)
* Reformatted the display of config files in the paths table to use line breaks instead of commas for better readability.
* Reordered rows in the paths table to group related items logically and added the output directory as a displayed item.