### PR TITLE
feat: add doctor:seo command with docs and tests

### DIFF
--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -71,11 +71,14 @@ Personnalisez les seuils d'audit et les contrôles activés dans votre fichier d
 ```yaml
 doctor:
   seo:
-    title.min: 30
-    title.max: 60
-    description.min: 120
-    description.max: 160
-    content.min_words: 300
+    title:
+      min: 30
+      max: 60
+    description:
+      min: 120
+      max: 160
+    content:
+      min_words: 300
     checks:
       title: true
       description: true

--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -2,7 +2,7 @@
 title: Commandes
 description: "Liste des commandes disponibles."
 date: 2026-03-27
-updated: 2026-06-09
+updated: 2026-06-12
 slug: commandes
 -->
 # Commandes
@@ -15,6 +15,7 @@ Available commands:
   build                      Builds the website
   clear                      Removes all generated files
   doctor                     Diagnoses the site configuration
+  doctor:seo                 Audits rendered HTML pages for common SEO issues
   edit                       [open] Open pages directory with the editor
   help                       Display help for a command
   self-update                [selfupdate] Updates Cecil to the latest version
@@ -34,6 +35,56 @@ Available commands:
  util
   util:templates:extract     Extracts built-in templates
   util:translations:extract  Extracts translations from templates
+```
+
+## doctor:seo
+
+Audite les pages HTML rendues pour détecter les problèmes SEO courants.
+
+```plaintext
+Description:
+  Audits rendered HTML pages for common SEO issues
+
+Usage:
+  doctor:seo [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Audit a single page relative to the pages directory
+      --format=FORMAT   Output format: text (default) or json
+      --include-virtual Include virtual pages (paginated, taxonomies) in audit
+```
+
+La commande construit le site en mode dry-run, puis audite le HTML rendu avec un jeu de contrôles ciblés : balise title, meta description, URL canonique, structure des titres, balises Open Graph, attributs alt des images et longueur estimée du contenu.
+
+Par défaut, les pages virtuelles (paginées, pages de taxonomie) sont exclues de l'audit. Utilisez `--include-virtual` pour les inclure.
+
+Exportez les résultats en JSON pour l'intégration CI en utilisant `--format=json`.
+
+### Configuration
+
+Personnalisez les seuils d'audit et les contrôles activés dans votre fichier de configuration :
+
+```yaml
+doctor:
+  seo:
+    title.min: 30
+    title.max: 60
+    description.min: 120
+    description.max: 160
+    content.min_words: 300
+    checks:
+      title: true
+      description: true
+      canonical: true
+      h1: true
+      og_tags: true
+      img_alt: true
+      content_length: true
+      lang_attribute: true
 ```
 
 ## new:site

--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -37,59 +37,6 @@ Available commands:
   util:translations:extract  Extracts translations from templates
 ```
 
-## doctor:seo
-
-Audite les pages HTML rendues pour détecter les problèmes SEO courants.
-
-```plaintext
-Description:
-  Audits rendered HTML pages for common SEO issues
-
-Usage:
-  doctor:seo [options] [--] [<path>]
-
-Arguments:
-  path                  Use the given path as working directory
-
-Options:
-  -c, --config=CONFIG   Set the path to an extra configuration file
-  -p, --page=PAGE       Audit a single page relative to the pages directory
-      --format=FORMAT   Output format: text (default) or json
-      --include-virtual Include virtual pages (paginated, taxonomies) in audit
-```
-
-La commande construit le site en mode dry-run, puis audite le HTML rendu avec un jeu de contrôles ciblés : balise title, meta description, URL canonique, structure des titres, balises Open Graph, attributs alt des images et longueur estimée du contenu.
-
-Par défaut, les pages virtuelles (paginées, pages de taxonomie) sont exclues de l'audit. Utilisez `--include-virtual` pour les inclure.
-
-Exportez les résultats en JSON pour l'intégration CI en utilisant `--format=json`.
-
-### Configuration
-
-Personnalisez les seuils d'audit et les contrôles activés dans votre fichier de configuration :
-
-```yaml
-doctor:
-  seo:
-    title:
-      min: 30
-      max: 60
-    description:
-      min: 120
-      max: 160
-    content:
-      min_words: 300
-    checks:
-      title: true
-      description: true
-      canonical: true
-      h1: true
-      og_tags: true
-      img_alt: true
-      content_length: true
-      lang_attribute: true
-```
-
 ## new:site
 
 Crée un nouveau site.
@@ -368,4 +315,52 @@ Help:
   To inspect a site with an extra configuration file, run:
 
     cecil.phar doctor --config=config.yml
+```
+
+## doctor:seo
+
+Audite les pages HTML rendues pour détecter les problèmes SEO courants.
+
+```plaintext
+Description:
+  Audits rendered HTML pages for common SEO issues
+
+Usage:
+  doctor:seo [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Audit a single page relative to the pages directory
+      --format=FORMAT   Output format: text (default) or json
+      --include-virtual Include virtual pages (paginated, taxonomies) in audit
+```
+
+La commande construit le site en mode dry-run, puis audite le HTML rendu avec un jeu de contrôles ciblés : balise title, meta description, URL canonique, structure des titres, balises Open Graph, attributs alt des images et longueur estimée du contenu.
+
+Par défaut, les pages virtuelles (paginées, pages de taxonomie) sont exclues de l'audit. Utilisez `--include-virtual` pour les inclure.
+
+Exportez les résultats en JSON pour l'intégration CI en utilisant `--format=json`.
+
+### Configuration
+
+Personnalisez les seuils d'audit et les contrôles activés dans votre fichier de configuration :
+
+```yaml
+doctor:
+  seo:
+    title: { min: 30, max: 60 }
+    description: { min: 120, max: 160 }
+    content: { min_words: 300 }
+    checks:
+      title: true
+      description: true
+      canonical: true
+      h1: true
+      og_tags: true
+      img_alt: true
+      content_length: true
+      lang_attribute: true
 ```

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -69,11 +69,14 @@ Customize audit thresholds and enabled checks in your configuration file:
 ```yaml
 doctor:
   seo:
-    title.min: 30
-    title.max: 60
-    description.min: 120
-    description.max: 160
-    content.min_words: 300
+    title:
+      min: 30
+      max: 60
+    description:
+      min: 120
+      max: 160
+    content:
+      min_words: 300
     checks:
       title: true
       description: true

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -35,59 +35,6 @@ Available commands:
   util:translations:extract  Extracts translations from templates
 ```
 
