### PR TITLE
refactor: use SymfonyStyle titles and success messages

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -146,7 +146,7 @@ EOF
         }
 
         // start build
-        $output->writeln(\sprintf('Building website%s...', $messageOpt));
+        $this->io->title(\sprintf('Build website%s', $messageOpt));
         $progressBar = null;
         /** @var LoggerInterface $originalLogger */
         $originalLogger = $builder->getLogger();

--- a/src/Command/CacheClear.php
+++ b/src/Command/CacheClear.php
@@ -50,18 +50,18 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('Removing cache directory');
         if (!Util\File::getFS()->exists($this->getBuilder()->getConfig()->getCachePath())) {
-            $output->writeln('<info>No cache.</info>');
+            $this->io->success('No cache.');
 
             return Command::SUCCESS;
         }
-        $output->writeln('Removing cache directory...');
         $output->writeln(
             \sprintf('<comment>Path: %s</comment>', $this->getBuilder()->getConfig()->getCachePath()),
             OutputInterface::VERBOSITY_VERBOSE
         );
         Util\File::getFS()->remove($this->getBuilder()->getConfig()->getCachePath());
-        $output->writeln('<info>Cache is clear.</info>');
+        $this->io->success('Cache cleared.');
 
         return Command::SUCCESS;
     }

--- a/src/Command/CacheClearAssets.php
+++ b/src/Command/CacheClearAssets.php
@@ -50,18 +50,18 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('Removing assets cache directory');
         if (!Util\File::getFS()->exists($this->getBuilder()->getConfig()->getCacheAssetsPath())) {
-            $output->writeln('<info>No assets cache.</info>');
+            $this->io->success('No assets cache.');
 
             return Command::SUCCESS;
         }
-        $output->writeln('Removing assets cache directory...');
         $output->writeln(
             \sprintf('<comment>Path: %s</comment>', $this->getBuilder()->getConfig()->getCacheAssetsPath()),
             OutputInterface::VERBOSITY_VERBOSE
         );
         Util\File::getFS()->remove($this->getBuilder()->getConfig()->getCacheAssetsPath());
-        $output->writeln('<info>Assets cache is clear.</info>');
+        $this->io->success('Assets cache cleared.');
 
         return Command::SUCCESS;
     }

--- a/src/Command/CacheClearTemplates.php
+++ b/src/Command/CacheClearTemplates.php
@@ -58,25 +58,25 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('Removing templates cache directory');
         $cacheTemplatesPath = $this->getBuilder()->getConfig()->getCacheTemplatesPath();
         if (!Util\File::getFS()->exists($cacheTemplatesPath)) {
-            $output->writeln('<info>No templates cache.</info>');
+            $this->io->success('No templates cache.');
 
             return Command::SUCCESS;
         }
         if ($input->getOption('fragments')) {
-            $output->writeln('Removing templates fragments cache directory...');
+            $this->io->title('Removing templates fragments cache directory');
             $cacheFragmentsPath = Util::joinFile($cacheTemplatesPath, '_fragments');
             $output->writeln(\sprintf('<comment>Path: %s</comment>', $cacheFragmentsPath), OutputInterface::VERBOSITY_VERBOSE);
             Util\File::getFS()->remove($cacheFragmentsPath);
-            $output->writeln('<info>Templates fragments cache is clear.</info>');
+            $this->io->success('Templates fragments cache cleared.');
 
             return Command::SUCCESS;
         }
-        $output->writeln('Removing templates cache directory...');
         $output->writeln(\sprintf('<comment>Path: %s</comment>', $cacheTemplatesPath), OutputInterface::VERBOSITY_VERBOSE);
         Util\File::getFS()->remove($cacheTemplatesPath);
-        $output->writeln('<info>Templates cache is clear.</info>');
+        $this->io->success('Templates cache cleared.');
 
         return Command::SUCCESS;
     }

