### PR TITLE
feat: add background serve mode and stop command

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -55,6 +55,7 @@ class Application extends BaseApplication
             new Command\Edit(),
             new Command\Build(),
             new Command\Serve(),
+            new Command\Stop(),
             new Command\Clear(),
             new Command\CacheClear(),
             new Command\CacheClearAssets(),

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -37,8 +37,9 @@ use Symfony\Component\Validator\Validation;
 class AbstractCommand extends Command
 {
     public const CONFIG_FILE = ['cecil.yml', 'config.yml'];
-    public const EXCLUDED_CMD = ['about', 'new:site', 'self-update'];
+    public const EXCLUDED_CMD = ['about', 'new:site', 'self-update', 'stop'];
     public const SERVE_OUTPUT = Builder::TMP_DIR . '/preview';
+    public const PID_FILE = Builder::TMP_DIR . '/server.pid';
 
     /** @var InputInterface */
     protected $input;

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -336,10 +336,12 @@ class AbstractCommand extends Command
         $placeholders = [
             '%command.name%',
             '%command.full_name%',
+            '%bin_name%',
         ];
         $replacements = [
             $name,
             $this->binName() . ' ' . $name,
+            $this->binName(),
         ];
 
         return str_replace($placeholders, $replacements, $this->getHelp() ?: $this->getDescription());

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -65,6 +65,7 @@ class Serve extends AbstractCommand
                 new InputOption('metrics', 'm', InputOption::VALUE_NONE, 'Show build metrics (duration and memory) of each step'),
                 new InputOption('timeout', null, InputOption::VALUE_REQUIRED, 'Sets the process timeout (max. runtime) in seconds', 7200), // default is 2 hours
                 new InputOption('notify', null, InputOption::VALUE_NONE, 'Send desktop notification on server start'),
+                new InputOption('background', 'b', InputOption::VALUE_NONE, 'Run the server in the background'),
             ])
             ->setHelp(
                 <<<'EOF'
@@ -96,6 +97,15 @@ To define the process <comment>timeout</comment> (in seconds), run:
 Send a desktop <comment>notification</comment> on server start, run:
 
   <info>%command.full_name% --notify</>
+
+To run the server in the <comment>background</comment>, run:
+
+  <info>%command.full_name% --background</>
+  <info>%command.full_name% -b</>
+
+Then stop it with:
+
+  <info>%command.full_name:stop</>
 EOF
             );
     }
@@ -120,9 +130,10 @@ EOF
         $verbose = $input->getOption('verbose');
         $notify = $input->getOption('notify');
         $noansi = $input->getOption('no-ansi');
+        $background = $input->getOption('background');
 
         $resourceWatcher = null;
-        $this->watcherEnabled = $input->getOption('watch');
+        $this->watcherEnabled = $background ? false : $input->getOption('watch');
 
         // checks if PHP executable is available
         $phpFinder = new PhpExecutableFinder();
@@ -130,7 +141,6 @@ EOF
         if ($php === false) {
             throw new RuntimeException('Unable to find a local PHP executable.');
         }
-
         // setup server
         $this->setUpServer();
         $command = \sprintf(
@@ -222,6 +232,48 @@ EOF
             $this->tearDownServer();
 
             return Command::FAILURE;
+        }
+
+        // background mode: start server as a detached process and exit
+        if ($background) {
+            $logFile = Util::joinFile($this->getPath(), Builder::TMP_DIR, 'server.log');
+            if (Util\Platform::isWindows()) {
+                // Use PowerShell Start-Process to launch detached hidden process
+                $phpWin = \str_replace('/', '\\', (string) $php);
+                $serverArgs = \sprintf(
+                    '-S %s:%d -t "%s" "%s"',
+                    $host,
+                    $port,
+                    \str_replace('/', '\\', Util::joinFile($this->getPath(), self::SERVE_OUTPUT)),
+                    \str_replace('/', '\\', Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'))
+                );
+                $psCommand = \sprintf(
+                    'powershell -NoProfile -Command "(Start-Process -PassThru -WindowStyle Hidden -FilePath \'%s\' -ArgumentList \'%s\').Id"',
+                    $phpWin,
+                    \str_replace("'", "''", $serverArgs)
+                );
+                \exec($psCommand, $pidOutput);
+            } else {
+                \exec(\sprintf('nohup %s > %s 2>&1 & echo $!', $command, \escapeshellarg($logFile)), $pidOutput);
+            }
+            $pid = (int)($pidOutput[0] ?? 0);
+            if ($pid <= 0) {
+                $this->tearDownServer();
+                throw new RuntimeException('Unable to start the server in the background.');
+            }
+            Util\File::getFS()->dumpFile(Util::joinFile($this->getPath(), self::PID_FILE), (string) $pid);
+            $output->writeln(\sprintf('<info>Starting server in the background (PID: %d)</info>', $pid));
+            $output->writeln(\sprintf('Server running at <href=http://%s:%d>http://%s:%d</>', $host, $port, $host, $port));
+            $output->writeln(\sprintf('To stop the server, run: <info>%s stop</info>', $this->binName()));
+            if ($notify) {
+                $this->notification('Starting server in background 🚀', \sprintf('http://%s:%s', $host, $port));
+            }
+            if ($open) {
+                $output->writeln('Opening web browser...');
+                Util\Platform::openBrowser(\sprintf('http://%s:%s', $host, $port));
+            }
+
+            return Command::SUCCESS;
         }
 
         // handles serve process
@@ -384,8 +436,8 @@ EOF
                     $livereloadJs,
                     true
                 );