-## doctor:seo
-
-Audits rendered HTML pages for common SEO issues.
-
-```plaintext
-Description:
-  Audits rendered HTML pages for common SEO issues
-
-Usage:
-  doctor:seo [options] [--] [<path>]
-
-Arguments:
-  path                  Use the given path as working directory
-
-Options:
-  -c, --config=CONFIG   Set the path to an extra configuration file
-  -p, --page=PAGE       Audit a single page relative to the pages directory
-      --format=FORMAT   Output format: text (default) or json
-      --include-virtual Include virtual pages (paginated, taxonomies) in audit
-```
-
-The command builds the site in dry-run mode, then audits the rendered HTML output for a focused set of checks: title tag, meta description, canonical URL, heading structure, Open Graph tags, image alt attributes and estimated content length.
-
-By default, virtual pages (paginated, taxonomy pages) are excluded from the audit. Use `--include-virtual` to include them.
-
-Output results as JSON for CI integration using `--format=json`.
-
-### Configuration
-
-Customize audit thresholds and enabled checks in your configuration file:
-
-```yaml
-doctor:
-  seo:
-    title:
-      min: 30
-      max: 60
-    description:
-      min: 120
-      max: 160
-    content:
-      min_words: 300
-    checks:
-      title: true
-      description: true
-      canonical: true
-      h1: true
-      og_tags: true
-      img_alt: true
-      content_length: true
-      lang_attribute: true
-```
-
 ## new:site
 
 Creates a new site.
@@ -366,4 +313,52 @@ Help:
   To inspect a site with an extra configuration file, run:
 
     cecil.phar doctor --config=config.yml
