### PR TITLE
refactor: rename stop command to serve:stop

### DIFF
--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -2,7 +2,7 @@
 title: Commandes
 description: "Liste des commandes disponibles."
 date: 2026-03-27
-updated: 2026-06-09
+updated: 2026-06-12
 slug: commandes
 -->
 # Commandes
@@ -19,7 +19,7 @@ Available commands:
   help                       Display help for a command
   self-update                [selfupdate] Updates Cecil to the latest version
   serve                      Starts the built-in server
-  stop                       Stops the background server
+  serve:stop                 Stops the background server
  cache
   cache:clear                Removes all cache files
   cache:clear:assets         Removes assets cache
@@ -214,7 +214,7 @@ Help:
 
   Then stop it with:
 
-    cecil.phar stop
+    cecil.phar serve:stop
 
   In background mode, file changes are not watched automatically.
 ```

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -1,7 +1,7 @@
 <!--
 description: "List of available commands."
 date: 2020-12-19
-updated: 2026-06-09
+updated: 2026-06-12
 -->
 # Commands
 
@@ -17,7 +17,7 @@ Available commands:
   help                       Display help for a command
   self-update                [selfupdate] Updates Cecil to the latest version
   serve                      Starts the built-in server
-  stop                       Stops the background server
+  serve:stop                 Stops the background server
  cache
   cache:clear                Removes all cache files
   cache:clear:assets         Removes assets cache
@@ -212,7 +212,7 @@ Help:
 
   Then stop it with:
 
-    cecil.phar stop
+    cecil.phar serve:stop
 
   In background mode, file changes are not watched automatically.
 ```

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -37,7 +37,7 @@ use Symfony\Component\Validator\Validation;
 class AbstractCommand extends Command
 {
     public const CONFIG_FILE = ['cecil.yml', 'config.yml'];
-    public const EXCLUDED_CMD = ['about', 'new:site', 'self-update', 'stop'];
+    public const EXCLUDED_CMD = ['about', 'new:site', 'self-update', 'serve:stop'];
     public const SERVE_OUTPUT = Builder::TMP_DIR . '/preview';
     public const PID_FILE = Builder::TMP_DIR . '/server.pid';
 

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -105,7 +105,7 @@ To run the server in the <comment>background</comment>, run:
 
 Then stop it with:
 
-  <info>%bin_name% stop</>
+  <info>%bin_name% serve:stop</>
 EOF
             );
     }

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -311,7 +311,7 @@ EOF
         Util\File::getFS()->dumpFile(Util::joinFile($this->getPath(), self::PID_FILE), (string) $pid);
         $output->writeln(\sprintf('<info>Starting server in the background (PID: %d)</info>', $pid));
         $output->writeln(\sprintf('Server running at <href=http://%s:%d>http://%s:%d</>', $host, $port, $host, $port));
-        $output->writeln(\sprintf('To stop the server, run: <info>%s stop</info>', $this->binName()));
+        $output->writeln(\sprintf('To stop the server, run: <info>%s serve:stop</info>', $this->binName()));
 
         if ($notify) {
             $this->notification('Starting server in background 🚀', \sprintf('http://%s:%s', $host, $port));

--- a/src/Command/Stop.php
+++ b/src/Command/Stop.php
@@ -35,6 +35,7 @@ class Stop extends AbstractCommand
     {
         $this
             ->setName('serve:stop')
+            ->setAliases(['stop'])
             ->setDescription('Stops the background server')
             ->setDefinition([
                 new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),

--- a/src/Command/Stop.php
+++ b/src/Command/Stop.php
@@ -34,7 +34,7 @@ class Stop extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setName('stop')
+            ->setName('serve:stop')
             ->setDescription('Stops the background server')
             ->setDefinition([
                 new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -101,10 +101,10 @@ class IntegrationCliTests extends IntegrationTests
         self::assertFileExists($pidFile, 'PID file should exist before stop');
         $this->backgroundPid = (int) file_get_contents($pidFile);
         $output = [];
-        exec('php ./bin/cecil stop tests/demo 2>&1', $output, $retval);
+        exec('php ./bin/cecil serve:stop tests/demo 2>&1', $output, $retval);
         echo implode("\n", $output);
-        self::assertSame(0, $retval, 'stop should exit with code 0');
-        self::assertFileDoesNotExist($pidFile, 'PID file should be removed by stop');
+        self::assertSame(0, $retval, 'serve:stop should exit with code 0');
+        self::assertFileDoesNotExist($pidFile, 'PID file should be removed by serve:stop');
         $this->backgroundPid = null;
     }
 }


### PR DESCRIPTION
This pull request renames the `stop` command to `serve:stop` throughout the codebase and documentation to improve clarity and consistency. The changes update command definitions, documentation, and related tests to reflect the new command name.

Changes proposed in this pull request:

**Command renaming and code updates:**

* Renamed the `stop` command to `serve:stop` in the command definition (`src/Command/Stop.php`).
* Added `stop` as a backward-compatible alias on the `serve:stop` command so existing scripts continue to work (`src/Command/Stop.php`).
* Updated the excluded commands list in `AbstractCommand` to use `serve:stop` instead of `stop` (`src/Command/AbstractCommand.php`).
* Updated the runtime message printed by `startServerInBackground()` to instruct users to run `serve:stop` instead of `stop` (`src/Command/Serve.php`).

**Documentation updates:**

* Updated all references to the `stop` command to `serve:stop` in both English and French documentation, including command listings and usage examples (`docs/5-Commands.md`, `docs/5-Commands.fr.md`).
* Updated the help text in the `Serve` command to reference `serve:stop` (`src/Command/Serve.php`).

**Test updates:**

* Modified integration tests to use the new `serve:stop` command and updated related assertions (`tests/IntegrationCliTests.php`).