### PR TITLE
refactor: add clear:output and clear:tmp commands

### DIFF
--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -2,7 +2,7 @@
 title: Commandes
 description: "Liste des commandes disponibles."
 date: 2026-03-27
-updated: 2026-06-12
+updated: 2026-06-13
 slug: commandes
 -->
 # Commandes
@@ -14,6 +14,8 @@ Available commands:
   about                      Shows a short description about Cecil
   build                      Builds the website
   clear                      Removes all generated files
+  clear:output               Removes output directory
+  clear:tmp                  Removes temporary directory
   doctor                     Diagnoses the site configuration
   doctor:seo                 Audits rendered HTML pages for common SEO issues
   edit                       [open] Open pages directory with the editor

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -1,7 +1,7 @@
 <!--
 description: "List of available commands."
 date: 2020-12-19
-updated: 2026-06-12
+updated: 2026-06-13
 -->
 # Commands
 
@@ -12,6 +12,8 @@ Available commands:
   about                      Shows a short description about Cecil
   build                      Builds the website
   clear                      Removes all generated files
+  clear:output               Removes output directory
+  clear:tmp                  Removes temporary directory
   doctor                     Diagnoses the site configuration
   doctor:seo                 Audits rendered HTML pages for common SEO issues
   edit                       [open] Open pages directory with the editor

--- a/src/Application.php
+++ b/src/Application.php
@@ -57,6 +57,8 @@ class Application extends BaseApplication
             new Command\Serve(),
             new Command\Stop(),
             new Command\Clear(),
+            new Command\ClearOutput(),
+            new Command\ClearTmp(),
             new Command\CacheClear(),
             new Command\CacheClearAssets(),
             new Command\CacheClearTemplates(),

--- a/src/Command/ClearOutput.php
+++ b/src/Command/ClearOutput.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Command;
+
+use Cecil\Builder;
+use Cecil\Util;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * ClearOutput command.
+ *
+ * This command removes the output directory.
+ */
+class ClearOutput extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('clear:output')
+            ->setDescription('Removes output directory')
+            ->setDefinition([
+                new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
+            ])
+            ->setHelp(
+                <<<'EOF'
+The <info>%command.name%</> command removes output directory.
+EOF
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->title('Removing output directory');
+        $outputDir = (string) $this->getBuilder()->getConfig()->get('output.dir');
+        // if custom output directory
+        if (Util\File::getFS()->exists(Util::joinFile($this->getPath(), Builder::TMP_DIR, 'output'))) {
+            $outputDir = Util\File::fileGetContents(Util::joinFile($this->getPath(), Builder::TMP_DIR, 'output'));
+        }
+        if ($outputDir === false || !Util\File::getFS()->exists(Util::joinFile($this->getPath(), $outputDir))) {
+            $this->io->success('No output directory.');
+
+            return Command::SUCCESS;
+        }
+        $output->writeln(
+            \sprintf('<comment>Path: %s</comment>', Util::joinFile($this->getPath(), $outputDir)),
+            OutputInterface::VERBOSITY_VERBOSE
+        );
+        Util\File::getFS()->remove(Util::joinFile($this->getPath(), $outputDir));
+        $this->io->success('Output directory removed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/ClearTmp.php
+++ b/src/Command/ClearTmp.php
@@ -13,18 +13,19 @@ declare(strict_types=1);
 
 namespace Cecil\Command;
 
+use Cecil\Builder;
+use Cecil\Util;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Clear command.
+ * ClearTmp command.
  *
- * This command removes all generated files, including the output directory, temporary directory, and cache files.
- * It is useful for cleaning up the build environment before starting a new build or to free up space.
+ * This command removes the temporary directory.
  */
-class Clear extends AbstractCommand
+class ClearTmp extends AbstractCommand
 {
     /**
      * {@inheritdoc}
@@ -32,14 +33,14 @@ class Clear extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setName('clear')
-            ->setDescription('Removes all generated files')
+            ->setName('clear:tmp')
+            ->setDescription('Removes temporary directory')
             ->setDefinition([
                 new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
             ])
             ->setHelp(
                 <<<'EOF'
-The <info>%command.name%</> command removes output directory, temporary directory and cache files.
+The <info>%command.name%</> command removes temporary directory.
 EOF
             );
     }
@@ -49,10 +50,18 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->io->title('Removing generated files');
-        $this->getApplication()->find('clear:output')->run($input, $output);
-        $this->getApplication()->find('clear:tmp')->run($input, $output);
-        $this->getApplication()->find('cache:clear')->run($input, $output);
+        $this->io->title('Removing temporary directory');
+        if (!Util\File::getFS()->exists(Util::joinFile($this->getPath(), Builder::TMP_DIR))) {
+            $this->io->success('No temporary directory.');
+
+            return Command::SUCCESS;
+        }
+        $output->writeln(
+            \sprintf('<comment>Path: %s</comment>', Util::joinFile($this->getPath(), Builder::TMP_DIR)),
+            OutputInterface::VERBOSITY_VERBOSE
+        );
+        Util\File::getFS()->remove(Util::joinFile($this->getPath(), Builder::TMP_DIR));
+        $this->io->success('Temporary directory removed.');
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
Introduce two new commands (clear:output, clear:tmp) to remove output and temporary directories respectively, and register them in the application. Refactor Clear command to delegate to these new commands and to run cache:clear, removing duplicated removal logic and unused imports. Update docs to list the new commands and bump updated dates.