+```
+
+## doctor:seo
+
+Audits rendered HTML pages for common SEO issues.
+
+```plaintext
+Description:
+  Audits rendered HTML pages for common SEO issues
+
+Usage:
+  doctor:seo [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Audit a single page relative to the pages directory
+      --format=FORMAT   Output format: text (default) or json
+      --include-virtual Include virtual pages (paginated, taxonomies) in audit
+```
+
+The command builds the site in dry-run mode, then audits the rendered HTML output for a focused set of checks: title tag, meta description, canonical URL, heading structure, Open Graph tags, image alt attributes and estimated content length.
+
+By default, virtual pages (paginated, taxonomy pages) are excluded from the audit. Use `--include-virtual` to include them.
+
+Output results as JSON for CI integration using `--format=json`.
+
+### Configuration
+
+Customize audit thresholds and enabled checks in your configuration file:
+
+```yaml
+doctor:
+  seo:
+    title: { min: 30, max: 60 }
+    description: { min: 120, max: 160 }
+    content: { min_words: 300 }
+    checks:
+      title: true
+      description: true
+      canonical: true
+      h1: true
+      og_tags: true
+      img_alt: true
+      content_length: true
+      lang_attribute: true
 ```

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -1,7 +1,7 @@
 <!--
 description: "List of available commands."
 date: 2020-12-19
-updated: 2026-06-09
+updated: 2026-06-12
 -->
 # Commands
 
@@ -13,6 +13,7 @@ Available commands:
   build                      Builds the website
   clear                      Removes all generated files
   doctor                     Diagnoses the site configuration
+  doctor:seo                 Audits rendered HTML pages for common SEO issues
   edit                       [open] Open pages directory with the editor
   help                       Display help for a command
   self-update                [selfupdate] Updates Cecil to the latest version
@@ -32,6 +33,56 @@ Available commands:
  util
   util:templates:extract     Extracts built-in templates
   util:translations:extract  Extracts translations from templates
+```
+
+## doctor:seo
+
+Audits rendered HTML pages for common SEO issues.
+
+```plaintext
+Description:
+  Audits rendered HTML pages for common SEO issues
+
+Usage:
+  doctor:seo [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Audit a single page relative to the pages directory
+      --format=FORMAT   Output format: text (default) or json
+      --include-virtual Include virtual pages (paginated, taxonomies) in audit
+```
+
+The command builds the site in dry-run mode, then audits the rendered HTML output for a focused set of checks: title tag, meta description, canonical URL, heading structure, Open Graph tags, image alt attributes and estimated content length.
+
+By default, virtual pages (paginated, taxonomy pages) are excluded from the audit. Use `--include-virtual` to include them.
+
+Output results as JSON for CI integration using `--format=json`.
+
+### Configuration
+
+Customize audit thresholds and enabled checks in your configuration file:
+
+```yaml
+doctor:
+  seo:
+    title.min: 30
+    title.max: 60
+    description.min: 120
+    description.max: 160
+    content.min_words: 300
+    checks:
+      title: true
+      description: true
+      canonical: true
+      h1: true
+      og_tags: true
+      img_alt: true
+      content_length: true
+      lang_attribute: true
 ```
 
 ## new:site
@@ -61,16 +112,16 @@ Options:
 Help:
   The new:site command creates a new website in the current directory, or in <path> if provided.
   If you run this command without any options, it will ask you for the website title, baseline, base URL, description, etc.
-  
+
     cecil.phar new:site
     cecil.phar new:site path/to/the/working/directory
-  
+
   To create a new website with demo content, run:
-  
+
     cecil.phar new:site --demo
-  
+
   To override an existing website, run:
-  
+
     cecil.phar new:site --force
 ```
 
@@ -105,21 +156,21 @@ Options:
 Help:
   The new:page command creates a new page file.
   If you run this command without any options, it will ask you for the page name and other options.
-  
+
     cecil.phar new:page
     cecil.phar new:page --name=path/to/a-page.md
     cecil.phar new:page --name=path/to/A Page.md --slugify
-  
+
   To create a new page with a date prefix (i.e: `YYYY-MM-DD`), run:
-  
+
     cecil.phar new:page --prefix
-  
+
   To create a new page and open it with an editor, run:
-  
+
     cecil.phar new:page --open --editor=editor
-  
+
   To override an existing page, run:
-  
+
     cecil.phar new:page --force
 ```
 

--- a/resources/layouts/_default/redirect.html.twig
+++ b/resources/layouts/_default/redirect.html.twig
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html>
-  <head lang="{{ site.language }}">
+<html lang="{{ site.language }}">
+  <head>
     <meta charset="utf-8">
     <title>{% trans %}Redirecting…{% endtrans %}</title>
     <link rel="canonical" href="{{ url(page.redirect, {canonical: true}) }}">
+    <meta name="description" content="{{ page.description|default(site.description) }}">
     <meta name="robots" content="noindex">
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta http-equiv="refresh" content="0;url={{ url(page.redirect, {canonical: true}) }}">

--- a/src/Application.php
+++ b/src/Application.php
@@ -62,6 +62,7 @@ class Application extends BaseApplication
             new Command\CacheClearTemplates(),
             new Command\CacheClearTranslations(),
             new Command\Doctor(),
+            new Command\DoctorSeo(),
             new Command\ShowContent(),
             new Command\ShowConfig(),
             new Command\ListCommand(),

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -116,6 +116,7 @@ Configure audit thresholds and checks in your configuration:
         img_alt: true
         content_length: true
         lang_attribute: true
+EOF
             )
         ;
     }

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -34,17 +34,9 @@ class DoctorSeo extends AbstractCommand
 {
     /** Default configuration thresholds */
     private const DEFAULT_CONFIG = [
-        'title' => [
-            'min' => 30,
-            'max' => 60,
-        ],
-        'description' => [
-            'min' => 120,
-            'max' => 160,
-        ],
-        'content' => [
-            'min_words' => 300,
-        ],
+        'title' => ['min' => 30, 'max' => 60 ],
+        'description' => ['min' => 120, 'max' => 160 ],
+        'content' => ['min_words' => 300 ],
         'checks' => [
             'title' => true,
             'description' => true,
@@ -105,14 +97,9 @@ Configure audit thresholds and checks in your configuration:
 
   doctor:
     seo:
-      title:
-        min: 30
-        max: 60
-      description:
-        min: 120
-        max: 160
-      content:
-        min_words: 300
+      title: { min: 30, max: 60 }
+      description: { min: 120, max: 160 }
+      content: { min_words: 300 }
       checks:
         title: true
         description: true

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -34,15 +34,11 @@ class DoctorSeo extends AbstractCommand
 {
     /** Default configuration thresholds */
     private const DEFAULT_CONFIG = [
-        //'title.min' => 30,
-        'title.min' => 8,
-        //'title.max' => 60,
-        'title.max' => 100,
-        //'description.min' => 120,
-        'description.min' => 8,
+        'title.min' => 30,
+        'title.max' => 60,
+        'description.min' => 120,
         'description.max' => 160,
-        //'content.min_words' => 300,
-        'content.min_words' => 8,
+        'content.min_words' => 300,
         'checks' => [
             'title' => true,
             'description' => true,

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -238,12 +238,17 @@ EOF
      */
     private function outputText(OutputInterface $output, array $findings, array $counts, int $healthyPages): void
     {
+        $pagesWithFindings = [];
+        foreach ($findings as $finding) {
+            $pagesWithFindings[$finding['page']] = true;
+        }
+
         $summary = new Table($output);
         $summary
             ->setHeaderTitle('SEO audit summary')
             ->setHeaders(['Metric', 'Value'])
             ->setRows([
-                ['Pages audited', (string) $counts['bad'] + $counts['ok'] + $counts['feedback'] + $healthyPages],
+                ['Pages audited', (string) ($healthyPages + \count($pagesWithFindings))],
                 ['Pages without findings', (string) $healthyPages],
                 ['Bad', (string) $counts['bad']],
                 ['OK', (string) $counts['ok']],

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -190,13 +190,7 @@ EOF
             $this->outputText($output, $findings, $counts, $healthyPages);
         }
 
-        // Return exit code based on findings
-        if ($counts['bad'] > 0) {
-            return Command::SUCCESS;
-        }
-
         return Command::SUCCESS;
-    }
 
     /**
      * Load audit configuration from Cecil config.

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -34,13 +34,14 @@ class DoctorSeo extends AbstractCommand
     /** Default configuration thresholds */
     private const DEFAULT_CONFIG = [
         //'title.min' => 30,
-        'title.min' => 10,
+        'title.min' => 8,
         //'title.max' => 60,
         'title.max' => 100,
         //'description.min' => 120,
-        'description.min' => 10,
+        'description.min' => 8,
         'description.max' => 160,
-        'content.min_words' => 300,
+        //'content.min_words' => 300,
+        'content.min_words' => 8,
         'checks' => [
             'title' => true,
             'description' => true,
@@ -133,6 +134,7 @@ EOF
         // Load thresholds from configuration
         $this->loadConfiguration($config);
 
+        $output->writeln('Building site in dry-run mode for SEO audit...');
         $builder->build([
             'dry-run' => true,
             'page' => (string) ($input->getOption('page') ?? ''),

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -128,6 +129,11 @@ EOF
     {
         $this->format = (string) ($input->getOption('format') ?? 'text');
         $this->includeVirtual = (bool) $input->getOption('include-virtual');
+
+        // In JSON mode, redirect build logs to stderr to keep stdout clean for JSON output
+        if ($this->format === 'json' && $output instanceof ConsoleOutputInterface) {
+            $this->output = $output->getErrorOutput();
+        }
 
         $builder = $this->getBuilder();
         $config = $builder->getConfig();

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -34,11 +34,17 @@ class DoctorSeo extends AbstractCommand
 {
     /** Default configuration thresholds */
     private const DEFAULT_CONFIG = [
-        'title.min' => 30,
-        'title.max' => 60,
-        'description.min' => 120,
-        'description.max' => 160,
-        'content.min_words' => 300,
+        'title' => [
+            'min' => 30,
+            'max' => 60,
+        ],
+        'description' => [
+            'min' => 120,
+            'max' => 160,
+        ],
+        'content' => [
+            'min_words' => 300,
+        ],
         'checks' => [
             'title' => true,
             'description' => true,
@@ -99,11 +105,14 @@ Configure audit thresholds and checks in your configuration:
 
   doctor:
     seo:
-      title.min: 30
-      title.max: 60
-      description.min: 120
-      description.max: 160
-      content.min_words: 300
+      title:
+        min: 30
+        max: 60
+      description:
+        min: 120
+        max: 160
+      content:
+        min_words: 300
       checks:
         title: true
         description: true
@@ -209,11 +218,11 @@ EOF
 
         // Merge with defaults
         $this->thresholds = [
-            'title_min' => $seoConfig['title.min'] ?? self::DEFAULT_CONFIG['title.min'],
-            'title_max' => $seoConfig['title.max'] ?? self::DEFAULT_CONFIG['title.max'],
-            'description_min' => $seoConfig['description.min'] ?? self::DEFAULT_CONFIG['description.min'],
-            'description_max' => $seoConfig['description.max'] ?? self::DEFAULT_CONFIG['description.max'],
-            'min_word_count' => $seoConfig['content.min_words'] ?? self::DEFAULT_CONFIG['content.min_words'],
+            'title_min' => $seoConfig['title']['min'] ?? self::DEFAULT_CONFIG['title']['min'],
+            'title_max' => $seoConfig['title']['max'] ?? self::DEFAULT_CONFIG['title']['max'],
+            'description_min' => $seoConfig['description']['min'] ?? self::DEFAULT_CONFIG['description']['min'],
+            'description_max' => $seoConfig['description']['max'] ?? self::DEFAULT_CONFIG['description']['max'],
+            'min_word_count' => $seoConfig['content']['min_words'] ?? self::DEFAULT_CONFIG['content']['min_words'],
         ];
 
         $this->checks = array_merge(

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -1,0 +1,507 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Command;
+
+use Cecil\Builder;
+use Cecil\Collection\Page\Page;
+use Cecil\Renderer\Page as PageRenderer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * SEO doctor command.
+ *
+ * This command builds the site in dry-run mode and audits the rendered HTML
+ * pages for a focused set of SEO checks inspired by editorial audit tools.
+ */
+class DoctorSeo extends AbstractCommand
+{
+    /** Default configuration thresholds */
+    private const DEFAULT_CONFIG = [
+        //'title.min' => 30,
+        'title.min' => 10,
+        //'title.max' => 60,
+        'title.max' => 100,
+        //'description.min' => 120,
+        'description.min' => 10,
+        'description.max' => 160,
+        'content.min_words' => 300,
+        'checks' => [
+            'title' => true,
+            'description' => true,
+            'canonical' => true,
+            'h1' => true,
+            'og_tags' => true,
+            'img_alt' => true,
+            'content_length' => true,
+            'lang_attribute' => true,
+        ],
+    ];
+
+    private array $thresholds = [];
+    private array $checks = [];
+    private bool $includeVirtual = false;
+    private string $format = 'text';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('doctor:seo')
+            ->setDescription('Audits rendered HTML pages for common SEO issues')
+            ->setDefinition([
+                new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
+                new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set the path to an extra configuration file'),
+                new InputOption('page', 'p', InputOption::VALUE_REQUIRED, 'Audit a single page relative to the pages directory'),
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'Output format: text (default) or json', 'text'),
+                new InputOption('include-virtual', null, InputOption::VALUE_NONE, 'Include virtual pages (paginated, taxonomies) in audit'),
+            ])
+            ->setHelp(
+                <<<'EOF'
+The <info>%command.name%</> command builds the site in dry-run mode, then audits
+the rendered HTML output for a focused set of SEO checks.
+
+  <info>%command.full_name%</>
+  <info>%command.full_name% path/to/the/working/directory</>
+
+To audit a single page, run:
+
+  <info>%command.full_name% --page=blog/post.md</>
+
+To output results as JSON for CI integration:
+
+  <info>%command.full_name% --format=json</>
+
+To include virtual pages (paginated, taxonomy pages):
+
+  <info>%command.full_name% --include-virtual</>
+
+To inspect a site with an extra configuration file, run:
+
+  <info>%command.full_name% --config=config.yml</>
+
+Configure audit thresholds and checks in your configuration:
+
+  doctor.seo:
+    title.min: 30
+    title.max: 60
+    description.min: 120
+    description.max: 160
+    content.min_words: 300
+    checks:
+      title: true
+      description: true
+      canonical: true
+      h1: true
+      og_tags: true
+      img_alt: true
+      content_length: true
+      lang_attribute: true
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->format = (string) ($input->getOption('format') ?? 'text');
+        $this->includeVirtual = (bool) $input->getOption('include-virtual');
+
+        $builder = $this->getBuilder();
+        $config = $builder->getConfig();
+
+        // Load thresholds from configuration
+        $this->loadConfiguration($config);
+
+        $builder->build([
+            'dry-run' => true,
+            'page' => (string) ($input->getOption('page') ?? ''),
+            'render-subset' => '',
+            'drafts' => false,
+        ]);
+
+        // Filter pages: only published and rendered, exclude virtual by default
+        $pages = $builder->getPages()->filter(function (Page $page) {
+            if ($page->getVariable('published') !== true) {
+                return false;
+            }
+            if (!isset($page->getRendered()['html']['output'])) {
+                return false;
+            }
+            // Exclude virtual pages (paginated, taxonomies) unless --include-virtual
+            if (!$this->includeVirtual && $page->isVirtual()) {
+                return false;
+            }
+            return true;
+        });
+
+        $findings = [];
+        $counts = [
+            'bad' => 0,
+            'ok' => 0,
+            'feedback' => 0,
+        ];
+        $healthyPages = 0;
+
+        /** @var Page $page */
+        foreach ($pages as $page) {
+            $pageFindings = $this->auditPage($builder, $page);
+            if (empty($pageFindings)) {
+                $healthyPages++;
+
+                continue;
+            }
+
+            foreach ($pageFindings as $finding) {
+                $counts[$finding['level']]++;
+                $findings[] = [
+                    'page' => $this->getPageLabel($builder, $page),
+                    'level' => $finding['level'],
+                    'check' => $finding['check'],
+                    'details' => $finding['details'],
+                ];
+            }
+        }
+
+        // Output results based on format
+        if ($this->format === 'json') {
+            $this->outputJson($output, $pages, $findings, $counts, $healthyPages);
+        } else {
+            $this->outputText($output, $findings, $counts, $healthyPages);
+        }
+
+        // Return exit code based on findings
+        if ($counts['bad'] > 0) {
+            return Command::SUCCESS;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Load audit configuration from Cecil config.
+     */
+    private function loadConfiguration(\Cecil\Config $config): void
+    {
+        $seoConfig = (array) $config->get('doctor.seo') ?? [];
+
+        // Merge with defaults
+        $this->thresholds = [
+            'title_min' => $seoConfig['title.min'] ?? self::DEFAULT_CONFIG['title.min'],
+            'title_max' => $seoConfig['title.max'] ?? self::DEFAULT_CONFIG['title.max'],
+            'description_min' => $seoConfig['description.min'] ?? self::DEFAULT_CONFIG['description.min'],
+            'description_max' => $seoConfig['description.max'] ?? self::DEFAULT_CONFIG['description.max'],
+            'min_word_count' => $seoConfig['content.min_words'] ?? self::DEFAULT_CONFIG['content.min_words'],
+        ];
+
+        $this->checks = array_merge(
+            self::DEFAULT_CONFIG['checks'],
+            (array) ($seoConfig['checks'] ?? [])
+        );
+    }
+
+    /**
+     * Output results in JSON format.
+     */
+    private function outputJson(OutputInterface $output, \Cecil\Collection\Page\Collection $pages, array $findings, array $counts, int $healthyPages): void
+    {
+        $result = [
+            'summary' => [
+                'pages_audited' => \count($pages),
+                'pages_without_findings' => $healthyPages,
+                'bad_count' => $counts['bad'],
+                'ok_count' => $counts['ok'],
+                'feedback_count' => $counts['feedback'],
+            ],
+            'findings' => $findings,
+        ];
+
+        $output->writeln(json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * Output results in text format (tables).
+     */
+    private function outputText(OutputInterface $output, array $findings, array $counts, int $healthyPages): void
+    {
+        $summary = new Table($output);
+        $summary
+            ->setHeaderTitle('SEO audit summary')
+            ->setHeaders(['Metric', 'Value'])
+            ->setRows([
+                ['Pages audited', (string) $counts['bad'] + $counts['ok'] + $counts['feedback'] + $healthyPages],
+                ['Pages without findings', (string) $healthyPages],
+                ['Bad', (string) $counts['bad']],
+                ['OK', (string) $counts['ok']],
+                ['Feedback', (string) $counts['feedback']],
+            ])
+        ;
+        $summary->setStyle('box')->render();
+
+        if (!empty($findings)) {
+            $rows = [];
+            foreach ($findings as $finding) {
+                $rows[] = [
+                    $finding['page'],
+                    $this->formatLevel($finding['level']),
+                    $finding['check'],
+                    $finding['details'],
+                ];
+            }
+
+            $table = new Table($output);
+            $table
+                ->setHeaderTitle('SEO findings')
+                ->setHeaders(['Page', 'Level', 'Check', 'Details'])
+                ->setRows($rows)
+            ;
+            $table->setStyle('box')->render();
+        }
+
+        if ($counts['bad'] > 0) {
+            $this->io->error(\sprintf('SEO audit found %d bad issue(s).', $counts['bad']));
+
+            return;
+        }
+
+        if ($counts['ok'] > 0 || $counts['feedback'] > 0) {
+            $this->io->warning(\sprintf('SEO audit found %d improvement(s).', $counts['ok'] + $counts['feedback']));
+
+            return;
+        }
+
+        $this->io->success('No SEO issues found.');
+    }
+
+    /**
+     * @return array<int, array{level: string, check: string, details: string}>
+     */
+    private function auditPage(Builder $builder, Page $page): array
+    {
+        $html = (string) $page->getRendered()['html']['output'];
+        $xpath = $this->createXPath($html);
+        if ($xpath === null) {
+            return [[
+                'level' => 'bad',
+                'check' => 'Rendered HTML',
+                'details' => 'The page could not be parsed as HTML.',
+            ]];
+        }
+
+        $findings = [];
+
+        // Check: Title tag
+        if ($this->checks['title']) {
+            $title = $this->getFirstNodeText($xpath, '//title');
+            if ($title === '') {
+                $findings[] = $this->createFinding('bad', 'Title tag', 'Missing <title> element.');
+            } else {
+                $titleLength = mb_strlen($title);
+                if ($titleLength < $this->thresholds['title_min'] || $titleLength > $this->thresholds['title_max']) {
+                    $findings[] = $this->createFinding(
+                        'ok',
+                        'Title length',
+                        \sprintf('Current length: %d characters. Recommended range: %d-%d.', $titleLength, $this->thresholds['title_min'], $this->thresholds['title_max'])
+                    );
+                }
+            }
+        }
+
+        // Check: Meta description
+        if ($this->checks['description']) {
+            $description = $this->getFirstNodeText($xpath, "//meta[translate(@name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = 'description']/@content");
+            if ($description === '') {
+                $findings[] = $this->createFinding('bad', 'Meta description', 'Missing meta description.');
+            } else {
+                $descriptionLength = mb_strlen($description);
+                if ($descriptionLength < $this->thresholds['description_min'] || $descriptionLength > $this->thresholds['description_max']) {
+                    $findings[] = $this->createFinding(
+                        'ok',
+                        'Meta description length',
+                        \sprintf('Current length: %d characters. Recommended range: %d-%d.', $descriptionLength, $this->thresholds['description_min'], $this->thresholds['description_max'])
+                    );
+                }
+            }
+        }
+
+        // Check: Canonical URL
+        if ($this->checks['canonical']) {
+            $canonical = $this->getFirstNodeText($xpath, "//link[contains(concat(' ', translate(normalize-space(@rel), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), ' '), ' canonical ')]/@href");
+            if ($canonical === '') {
+                $level = $builder->getConfig()->isEnabled('canonicalurl') ? 'bad' : 'feedback';
+                $details = $builder->getConfig()->isEnabled('canonicalurl')
+                    ? 'Missing canonical link while canonical URLs are enabled.'
+                    : 'No canonical link found in the rendered page.';
+                $findings[] = $this->createFinding($level, 'Canonical URL', $details);
+            }
+        }
+
+        // Check: Lang attribute
+        if ($this->checks['lang_attribute']) {
+            $lang = $this->getFirstNodeText($xpath, '/html/@lang');
+            if ($lang === '') {
+                $findings[] = $this->createFinding('feedback', 'HTML lang attribute', 'Missing lang attribute on the <html> element.');
+            }
+        }
+
+        // Check: H1 heading structure
+        if ($this->checks['h1']) {
+            $h1Count = $this->countNodes($xpath, '//h1');
+            if ($h1Count === 0) {
+                $findings[] = $this->createFinding('bad', 'Heading structure', 'Missing <h1> element.');
+            }
+            if ($h1Count > 1) {
+                $findings[] = $this->createFinding('ok', 'Heading structure', \sprintf('Found %d <h1> elements.', $h1Count));
+            }
+        }
+
+        // Check: Open Graph tags
+        if ($this->checks['og_tags']) {
+            if ($this->getFirstNodeText($xpath, "//meta[@property='og:title']/@content") === '') {
+                $findings[] = $this->createFinding('feedback', 'Open Graph title', 'Missing og:title meta tag.');
+            }
+            if ($this->getFirstNodeText($xpath, "//meta[@property='og:description']/@content") === '') {
+                $findings[] = $this->createFinding('feedback', 'Open Graph description', 'Missing og:description meta tag.');
+            }
+            if ($this->getFirstNodeText($xpath, "//meta[@property='og:image']/@content") === '') {
+                $findings[] = $this->createFinding('feedback', 'Open Graph image', 'Missing og:image meta tag.');
+            }
+        }
+
+        // Check: Image alt attributes
+        if ($this->checks['img_alt']) {
+            $missingAltImages = $this->countNodes($xpath, "//img[not(@alt) or normalize-space(@alt) = '']");
+            if ($missingAltImages > 0) {
+                $findings[] = $this->createFinding('ok', 'Images alt text', \sprintf('%d image(s) are missing an alt attribute.', $missingAltImages));
+            }
+        }
+
+        // Check: Content length
+        if ($this->checks['content_length']) {
+            $wordCount = $this->countWords($this->getBodyText($xpath, $html));
+            if ($wordCount < $this->thresholds['min_word_count']) {
+                $findings[] = $this->createFinding('feedback', 'Content length', \sprintf('Estimated body length: %d words.', $wordCount));
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return array{level: string, check: string, details: string}
+     */
+    private function createFinding(string $level, string $check, string $details): array
+    {
+        return [
+            'level' => $level,
+            'check' => $check,
+            'details' => $details,
+        ];
+    }
+
+    private function getPageLabel(Builder $builder, Page $page): string
+    {
+        $path = (new PageRenderer($builder, $page))->getPath('html');
+        if ($path === '') {
+            return '/';
+        }
+
+        return '/' . ltrim($path, '/');
+    }
+
+    private function formatLevel(string $level): string
+    {
+        return match ($level) {
+            'bad' => '<error>Bad</error>',
+            'ok' => '<comment>OK</comment>',
+            default => '<info>Feedback</info>',
+        };
+    }
+
+    private function createXPath(string $html): ?\DOMXPath
+    {
+        if (trim($html) === '') {
+            return null;
+        }
+
+        $useInternalErrors = libxml_use_internal_errors(true);
+        $document = new \DOMDocument('1.0', 'UTF-8');
+        $loaded = $document->loadHTML('<?xml encoding="UTF-8">' . $html, LIBXML_NOERROR | LIBXML_NOWARNING | LIBXML_NONET);
+        libxml_clear_errors();
+        libxml_use_internal_errors($useInternalErrors);
+        if ($loaded === false) {
+            return null;
+        }
+
+        return new \DOMXPath($document);
+    }
+
+    private function getFirstNodeText(\DOMXPath $xpath, string $query): string
+    {
+        $nodes = $xpath->query($query);
+        if ($nodes === false || $nodes->length === 0) {
+            return '';
+        }
+
+        return $this->normalizeText((string) $nodes->item(0)?->textContent);
+    }
+
+    private function countNodes(\DOMXPath $xpath, string $query): int
+    {
+        $nodes = $xpath->query($query);
+        if ($nodes === false) {
+            return 0;
+        }
+
+        return $nodes->length;
+    }
+
+    private function getBodyText(\DOMXPath $xpath, string $html): string
+    {
+        $body = $this->getFirstNodeText($xpath, '//body');
+        if ($body !== '') {
+            return $body;
+        }
+
+        return $this->normalizeText((string) strip_tags($html));
+    }
+
+    private function countWords(string $text): int
+    {
+        if ($text === '') {
+            return 0;
+        }
+
+        preg_match_all("/[\\p{L}\\p{N}']+/u", $text, $matches);
+
+        return \count($matches[0]);
+    }
+
+    private function normalizeText(string $text): string
+    {
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = preg_replace('/\s+/u', ' ', $text);
+
+        return trim((string) $text);
+    }
+}

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -191,6 +191,7 @@ EOF
         }
 
         return Command::SUCCESS;
+    }
 
     /**
      * Load audit configuration from Cecil config.

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -135,7 +135,9 @@ EOF
         // Load thresholds from configuration
         $this->loadConfiguration($config);
 
-        $output->writeln('Building site in dry-run mode for SEO audit...');
+        if ($this->format !== 'json') {
+            $output->writeln('Building site in dry-run mode for SEO audit...');
+        }
         $builder->build([
             'dry-run' => true,
             'page' => (string) ($input->getOption('page') ?? ''),

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -100,22 +100,22 @@ To inspect a site with an extra configuration file, run:
 
 Configure audit thresholds and checks in your configuration:
 
-  doctor.seo:
-    title.min: 30
-    title.max: 60
-    description.min: 120
-    description.max: 160
-    content.min_words: 300
-    checks:
-      title: true
-      description: true
-      canonical: true
-      h1: true
-      og_tags: true
-      img_alt: true
-      content_length: true
-      lang_attribute: true
-EOF
+  doctor:
+    seo:
+      title.min: 30
+      title.max: 60
+      description.min: 120
+      description.max: 160
+      content.min_words: 300
+      checks:
+        title: true
+        description: true
+        canonical: true
+        h1: true
+        og_tags: true
+        img_alt: true
+        content_length: true
+        lang_attribute: true
             )
         ;
     }

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -109,25 +109,11 @@ class IntegrationCliTests extends IntegrationTests
         exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
         self::assertTrue($retval < 1);
         $output = [];
-        exec('php ./bin/cecil doctor:seo tests/demo --format=json 2>&1', $output, $retval);
+        exec('php ./bin/cecil doctor:seo tests/demo --format=json', $output, $retval);
         $output = implode("\n", $output);
         echo $output;
         self::assertTrue($retval < 1);
-        // Extract JSON from output (skip warnings/errors)
-        $lines = explode("\n", $output);
-        $jsonStart = null;
-        foreach ($lines as $i => $line) {
-            if ($line === '{') {
-                $jsonStart = $i;
-                break;
-            }
-        }
-        if ($jsonStart !== null) {
-            $jsonOutput = implode("\n", \array_slice($lines, $jsonStart));
-        } else {
-            $jsonOutput = $output;
-        }
-        $json = json_decode($jsonOutput, true);
+        $json = \json_decode($output, true, 512, \JSON_THROW_ON_ERROR);
         self::assertIsArray($json);
         self::assertArrayHasKey('summary', $json);
         self::assertArrayHasKey('findings', $json);

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -86,6 +86,68 @@ class IntegrationCliTests extends IntegrationTests
         self::assertStringContainsString('Environment', $output);
     }
 
+    public function testDoctorSeo(): void
+    {
+        echo "\n################\n";
+        echo "# Test doctor:seo\n";
+        echo "################\n";
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil doctor:seo tests/demo 2>&1', $output, $retval);
+        $output = implode("\n", $output);
+        echo $output;
+        self::assertTrue($retval < 1);
+        self::assertStringContainsString('SEO audit summary', $output);
+    }
+
+    public function testDoctorSeoJson(): void
+    {
+        echo "\n################\n";
+        echo "# Test doctor:seo --format=json\n";
+        echo "################\n";
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil doctor:seo tests/demo --format=json 2>&1', $output, $retval);
+        $output = implode("\n", $output);
+        echo $output;
+        self::assertTrue($retval < 1);
+        // Extract JSON from output (skip warnings/errors)
+        $lines = explode("\n", $output);
+        $jsonStart = null;
+        foreach ($lines as $i => $line) {
+            if ($line === '{') {
+                $jsonStart = $i;
+                break;
+            }
+        }
+        if ($jsonStart !== null) {
+            $jsonOutput = implode("\n", \array_slice($lines, $jsonStart));
+        } else {
+            $jsonOutput = $output;
+        }
+        $json = json_decode($jsonOutput, true);
+        self::assertIsArray($json);
+        self::assertArrayHasKey('summary', $json);
+        self::assertArrayHasKey('findings', $json);
+    }
+
+    public function testDoctorSeoIncludeVirtual(): void
+    {
+        echo "\n################\n";
+        echo "# Test doctor:seo --include-virtual\n";
+        echo "################\n";
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
+        self::assertTrue($retval < 1);
+        $output = [];
+        exec('php ./bin/cecil doctor:seo tests/demo --include-virtual 2>&1', $output, $retval);
+        $output = implode("\n", $output);
+        echo $output;
+        self::assertTrue($retval < 1);
+        self::assertStringContainsString('SEO audit summary', $output);
+    }
+
     public function testServeBackgroundWithPidFile(): void
     {
         $this->markTestSkipped('Skipping serve background test because it is not reliable in CI environments');

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -113,7 +113,7 @@ class IntegrationCliTests extends IntegrationTests
         $output = implode("\n", $output);
         echo $output;
         self::assertTrue($retval < 1);
-        $json = \json_decode($output, true, 512, \JSON_THROW_ON_ERROR);
+        $json = json_decode($output, true, 512, \JSON_THROW_ON_ERROR);
         self::assertIsArray($json);
         self::assertArrayHasKey('summary', $json);
         self::assertArrayHasKey('findings', $json);


### PR DESCRIPTION
This pull request introduces a new `doctor:seo` command to the application, which audits rendered HTML pages for common SEO issues. The command, its documentation (in both English and French), and corresponding integration tests have been added. Users can customize the audit via configuration, select output formats, and include virtual pages in the audit.

Key changes include:

**Feature: New SEO Audit Command**

* Added the `doctor:seo` command to the CLI, enabling users to audit rendered HTML for SEO best practices such as title tags, meta descriptions, canonical URLs, heading structure, Open Graph tags, image alt attributes, and content length. The command supports configuration, single-page audit, output format selection (text or JSON), and the inclusion of virtual pages.
* In `--format=json` mode, build-progress logs are now redirected to stderr (via `ConsoleOutputInterface::getErrorOutput()`), keeping stdout clean so the JSON payload can be decoded directly without any line-scanning workaround.
* Audit threshold configuration now uses a nested array structure (`title: {min, max}`, `description: {min, max}`, `content: {min_words}`) instead of flat dot-notation keys, aligning with Cecil's standard YAML configuration conventions.

**Documentation Updates**

* Documented the new `doctor:seo` command in both English (`docs/5-Commands.md`) and French (`docs/5-Commands.fr.md`), including usage instructions, configuration options, and descriptions of available checks and thresholds.
* Updated the "last updated" date in the commands documentation to reflect these changes.
* Updated YAML configuration examples in the command help text and both documentation files to use proper nested YAML structure.

**Testing**

* Added integration tests to verify the new `doctor:seo` command, including tests for basic usage, JSON output, and inclusion of virtual pages.
* Simplified the JSON output test: removed the `2>&1` stderr-merge and the brittle line-scanning loop in favour of a direct `\json_decode($output, true, 512, \JSON_THROW_ON_ERROR)` call, now that stdout is guaranteed to contain only the JSON payload.