--- a/src/Command/CacheClearTemplates.php
+++ b/src/Command/CacheClearTemplates.php
@@ -58,7 +58,6 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->io->title('Removing templates cache directory');
         $cacheTemplatesPath = $this->getBuilder()->getConfig()->getCacheTemplatesPath();
         if (!Util\File::getFS()->exists($cacheTemplatesPath)) {
             $this->io->success('No templates cache.');
@@ -74,6 +73,7 @@ EOF
 
             return Command::SUCCESS;
         }
+        $this->io->title('Removing templates cache directory');
         $output->writeln(\sprintf('<comment>Path: %s</comment>', $cacheTemplatesPath), OutputInterface::VERBOSITY_VERBOSE);
         Util\File::getFS()->remove($cacheTemplatesPath);
         $this->io->success('Templates cache cleared.');

--- a/src/Command/CacheClearTranslations.php
+++ b/src/Command/CacheClearTranslations.php
@@ -50,18 +50,18 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('Removing translations cache directory');
         if (!Util\File::getFS()->exists($this->getBuilder()->getConfig()->getCacheTranslationsPath())) {
-            $output->writeln('<info>No translations cache.</info>');
+            $this->io->success('No translations cache.');
 
             return Command::SUCCESS;
         }
-        $output->writeln('Removing translations cache directory...');
         $output->writeln(
             \sprintf('<comment>Path: %s</comment>', $this->getBuilder()->getConfig()->getCacheTranslationsPath()),
             OutputInterface::VERBOSITY_VERBOSE
         );
         Util\File::getFS()->remove($this->getBuilder()->getConfig()->getCacheTranslationsPath());
-        $output->writeln('<info>Translations cache is clear.</info>');
+        $this->io->success('Translations cache cleared.');
 
         return Command::SUCCESS;
     }

--- a/src/Command/Clear.php
+++ b/src/Command/Clear.php
@@ -51,6 +51,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('Clear generated files');
         $this->removeOutputDir($output);
         $this->removeTmpDir($output);
         // deletes all cache files

--- a/src/Command/Doctor.php
+++ b/src/Command/Doctor.php
@@ -66,6 +66,8 @@ EOF
         $builder = $this->getBuilder();
         $config = $builder->getConfig();
 