+                Util\File::getFS()->chmod($livereloadJs, 0777 & ~umask());
             }
-            Util\File::getFS()->chmod(Util::joinFile($this->getPath(), Builder::TMP_DIR, 'livereload.js'), 0777 & ~umask());
         } catch (IOExceptionInterface $e) {
             throw new RuntimeException(\sprintf('An error occurred while copying server\'s files: "%s".', $e->getMessage()));
         }

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -132,7 +132,6 @@ EOF
         $noansi = $input->getOption('no-ansi');
         $background = $input->getOption('background');
 
-        $resourceWatcher = null;
         $this->watcherEnabled = $background ? false : $input->getOption('watch');
 
         // checks if PHP executable is available
@@ -143,67 +142,29 @@ EOF
         }
         // setup server
         $this->setUpServer();
-        $command = \implode(' ', [
+        $cmd = [
             $php,
             '-S',
             $host . ':' . (int) $port,
             '-t',
             Util::joinFile($this->getPath(), self::SERVE_OUTPUT),
             Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'),
-        ]);
-        $process = new Process([
-            $php,
-            '-S',
-            $host . ':' . (int) $port,
-            '-t',
-            Util::joinFile($this->getPath(), self::SERVE_OUTPUT),
-            Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'),
-        ]);
+        ];
+        $command = implode(' ', $cmd);
+        $process = new Process($cmd);
 
         // setup build process
-        $buildProcessArguments = [
-            $php,
-            $_SERVER['argv'][0],
-        ];
-        $buildProcessArguments[] = 'build';
-        $buildProcessArguments[] = $this->getPath();
-        if (!empty($this->getConfigFiles())) {
-            $buildProcessArguments[] = '--config';
-            $buildProcessArguments[] = implode(',', $this->getConfigFiles());
-        }
-        if ($drafts) {
-            $buildProcessArguments[] = '--drafts';
-        }
-        if ($optimize === true) {
-            $buildProcessArguments[] = '--optimize';
-        }
-        if ($optimize === false) {
-            $buildProcessArguments[] = '--no-optimize';
-        }
-        if ($clearcache === null) {
-            $buildProcessArguments[] = '--clear-cache';
-        }
-        if (!empty($clearcache)) {
-            $buildProcessArguments[] = '--clear-cache';
-            $buildProcessArguments[] = $clearcache;
-        }
-        if ($verbose) {
-            $buildProcessArguments[] = '-' . str_repeat('v', $_SERVER['SHELL_VERBOSITY']);
-        }
-        if (!empty($page)) {
-            $buildProcessArguments[] = '--page';
-            $buildProcessArguments[] = $page;
-        }
-        if ($metrics) {
-            $buildProcessArguments[] = '--metrics';
-        }
-        if ($noansi) {
-            $buildProcessArguments[] = '--no-ansi';
-        }
-        $buildProcessArguments[] = '--baseurl';
-        $buildProcessArguments[] = "http://$host:$port/";
-        $buildProcessArguments[] = '--output';
-        $buildProcessArguments[] = self::SERVE_OUTPUT;
+        $buildProcessArguments = $this->createBuildProcessArguments($php, [
+            'drafts' => $drafts,
+            'optimize' => $optimize,
+            'clearcache' => $clearcache,
+            'verbose' => $verbose,
+            'page' => $page,
+            'metrics' => $metrics,
+            'noansi' => $noansi,
+            'host' => $host,
+            'port' => $port,
+        ]);
         $buildProcess = new Process(
             $buildProcessArguments,
             null,
@@ -229,13 +190,7 @@ EOF
         };
 
         // builds before serve
