### PR TITLE
feat: add dotenv support and load .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ phpdoc
 .php-cs-fixer.cache
 .phpmd.result-cache.php
 .phpunit.result.cache
-
 # If you run Cecil here
 _site/
 .cache/
 .cecil/
+# Environment variables
+.env

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
     "twig/intl-extra": "^3.26",
     "twig/string-extra": "^3.24",
     "twig/twig": "^3.27",
+    "vlucas/phpdotenv": "^5.6",
     "voku/html-min": "^5.0",
     "wapmorgan/mp3info": "^0.1",
     "yosymfony/toml": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a148e052a8be1a3a55abdea34c3b0fd",
+    "content-hash": "df0a61a889aba205e3ff303310ba02ad",
     "packages": [
         {
             "name": "benjaminhoegh/parsedown-toc",
@@ -329,6 +329,68 @@
                 }
             ],
             "time": "2026-02-16T13:06:37+00:00"
+        },
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-27T19:43:20+00:00"
         },
         {
             "name": "intervention/gif",
@@ -1150,6 +1212,81 @@
                 "source": "https://github.com/performingdigital/twig-components/tree/0.7.0"
             },
             "time": "2025-08-12T21:28:14+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "psr/cache",
@@ -3132,6 +3269,90 @@
             "time": "2026-05-27T06:59:30+00:00"
         },
         {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
             "name": "symfony/polyfill-php83",
             "version": "v1.38.2",
             "source": {
@@ -4872,6 +5093,90 @@
                 }
             ],
             "time": "2026-05-30T17:09:26+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.1.4",
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.5",
+                "symfony/polyfill-ctype": "^1.26",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/polyfill-php80": "^1.26"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "5.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://github.com/vlucas"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-27T19:49:13+00:00"
         },
         {
             "name": "voku/html-min",
@@ -9332,90 +9637,6 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php81",

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -76,7 +76,7 @@ class AbstractCommand extends Command
         $this->io = new SymfonyStyle($input, $output);
         $this->rootPath = (Util\Platform::isPhar() ? Util\Platform::getPharPath() : realpath(Util::joinFile(__DIR__, '/../../'))) . '/';
 
-        // load .env file from working directory if it exists
+        // load .env file from the current path (working dir or provided <path>) if it exists
         Dotenv::createUnsafeImmutable($this->getPath())->safeLoad();
 
         // prepare configuration files list

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -77,7 +77,7 @@ class AbstractCommand extends Command
         $this->rootPath = (Util\Platform::isPhar() ? Util\Platform::getPharPath() : realpath(Util::joinFile(__DIR__, '/../../'))) . '/';
 
         // load .env file from the current path (working dir or provided <path>) if it exists
-        Dotenv::createUnsafeImmutable($this->getPath())->safeLoad();
+        Dotenv::createUnsafeImmutable($this->getPath(false))->safeLoad();
 
         // prepare configuration files list
         if (!\in_array($this->getName(), self::EXCLUDED_CMD)) {

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -18,6 +18,7 @@ use Cecil\Config;
 use Cecil\Exception\RuntimeException;
 use Cecil\Logger\ConsoleLogger;
 use Cecil\Util;
+use Dotenv\Dotenv;
 use Joli\JoliNotif\DefaultNotifier;
 use Joli\JoliNotif\Notification;
 use Symfony\Component\Console\Command\Command;
@@ -74,6 +75,9 @@ class AbstractCommand extends Command
         $this->output = $output;
         $this->io = new SymfonyStyle($input, $output);
         $this->rootPath = (Util\Platform::isPhar() ? Util\Platform::getPharPath() : realpath(Util::joinFile(__DIR__, '/../../'))) . '/';
+
+        // load .env file from working directory if it exists
+        Dotenv::createUnsafeImmutable($this->getPath())->safeLoad();
 
         // prepare configuration files list
         if (!\in_array($this->getName(), self::EXCLUDED_CMD)) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -615,9 +615,10 @@ class Config
      */
     private function setFromEnv(): void
     {
-        foreach (getenv() as $key => $value) {
-            if (str_starts_with($key, 'CECIL_')) {
-                $this->data->set(str_replace(['cecil_', '_'], ['', '.'], strtolower($key)), $this->castSetValue($value));
+        $env = array_merge(getenv() ?: [], $_ENV);
+        foreach ($env as $key => $value) {
+            if (str_starts_with((string) $key, 'CECIL_')) {
+                $this->data->set(str_replace(['cecil_', '_'], ['', '.'], strtolower((string) $key)), $this->castSetValue($value));
             }
         }
     }

--- a/tests/Unit/DotenvTest.php
+++ b/tests/Unit/DotenvTest.php
@@ -40,7 +40,7 @@ class DotenvTest extends TestCase
 
     public function testDotenvLoadsVariablesViaGetenv(): void
     {
-        file_put_contents($this->tmpDir . '/.env', "CECIL_TITLE=\"Hello Dotenv\"\n");
+        file_put_contents($this->tmpDir . DIRECTORY_SEPARATOR . '.env', "CECIL_TITLE=\"Hello Dotenv\"\n");
 
         Dotenv::createUnsafeImmutable($this->tmpDir)->load();
 

--- a/tests/Unit/DotenvTest.php
+++ b/tests/Unit/DotenvTest.php
@@ -31,7 +31,7 @@ class DotenvTest extends TestCase
 
     protected function tearDown(): void
     {
-        $envFile = $this->tmpDir . '/.env';
+        $envFile = $this->tmpDir . DIRECTORY_SEPARATOR . '.env';
         if (file_exists($envFile)) {
             unlink($envFile);
         }

--- a/tests/Unit/DotenvTest.php
+++ b/tests/Unit/DotenvTest.php
@@ -25,7 +25,7 @@ class DotenvTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->tmpDir = sys_get_temp_dir() . '/cecil_dotenv_test_' . uniqid();
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-dotenv-test-' . uniqid('', true);
         mkdir($this->tmpDir);
     }
 

--- a/tests/Unit/DotenvTest.php
+++ b/tests/Unit/DotenvTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit;
+
+use Cecil\Config;
+use Dotenv\Dotenv;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+class DotenvTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cecil_dotenv_test_' . uniqid();
+        mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $envFile = $this->tmpDir . '/.env';
+        if (file_exists($envFile)) {
+            unlink($envFile);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testDotenvLoadsVariablesViaGetenv(): void
+    {
+        file_put_contents($this->tmpDir . '/.env', "CECIL_TITLE=\"Hello Dotenv\"\n");
+
+        Dotenv::createUnsafeImmutable($this->tmpDir)->load();
+
+        self::assertSame('Hello Dotenv', getenv('CECIL_TITLE'));
+    }
+
+    public function testDotenvVariablesAreInjectedIntoConfig(): void
+    {
+        file_put_contents($this->tmpDir . '/.env', "CECIL_TITLE=\"My Dotenv Site\"\nCECIL_BASEURL=https://example.com/\n");
+
+        Dotenv::createUnsafeImmutable($this->tmpDir)->load();
+
+        $config = new Config();
+        $config->import([]);
+
+        self::assertSame('My Dotenv Site', $config->get('title'));
+        self::assertSame('https://example.com/', $config->get('baseurl'));
+    }
+
+    public function testSafeLoadDoesNotThrowWhenEnvFileIsMissing(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        Dotenv::createUnsafeImmutable($this->tmpDir)->safeLoad();
+    }
+}

--- a/tests/Unit/DotenvTest.php
+++ b/tests/Unit/DotenvTest.php
@@ -49,7 +49,7 @@ class DotenvTest extends TestCase
 
     public function testDotenvVariablesAreInjectedIntoConfig(): void
     {
-        file_put_contents($this->tmpDir . '/.env', "CECIL_TITLE=\"My Dotenv Site\"\nCECIL_BASEURL=https://example.com/\n");
+        file_put_contents($this->tmpDir . DIRECTORY_SEPARATOR . '.env', "CECIL_TITLE=\"My Dotenv Site\"\nCECIL_BASEURL=https://example.com/\n");
 
         Dotenv::createUnsafeImmutable($this->tmpDir)->load();
 


### PR DESCRIPTION
This pull request introduces support for loading environment variables from `.env` files using the `vlucas/phpdotenv` library. This allows configuration values to be set via environment variables, making the application more flexible and easier to configure in different environments. The changes ensure that environment variables from `.env` files are loaded at initialization and appropriately injected into the configuration. Additionally, comprehensive unit tests for the dotenv integration have been added.

**Environment variable loading and configuration:**

* Added `vlucas/phpdotenv` as a dependency in `composer.json` to enable loading environment variables from `.env` files.
* Updated `AbstractCommand.php` to load a `.env` file from the current working directory (or provided path) at initialization, ensuring environment variables are available early in the application lifecycle. [[1]](diffhunk://#diff-034f8c9ba320fac2515ff9c2938941d7636d43c912645335d995b1c6254389a5R21) [[2]](diffhunk://#diff-034f8c9ba320fac2515ff9c2938941d7636d43c912645335d995b1c6254389a5R79-R81)
* Improved the environment variable import logic in `Config.php` to merge both `getenv()` and `$_ENV`, ensuring all environment variables are considered and correctly mapped to configuration keys.

**Testing:**

* Added a new unit test `DotenvTest.php` to verify that environment variables are loaded from `.env` files, injected into the configuration, and that missing `.env` files do not cause errors.