+        $this->io->title('Diagnose site configuration');
+
         $table = new Table($output);
         $table
             ->setHeaderTitle('Environment')

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -134,7 +134,7 @@ EOF
         $this->loadConfiguration($config);
 
         if ($this->format !== 'json') {
-            $output->writeln('Building site in dry-run mode for SEO audit...');
+            $this->io->title('Building site in dry-run mode for SEO audit');
         }
         $builder->build([
             'dry-run' => true,

--- a/src/Command/NewPage.php
+++ b/src/Command/NewPage.php
@@ -85,6 +85,7 @@ EOF
         $open = (bool) $input->getOption('open');
         $editor = $input->getOption('editor');
 
+        $this->io->title('Create a new page');
         try {
             // ask
             if (empty($name)) {

--- a/src/Command/NewSite.php
+++ b/src/Command/NewSite.php
@@ -74,6 +74,7 @@ EOF
         $force = $input->getOption('force');
         $demo = $input->getOption('demo');
 
+        $this->io->title('Create a new website');
         try {
             // ask to override existing site?
             if (Util\File::getFS()->exists(Util::joinFile($this->getPath(false), $this->locateConfigFile($this->getPath())['name'] ?: self::CONFIG_FILE[0])) && !$force) {

--- a/src/Command/ShowContent.php
+++ b/src/Command/ShowContent.php
@@ -70,6 +70,8 @@ EOF
         $count = 0;
         $contentTypes = ['pages', 'data'];
 
+        $this->io->title('Show pages and data content');
+
         // formating output
         $unicodeTreePrefix = function (RecursiveTreeIterator $tree) {
             $prefixParts = [

--- a/src/Command/UtilTemplatesExtract.php
+++ b/src/Command/UtilTemplatesExtract.php
@@ -66,6 +66,8 @@ EOF
     {
         $force = $input->getOption('force');
 
+        $this->io->title('Extract built-in templates');
+
         try {
             $phar = new \Phar(Util\Platform::getPharPath());
 

--- a/src/Command/UtilTranslationsExtract.php
+++ b/src/Command/UtilTranslationsExtract.php
@@ -85,6 +85,8 @@ EOF
         $layoutsPath = $config->getLayoutsPath();
         $translationsPath = $config->getTranslationsPath();
 
+        $this->io->title('Extract translations from templates');
+
         $this->initTranslationComponents();
 
         $this->checkOptions($input);


### PR DESCRIPTION
This pull request updates the user interface of several CLI commands to use more consistent and user-friendly output formatting. The main change is the adoption of `$this->io->title()` for section headers and `$this->io->success()` for success messages, replacing various usages of `$output->writeln()`. This improves the clarity and visual structure of command-line feedback across the application.

**Improvements to CLI output formatting:**

* Replaced generic `$output->writeln()` calls for section headers with `$this->io->title()` in commands such as `Build`, `CacheClear`, `CacheClearAssets`, `CacheClearTemplates`, `CacheClearTranslations`, `Clear`, `Doctor`, `DoctorSeo`, `NewPage`, `NewSite`, `ShowContent`, `UtilTemplatesExtract`, and `UtilTranslationsExtract` for clearer, more prominent section titles. [[1]](diffhunk://#diff-7da763cf51b7fe35d72081b1f102ebb75a5c9b1fbf155f00e085715d4aa32c1aL149-R149) [[2]](diffhunk://#diff-fe86670615f20e5582e14e5503f27c4d70212441584b23623e0d99b07eff142bR53-R64) [[3]](diffhunk://#diff-1384ede92993d268a7c464de37d125f333a87a53514c1507d88e49560dbad2d3R53-R64) [[4]](diffhunk://#diff-aa09b0dd4be32e811d0603a7ebcb7a0f64a224808babd30545bc35741cdbaa38R61-R79) [[5]](diffhunk://#diff-35a511365d66d3b2f92e5288494f040a404023bf54013aba1f6860cab1322041R53-R64) [[6]](diffhunk://#diff-deae8de1db4c996f62f774de90401b84bf6024ad8719531698276ec87fee3701R54) [[7]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18R69-R70) [[8]](diffhunk://#diff-c3d09f91373e3ac65e69ff1a9adf4bf4ab4588169948250b5e5e14b7a602831bL137-R137) [[9]](diffhunk://#diff-baa9f80d383a9b1052e3c8ce1bee834d55bc14ffe3804b74810272f8e00f0819R88) [[10]](diffhunk://#diff-0058f377e8066c978766feaa08f70d3f2c109050f2c1f96e8e8474399869d451R77) [[11]](diffhunk://#diff-557246fdefab8a2d40d6048a11c0dd45a62da213359ffa8a4cf024657331c707R73-R74) [[12]](diffhunk://#diff-9bc9065e51074fe5772304ddb4dffd8e839d55600710f3f5edc04d0bfe1e77b9R69-R70) [[13]](diffhunk://#diff-a9ef072e58a9b0a003b08d8e6f069284ef3e2118538f6866e81ea797d1799450R88-R89)
* Updated success and informational messages to use `$this->io->success()` instead of plain info-level output, providing a more visually distinct confirmation of completed actions or no-ops in cache and asset clearing commands. [[1]](diffhunk://#diff-fe86670615f20e5582e14e5503f27c4d70212441584b23623e0d99b07eff142bR53-R64) [[2]](diffhunk://#diff-1384ede92993d268a7c464de37d125f333a87a53514c1507d88e49560dbad2d3R53-R64) [[3]](diffhunk://#diff-aa09b0dd4be32e811d0603a7ebcb7a0f64a224808babd30545bc35741cdbaa38R61-R79) [[4]](diffhunk://#diff-35a511365d66d3b2f92e5288494f040a404023bf54013aba1f6860cab1322041R53-R64)

These changes enhance the overall user experience by making command outputs more readable and standardized.