-        $output->writeln(\sprintf('<comment>Build process: %s</comment>', implode(' ', $buildProcessArguments)), OutputInterface::VERBOSITY_DEBUG);
-        $buildProcess->run($processOutputCallback);
-        $flushBuildOutput();
-        if ($buildProcess->isSuccessful()) {
-            $this->buildSuccessActions($output);
-        }
-        if ($buildProcess->getExitCode() !== 0) {
+        if (!$this->runInitialBuild($buildProcess, $processOutputCallback, $flushBuildOutput, $output, $buildProcessArguments)) {
             $this->tearDownServer();
 
             return Command::FAILURE;
@@ -243,145 +198,274 @@ EOF
 
         // background mode: start server as a detached process and exit
         if ($background) {
-            $logFile = Util::joinFile($this->getPath(), Builder::TMP_DIR, 'server.log');
-            if (Util\Platform::isWindows()) {
-                // Use PowerShell Start-Process to launch detached hidden process
-                $phpWin = \str_replace('/', '\\', (string) $php);
-                $logFileWin = \str_replace('/', '\\', $logFile);
-                $serverArgs = \sprintf(
-                    '-S %s:%d -t "%s" "%s"',
-                    $host,
-                    $port,
-                    \str_replace('/', '\\', Util::joinFile($this->getPath(), self::SERVE_OUTPUT)),
-                    \str_replace('/', '\\', Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'))
-                );
-                $psCommand = \sprintf(
-                    'powershell -NoProfile -Command "(Start-Process -PassThru -WindowStyle Hidden -FilePath \'%s\' -ArgumentList \'%s\' -RedirectStandardOutput \'%s\' -RedirectStandardError \'%s\').Id"',
-                    $phpWin,
-                    \str_replace('"', '""', \str_replace("'", "''", $serverArgs)),
-                    \str_replace("'", "''", $logFileWin),
-                    \str_replace("'", "''", $logFileWin)
-                );
-                \exec($psCommand, $pidOutput);
-            } else {
-                \exec(\sprintf(
-                    'nohup %s -S %s -t %s %s > %s 2>&1 & echo $!',
-                    \escapeshellarg((string) $php),
-                    \escapeshellarg($host . ':' . (int) $port),
-                    \escapeshellarg(Util::joinFile($this->getPath(), self::SERVE_OUTPUT)),
-                    \escapeshellarg(Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php')),
-                    \escapeshellarg($logFile)
-                ), $pidOutput);
+            return $this->startServerInBackground($php, (string) $host, (int) $port, $output, (bool) $notify, (bool) $open);
+        }
+
+        return $this->runForegroundServer(
+            $process,
+            (bool) $noignorevcs,
+            (string) $host,
+            (int) $port,
+            $command,
+            $output,
+            (bool) $notify,
+            (bool) $open,
+            $buildProcess,
+            $processOutputCallback,
+            $flushBuildOutput
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<int, string>
+     */
+    private function createBuildProcessArguments(string $php, array $options): array
+    {
+        $buildProcessArguments = [
+            $php,
+            $_SERVER['argv'][0],
+            'build',
+            $this->getPath(),
+        ];
+
+        if (!empty($this->getConfigFiles())) {
+            $buildProcessArguments[] = '--config';
+            $buildProcessArguments[] = implode(',', $this->getConfigFiles());
+        }
+        if ($options['drafts']) {
+            $buildProcessArguments[] = '--drafts';
+        }
+        if ($options['optimize'] === true) {
+            $buildProcessArguments[] = '--optimize';
+        }
+        if ($options['optimize'] === false) {
+            $buildProcessArguments[] = '--no-optimize';
+        }
+        if ($options['clearcache'] === null) {
+            $buildProcessArguments[] = '--clear-cache';
+        }
+        if (!empty($options['clearcache'])) {
+            $buildProcessArguments[] = '--clear-cache';
+            $buildProcessArguments[] = (string) $options['clearcache'];
+        }
+        if ($options['verbose']) {
+            $buildProcessArguments[] = '-' . str_repeat('v', (int) $_SERVER['SHELL_VERBOSITY']);
+        }
+        if (!empty($options['page'])) {
+            $buildProcessArguments[] = '--page';
+            $buildProcessArguments[] = (string) $options['page'];
+        }
+        if ($options['metrics']) {
+            $buildProcessArguments[] = '--metrics';
+        }
+        if ($options['noansi']) {
+            $buildProcessArguments[] = '--no-ansi';
+        }
+        $buildProcessArguments[] = '--baseurl';
+        $buildProcessArguments[] = \sprintf('http://%s:%s/', (string) $options['host'], (string) $options['port']);
+        $buildProcessArguments[] = '--output';
+        $buildProcessArguments[] = self::SERVE_OUTPUT;
+
+        return $buildProcessArguments;
+    }
+
+    /**
+     * @param array<int, string> $buildProcessArguments
+     */
+    private function runInitialBuild(
+        Process $buildProcess,
+        callable $processOutputCallback,
+        callable $flushBuildOutput,
+        OutputInterface $output,
+        array $buildProcessArguments
+    ): bool {
+        $output->writeln(\sprintf('<comment>Build process: %s</comment>', implode(' ', $buildProcessArguments)), OutputInterface::VERBOSITY_DEBUG);
+        $buildProcess->run($processOutputCallback);
+        $flushBuildOutput();
+
+        if ($buildProcess->isSuccessful()) {
+            $this->buildSuccessActions($output);
+        }
+
+        return $buildProcess->getExitCode() === 0;
+    }
+
+    private function startServerInBackground(
+        string $php,
+        string $host,
+        int $port,
+        OutputInterface $output,
+        bool $notify,
+        bool $open
+    ): int {
+        $logFile = Util::joinFile($this->getPath(), Builder::TMP_DIR, 'server.log');
+        $errorLogFile = Util::joinFile($this->getPath(), Builder::TMP_DIR, 'errors.log');
+        $pid = $this->startDetachedServerProcess($php, $host, $port, $logFile, $errorLogFile);
+
+        if ($pid <= 0) {
+            $this->tearDownServer();
+            throw new RuntimeException('Unable to start the server in the background.');
+        }
+
+        Util\File::getFS()->dumpFile(Util::joinFile($this->getPath(), self::PID_FILE), (string) $pid);
+        $output->writeln(\sprintf('<info>Starting server in the background (PID: %d)</info>', $pid));
+        $output->writeln(\sprintf('Server running at <href=http://%s:%d>http://%s:%d</>', $host, $port, $host, $port));
+        $output->writeln(\sprintf('To stop the server, run: <info>%s stop</info>', $this->binName()));
+
+        if ($notify) {
+            $this->notification('Starting server in background 🚀', \sprintf('http://%s:%s', $host, $port));
+        }
+        if ($open) {
+            $output->writeln('Opening web browser...');
+            Util\Platform::openBrowser(\sprintf('http://%s:%s', $host, $port));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function startDetachedServerProcess(string $php, string $host, int $port, string $logFile, string $errorLogFile): int
+    {
+        $pidOutput = [];
+
+        if (Util\Platform::isWindows()) {
+            // Use PowerShell Start-Process to launch detached hidden process
+            $phpWin = str_replace('/', '\\', $php);
+            $logFileWin = str_replace('/', '\\', $logFile);
+            $errorLogFileWin = str_replace('/', '\\', $errorLogFile);
+            $serverArgs = \sprintf(
+                '-S %s:%d -t "%s" "%s"',
+                $host,
+                $port,
+                str_replace('/', '\\', Util::joinFile($this->getPath(), self::SERVE_OUTPUT)),
+                str_replace('/', '\\', Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'))
+            );
+            $psCommand = \sprintf(
+                'powershell -NoProfile -Command "(Start-Process -PassThru -WindowStyle Hidden -FilePath \'%s\' -ArgumentList \'%s\' -RedirectStandardOutput \'%s\' -RedirectStandardError \'%s\').Id"',
+                $phpWin,
+                str_replace('"', '""', str_replace("'", "''", $serverArgs)),
+                str_replace("'", "''", $logFileWin),
+                str_replace("'", "''", $errorLogFileWin)
+            );
+            exec($psCommand, $pidOutput);
+        } else {
+            exec(\sprintf(
+                'nohup %s -S %s -t %s %s > %s 2> %s & echo $!',
+                escapeshellarg($php),
+                escapeshellarg($host . ':' . $port),
+                escapeshellarg(Util::joinFile($this->getPath(), self::SERVE_OUTPUT)),
+                escapeshellarg(Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php')),
+                escapeshellarg($logFile),
+                escapeshellarg($errorLogFile)
+            ), $pidOutput);
+        }
+
+        return (int) ($pidOutput[0] ?? 0);
+    }
+
+    private function runForegroundServer(
+        Process $process,
+        bool $noignorevcs,
+        string $host,
+        int $port,
+        string $command,
+        OutputInterface $output,
+        bool $notify,
+        bool $open,
+        Process $buildProcess,
+        callable $processOutputCallback,
+        callable $flushBuildOutput
+    ): int {
+        $resourceWatcher = null;
+
+        if ($process->isStarted()) {
+            return Command::SUCCESS;
+        }
+
+        $messageSuffix = '';
+        if ($this->watcherEnabled) {
+            $resourceWatcher = $this->setupWatcher($noignorevcs);
+            $resourceWatcher->initialize();
+            $messageSuffix = ' with changes watcher';
+        }
+
+        try {
+            if (\function_exists('\pcntl_signal')) {
+                pcntl_async_signals(true);
+                pcntl_signal(SIGINT, [$this, 'tearDownServer']);
+                pcntl_signal(SIGTERM, [$this, 'tearDownServer']);
             }
-            $pid = (int)($pidOutput[0] ?? 0);
-            if ($pid <= 0) {
-                $this->tearDownServer();
-                throw new RuntimeException('Unable to start the server in the background.');
-            }
-            Util\File::getFS()->dumpFile(Util::joinFile($this->getPath(), self::PID_FILE), (string) $pid);
-            $output->writeln(\sprintf('<info>Starting server in the background (PID: %d)</info>', $pid));
-            $output->writeln(\sprintf('Server running at <href=http://%s:%d>http://%s:%d</>', $host, $port, $host, $port));
-            $output->writeln(\sprintf('To stop the server, run: <info>%s stop</info>', $this->binName()));
+
+            $output->writeln(\sprintf('<comment>Server process: %s</comment>', $command), OutputInterface::VERBOSITY_DEBUG);
+            $output->writeln(\sprintf('Starting server%s (<href=http://%s:%d>http://%s:%d</>)', $messageSuffix, $host, $port, $host, $port));
+            $process->start(function ($type, $buffer) {
+                if ($type === Process::ERR) {
+                    error_log($buffer, 3, Util::joinFile($this->getPath(), Builder::TMP_DIR, 'errors.log'));
+                }
+            });
+
             if ($notify) {
-                $this->notification('Starting server in background 🚀', \sprintf('http://%s:%s', $host, $port));
+                $this->notification('Starting server 🚀', \sprintf('http://%s:%s', $host, $port));
             }
             if ($open) {
                 $output->writeln('Opening web browser...');
                 Util\Platform::openBrowser(\sprintf('http://%s:%s', $host, $port));
             }
 
-            return Command::SUCCESS;
-        }
+            while ($process->isRunning()) {
+                sleep(1); // wait for server is ready
+                if (!fsockopen($host, $port)) {
+                    $output->writeln('<info>Server is not ready</info>');
 
-        // handles serve process
-        if (!$process->isStarted()) {
-            $messageSuffix = '';
-            // setup resource watcher
-            if ($this->watcherEnabled) {
-                $resourceWatcher = $this->setupWatcher($noignorevcs);
-                $resourceWatcher->initialize();
-                $messageSuffix = ' with changes watcher';
-            }
-            // starts server
-            try {
-                if (\function_exists('\pcntl_signal')) {
-                    pcntl_async_signals(true);
-                    pcntl_signal(SIGINT, [$this, 'tearDownServer']);
-                    pcntl_signal(SIGTERM, [$this, 'tearDownServer']);
+                    return Command::FAILURE;
                 }
-                $output->writeln(\sprintf('<comment>Server process: %s</comment>', $command), OutputInterface::VERBOSITY_DEBUG);
-                $output->writeln(\sprintf('Starting server%s (<href=http://%s:%d>http://%s:%d</>)', $messageSuffix, $host, $port, $host, $port));
-                $process->start(function ($type, $buffer) {
-                    if ($type === Process::ERR) {
-                        error_log($buffer, 3, Util::joinFile($this->getPath(), Builder::TMP_DIR, 'errors.log'));
-                    }
-                });
-                // notification
-                if ($notify) {
-                    $this->notification('Starting server 🚀', \sprintf('http://%s:%s', $host, $port));
-                }
-                // open web browser
-                if ($open) {
-                    $output->writeln('Opening web browser...');
-                    Util\Platform::openBrowser(\sprintf('http://%s:%s', $host, $port));
-                }
-                while ($process->isRunning()) {
-                    sleep(1); // wait for server is ready
-                    if (!fsockopen($host, (int) $port)) {
-                        $output->writeln('<info>Server is not ready</info>');
+                if ($this->watcherEnabled && $resourceWatcher instanceof ResourceWatcher) {
+                    $watcher = $resourceWatcher->findChanges();
+                    if ($watcher->hasChanges()) {
+                        $output->writeln('<comment>Changes detected</comment>');
+                        if ($notify) {
+                            $this->notification('Changes detected, building website...');
+                        }
+                        if (\count($watcher->getDeletedFiles()) > 0) {
+                            $output->writeln('<comment>Deleted files:</comment>', OutputInterface::VERBOSITY_DEBUG);
+                            foreach ($watcher->getDeletedFiles() as $file) {
+                                $output->writeln("<comment>- $file</comment>", OutputInterface::VERBOSITY_DEBUG);
+                            }
+                        }
+                        if (\count($watcher->getNewFiles()) > 0) {
+                            $output->writeln('<comment>New files:</comment>', OutputInterface::VERBOSITY_DEBUG);
+                            foreach ($watcher->getNewFiles() as $file) {
+                                $output->writeln("<comment>- $file</comment>", OutputInterface::VERBOSITY_DEBUG);
+                            }
+                        }
+                        if (\count($watcher->getUpdatedFiles()) > 0) {
+                            $output->writeln('<comment>Updated files:</comment>', OutputInterface::VERBOSITY_DEBUG);
+                            foreach ($watcher->getUpdatedFiles() as $file) {
+                                $output->writeln("<comment>- $file</comment>", OutputInterface::VERBOSITY_DEBUG);
+                            }
+                        }
+                        $output->writeln('');
 
-                        return Command::FAILURE;
-                    }
-                    if ($this->watcherEnabled && $resourceWatcher instanceof ResourceWatcher) {
-                        $watcher = $resourceWatcher->findChanges();
-                        if ($watcher->hasChanges()) {
-                            $output->writeln('<comment>Changes detected</comment>');
-                            // notification
-                            if ($notify) {
-                                $this->notification('Changes detected, building website...');
-                            }
-                            // prints deleted/new/updated files in debug mode
-                            if (\count($watcher->getDeletedFiles()) > 0) {
-                                $output->writeln('<comment>Deleted files:</comment>', OutputInterface::VERBOSITY_DEBUG);
-                                foreach ($watcher->getDeletedFiles() as $file) {
-                                    $output->writeln("<comment>- $file</comment>", OutputInterface::VERBOSITY_DEBUG);
-                                }
-                            }
-                            if (\count($watcher->getNewFiles()) > 0) {
-                                $output->writeln('<comment>New files:</comment>', OutputInterface::VERBOSITY_DEBUG);
-                                foreach ($watcher->getNewFiles() as $file) {
-                                    $output->writeln("<comment>- $file</comment>", OutputInterface::VERBOSITY_DEBUG);
-                                }
-                            }
-                            if (\count($watcher->getUpdatedFiles()) > 0) {
-                                $output->writeln('<comment>Updated files:</comment>', OutputInterface::VERBOSITY_DEBUG);
-                                foreach ($watcher->getUpdatedFiles() as $file) {
-                                    $output->writeln("<comment>- $file</comment>", OutputInterface::VERBOSITY_DEBUG);
-                                }
-                            }
-                            $output->writeln('');
-                            // re-builds
-                            $buildProcess->run($processOutputCallback);
-                            $flushBuildOutput();
-                            if ($buildProcess->isSuccessful()) {
-                                $this->buildSuccessActions($output);
-                            }
-                            $output->writeln('<info>Server is running...</info>');
-                            // notification
-                            if ($notify) {
-                                $this->notification('Server is running...');
-                            }
+                        $buildProcess->run($processOutputCallback);
+                        $flushBuildOutput();
+                        if ($buildProcess->isSuccessful()) {
+                            $this->buildSuccessActions($output);
+                        }
+                        $output->writeln('<info>Server is running...</info>');
+                        if ($notify) {
+                            $this->notification('Server is running...');
                         }
                     }
                 }
-                if ($process->getExitCode() > 0) {
-                    $output->writeln(\sprintf('<comment>%s</comment>', trim($process->getErrorOutput())));
-                }
-            } catch (ProcessFailedException $e) {
-                $this->tearDownServer();
-
-                throw new RuntimeException(\sprintf($e->getMessage()));
             }
+
+            if ($process->getExitCode() > 0) {
+                $output->writeln(\sprintf('<comment>%s</comment>', trim($process->getErrorOutput())));
+            }
+        } catch (ProcessFailedException $e) {
+            $this->tearDownServer();
+
+            throw new RuntimeException(\sprintf($e->getMessage()));
         }
 
         return Command::SUCCESS;

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -143,15 +143,22 @@ EOF
         }
         // setup server
         $this->setUpServer();
-        $command = \sprintf(
-            '"%s" -S %s:%d -t "%s" "%s"',
+        $command = \implode(' ', [
             $php,
-            $host,
-            $port,
+            '-S',
+            $host . ':' . (int) $port,
+            '-t',
             Util::joinFile($this->getPath(), self::SERVE_OUTPUT),
-            Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php')
-        );
-        $process = Process::fromShellCommandline($command);
+            Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'),
+        ]);
+        $process = new Process([
+            $php,
+            '-S',
+            $host . ':' . (int) $port,
+            '-t',
+            Util::joinFile($this->getPath(), self::SERVE_OUTPUT),
+            Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'),
+        ]);
 
         // setup build process
         $buildProcessArguments = [
@@ -257,7 +264,14 @@ EOF
                 );
                 \exec($psCommand, $pidOutput);
             } else {
-                \exec(\sprintf('nohup %s > %s 2>&1 & echo $!', $command, \escapeshellarg($logFile)), $pidOutput);
+                \exec(\sprintf(
+                    'nohup %s -S %s -t %s %s > %s 2>&1 & echo $!',
+                    \escapeshellarg((string) $php),
+                    \escapeshellarg($host . ':' . (int) $port),
+                    \escapeshellarg(Util::joinFile($this->getPath(), self::SERVE_OUTPUT)),
+                    \escapeshellarg(Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php')),
+                    \escapeshellarg($logFile)
+                ), $pidOutput);
             }
             $pid = (int)($pidOutput[0] ?? 0);
             if ($pid <= 0) {

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -208,8 +208,10 @@ EOF
             (int) $port,
             $command,
             $output,
-            (bool) $notify,
-            (bool) $open,
+            [
+                'notify' => (bool) $notify,
+                'open' => (bool) $open,
+            ],
             $buildProcess,
             $processOutputCallback,
             $flushBuildOutput
@@ -370,12 +372,13 @@ EOF
         int $port,
         string $command,
         OutputInterface $output,
-        bool $notify,
-        bool $open,
+        array $options,
         Process $buildProcess,
         callable $processOutputCallback,
         callable $flushBuildOutput
     ): int {
+        $notify = (bool) ($options['notify'] ?? false);
+        $open = (bool) ($options['open'] ?? false);
         $resourceWatcher = null;
 
         if ($process->isStarted()) {

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -240,6 +240,7 @@ EOF
             if (Util\Platform::isWindows()) {
                 // Use PowerShell Start-Process to launch detached hidden process
                 $phpWin = \str_replace('/', '\\', (string) $php);
+                $logFileWin = \str_replace('/', '\\', $logFile);
                 $serverArgs = \sprintf(
                     '-S %s:%d -t "%s" "%s"',
                     $host,
@@ -248,9 +249,11 @@ EOF
                     \str_replace('/', '\\', Util::joinFile($this->getPath(), Builder::TMP_DIR, 'router.php'))
                 );
                 $psCommand = \sprintf(
-                    'powershell -NoProfile -Command "(Start-Process -PassThru -WindowStyle Hidden -FilePath \'%s\' -ArgumentList \'%s\').Id"',
+                    'powershell -NoProfile -Command "(Start-Process -PassThru -WindowStyle Hidden -FilePath \'%s\' -ArgumentList \'%s\' -RedirectStandardOutput \'%s\' -RedirectStandardError \'%s\').Id"',
                     $phpWin,
-                    \str_replace("'", "''", $serverArgs)
+                    \str_replace('"', '""', \str_replace("'", "''", $serverArgs)),
+                    \str_replace("'", "''", $logFileWin),
+                    \str_replace("'", "''", $logFileWin)
                 );
                 \exec($psCommand, $pidOutput);
             } else {

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -105,7 +105,7 @@ To run the server in the <comment>background</comment>, run:
 
 Then stop it with:
 
-  <info>%command.full_name:stop</>
+  <info>%bin_name% stop</>
 EOF
             );
     }

--- a/src/Command/Stop.php
+++ b/src/Command/Stop.php
@@ -58,13 +58,13 @@ EOF
     {
         $pidFile = Util::joinFile($this->getPath(), self::PID_FILE);
 
-        if (!\is_file($pidFile)) {
+        if (!is_file($pidFile)) {
             $output->writeln('<error>No background server found (PID file missing).</error>');
 
             return Command::FAILURE;
         }
 
-        $pid = (int) \file_get_contents($pidFile);
+        $pid = (int) file_get_contents($pidFile);
         if ($pid <= 0) {
             $output->writeln('<error>Invalid PID file.</error>');
             try {
@@ -78,9 +78,9 @@ EOF
 
         // kill the server process
         if (Util\Platform::isWindows()) {
-            \exec(\sprintf('taskkill /F /PID %d 2>NUL', $pid));
+            exec(\sprintf('taskkill /F /PID %d 2>NUL', $pid));
         } else {
-            \exec(\sprintf('kill %d 2>/dev/null', $pid));
+            exec(\sprintf('kill %d 2>/dev/null', $pid));
         }
 
         // clean up PID file

--- a/src/Command/Stop.php
+++ b/src/Command/Stop.php
@@ -67,7 +67,11 @@ EOF
         $pid = (int) \file_get_contents($pidFile);
         if ($pid <= 0) {
             $output->writeln('<error>Invalid PID file.</error>');
-            Util\File::getFS()->remove($pidFile);
+            try {
+                Util\File::getFS()->remove($pidFile);
+            } catch (IOExceptionInterface $e) {
+                throw new RuntimeException($e->getMessage());
+            }
 
             return Command::FAILURE;
         }

--- a/src/Command/Stop.php
+++ b/src/Command/Stop.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Command;
+
+use Cecil\Exception\RuntimeException;
+use Cecil\Util;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+
+/**
+ * Stop command.
+ *
+ * This command stops a background server started with `serve --background`.
+ */
+class Stop extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('stop')
+            ->setDescription('Stops the background server')
+            ->setDefinition([
+                new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
+            ])
+            ->setHelp(
+                <<<'EOF'
+The <info>%command.name%</> command stops a background server previously started with <info>serve --background</>.
+
+  <info>%command.full_name%</>
+  <info>%command.full_name% path/to/the/working/directory</>
+EOF
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws RuntimeException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $pidFile = Util::joinFile($this->getPath(), self::PID_FILE);
+
+        if (!\is_file($pidFile)) {
+            $output->writeln('<error>No background server found (PID file missing).</error>');
+
+            return Command::FAILURE;
+        }
+
+        $pid = (int) \file_get_contents($pidFile);
+        if ($pid <= 0) {
+            $output->writeln('<error>Invalid PID file.</error>');
+            Util\File::getFS()->remove($pidFile);
+
+            return Command::FAILURE;
+        }
+
+        // kill the server process
+        if (Util\Platform::isWindows()) {
+            \exec(\sprintf('taskkill /F /PID %d 2>NUL', $pid));
+        } else {
+            \exec(\sprintf('kill %d 2>/dev/null', $pid));
+        }
+
+        // clean up PID file
+        Util\File::getFS()->remove($pidFile);
+
+        // remove server output directory
+        try {
+            Util\File::getFS()->remove(Util::joinFile($this->getPath(), self::SERVE_OUTPUT));
+        } catch (IOExceptionInterface $e) {
+            throw new RuntimeException($e->getMessage());
+        }
+
+        $output->writeln('<info>Server stopped.</info>');
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -25,17 +25,17 @@ class IntegrationCliTests extends IntegrationTests
     /** @var int|null PID of any background server process started during a test */
     private ?int $backgroundPid = null;
 
-public function tearDown(): void
-{
-    // ensure any background server process is killed even if the test fails
-    if ($this->backgroundPid !== null) {
-        $pidFile = Util::joinFile(__DIR__, 'demo', '.cecil', 'server.pid');
-        if (is_file($pidFile) && (int) file_get_contents($pidFile) === $this->backgroundPid) {
-            exec(sprintf('kill %d 2>/dev/null', $this->backgroundPid));
+    public function tearDown(): void
+    {
+        // ensure any background server process is killed even if the test fails
+        if ($this->backgroundPid !== null) {
+            $pidFile = Util::joinFile(__DIR__, 'demo', '.cecil', 'server.pid');
+            if (is_file($pidFile) && (int) file_get_contents($pidFile) === $this->backgroundPid) {
+                exec(\sprintf('kill %d 2>/dev/null', $this->backgroundPid));
+            }
+            $this->backgroundPid = null;
         }
-        $this->backgroundPid = null;
-    }
-    $fs = new Filesystem();
+        $fs = new Filesystem();
         $fs = new Filesystem();
         if (!self::DEBUG) {
             $fs->remove(Util::joinFile(__DIR__, 'demo'));
@@ -114,12 +114,12 @@ public function tearDown(): void
         self::assertSame(0, $retval, 'serve --background should exit with code 0');
         $pidFile = Util::joinFile(__DIR__, 'demo', '.cecil', 'server.pid');
         self::assertFileExists($pidFile, 'PID file should exist before stop');
-$this->backgroundPid = (int) file_get_contents($pidFile);
-$output = [];
-exec('php ./bin/cecil stop tests/demo 2>&1', $output, $retval);
-echo implode("\n", $output);
-self::assertSame(0, $retval, 'stop should exit with code 0');
-self::assertFileDoesNotExist($pidFile, 'PID file should be removed by stop');
-$this->backgroundPid = null;
+        $this->backgroundPid = (int) file_get_contents($pidFile);
+        $output = [];
+        exec('php ./bin/cecil stop tests/demo 2>&1', $output, $retval);
+        echo implode("\n", $output);
+        self::assertSame(0, $retval, 'stop should exit with code 0');
+        self::assertFileDoesNotExist($pidFile, 'PID file should be removed by stop');
+        $this->backgroundPid = null;
     }
 }

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -22,8 +22,20 @@ class IntegrationCliTests extends IntegrationTests
      */
     public const DEBUG = false;
 
-    public function tearDown(): void
-    {
+    /** @var int|null PID of any background server process started during a test */
+    private ?int $backgroundPid = null;
+
+public function tearDown(): void
+{
+    // ensure any background server process is killed even if the test fails
+    if ($this->backgroundPid !== null) {
+        $pidFile = Util::joinFile(__DIR__, 'demo', '.cecil', 'server.pid');
+        if (is_file($pidFile) && (int) file_get_contents($pidFile) === $this->backgroundPid) {
+            exec(sprintf('kill %d 2>/dev/null', $this->backgroundPid));
+        }
+        $this->backgroundPid = null;
+    }
+    $fs = new Filesystem();
         $fs = new Filesystem();
         if (!self::DEBUG) {
             $fs->remove(Util::joinFile(__DIR__, 'demo'));
@@ -62,5 +74,52 @@ class IntegrationCliTests extends IntegrationTests
         echo $output;
         self::assertTrue($retval < 1);
         self::assertStringContainsString('Environment', $output);
+    }
+
+    /**
+     * @requires OS Linux|Darwin
+     */
+    public function testServeBackgroundWritesPidFile(): void
+    {
+        echo "\n";
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil build tests/demo -v', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil serve tests/demo --background --no-watch 2>&1', $output, $retval);
+        echo implode("\n", $output);
+        self::assertSame(0, $retval, 'serve --background should exit with code 0');
+        $pidFile = Util::joinFile(__DIR__, 'demo', '.cecil', 'server.pid');
+        self::assertFileExists($pidFile, 'PID file should be written by serve --background');
+        $pid = (int) file_get_contents($pidFile);
+        self::assertGreaterThan(0, $pid, 'PID file should contain a valid PID');
+        $this->backgroundPid = $pid;
+    }
+
+    /**
+     * @requires OS Linux|Darwin
+     */
+    public function testStopRemovesPidFile(): void
+    {
+        echo "\n";
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil build tests/demo -v', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil serve tests/demo --background --no-watch 2>&1', $output, $retval);
+        self::assertSame(0, $retval, 'serve --background should exit with code 0');
+        $pidFile = Util::joinFile(__DIR__, 'demo', '.cecil', 'server.pid');
+        self::assertFileExists($pidFile, 'PID file should exist before stop');
+$this->backgroundPid = (int) file_get_contents($pidFile);
+$output = [];
+exec('php ./bin/cecil stop tests/demo 2>&1', $output, $retval);
+echo implode("\n", $output);
+self::assertSame(0, $retval, 'stop should exit with code 0');
+self::assertFileDoesNotExist($pidFile, 'PID file should be removed by stop');
+$this->backgroundPid = null;
     }
 }


### PR DESCRIPTION
This pull request adds support for running the development server in the background and introduces a new `stop` command to terminate background server processes. The changes also improve the user experience and maintainability of the serve workflow, including better process management, clearer help messages, and enhanced test cleanup.

**Background server support and process management:**

* Added a new `stop` command (`src/Command/Stop.php`) that stops a background server process started with `serve --background`, including cross-platform process termination and cleanup of PID files and output directories. [[1]](diffhunk://#diff-aababb7f87772a7a8488b8df255be72423eac560d1f89a642dfd70c71b0d0b4eR1-R100) [[2]](diffhunk://#diff-00ce90757b1e2f4249d3e36b770c52ad59fbc9d6f7148a08d1f2a896fcedb08fR58) [[3]](diffhunk://#diff-034f8c9ba320fac2515ff9c2938941d7636d43c912645335d995b1c6254389a5L40-R42)
* Updated the `serve` command (`src/Command/Serve.php`) to support a `--background`/`-b` option, allowing the server to run as a detached process, writing its PID to a file for later termination. [[1]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R68) [[2]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R100-R108) [[3]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R133-R420)

**Serve command refactoring and enhancements:**

* Refactored the serve workflow to separate initial build, background/foreground server start, and process output handling, improving code clarity and robustness. [[1]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R133-R420) [[2]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62L270-L274) [[3]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62L294-R464) [[4]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62L316)
* Improved help messages and placeholders to clarify usage of background mode and the new stop command. [[1]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R100-R108) [[2]](diffhunk://#diff-034f8c9ba320fac2515ff9c2938941d7636d43c912645335d995b1c6254389a5R339-R344)

**Testing and file permission improvements:**

* Enhanced integration tests to ensure any background server process is properly cleaned up after tests, preventing orphan processes.
* Fixed file permission handling for the `livereload.js` file in the serve setup.