### PR TITLE
refactor: add Doctor services and refactor commands

### DIFF
--- a/docs/8-Library.fr.md
+++ b/docs/8-Library.fr.md
@@ -2,23 +2,20 @@
 title: "Bibliothèque"
 description: "Utilisez Cecil comme bibliothèque PHP."
 date: 2026-03-27
+updated: 2026-06-13
 slug: bibliotheque
 -->
 # Bibliothèque
 
-Vous pouvez utiliser Cecil comme bibliothèque [PHP](https://www.php.net).
+Cecil propose une API PHP simple pour générer votre site web.
+
+Vous pouvez consulter la [documentation de l'API](https://cecil.app/documentation/library/api/namespaces/cecil.html) pour plus de détails.
 
 ## Installation
 
 ```bash
 composer require cecil/cecil
 ```
-
-## API
-
-Cecil propose une API PHP simple pour générer votre site web.
-
-Vous pouvez consulter la [documentation de l'API](https://cecil.app/documentation/library/api/namespaces/cecil.html) pour plus de détails.
 
 ## Utilisation
 
@@ -29,13 +26,13 @@ Construisez un nouveau site web avec une configuration personnalisée :
 ```php
 use Cecil\Builder;
 
-// Create a configuration array
+// Crée un tableau de configuration
 $config = [
     'title'   => "My website",
     'baseurl' => 'https://domain.tld/',
 ];
 
-// Build with the custom configuration
+// Construit avec la configuration personnalisée
 Builder::create($config)->build();
 ```
 
@@ -50,9 +47,38 @@ require_once 'vendor/autoload.php';
 
 use Cecil\Builder;
 
-// Build with the website with the `config.php` configuration file
-Cecil::create(require('config.php'))->build();
+// Construit le site web avec le fichier de configuration `config.php`
+Builder::create(require('config.php'))->build();
 
-// Preview locally
+// Prévisualise localement
 exec('php -S localhost:8000 -t _site');
+```
+
+### Services de domaine Doctor
+
+Vous pouvez aussi exécuter les diagnostics doctor via des services de domaine dédiés, sans utiliser les commandes CLI.
+
+```php
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Cecil\Builder;
+use Cecil\Doctor\SeoDoctor;
+use Cecil\Doctor\SiteDoctor;
+
+$builder = Builder::create(require 'config.php')
+    ->setSourceDir(__DIR__)
+    ->setDestinationDir(__DIR__);
+
+$siteDoctor = new SiteDoctor();
+$diagnosis = $siteDoctor->diagnose($builder, __DIR__, ['cecil.yml']);
+
+$seoDoctor = new SeoDoctor();
+$seoAudit = $seoDoctor->audit($builder, [
+    'page' => '',
+    'include_virtual' => false,
+]);
+
+var_dump($diagnosis['errors'], $seoAudit['summary']);
 ```

--- a/docs/8-Library.md
+++ b/docs/8-Library.md
@@ -1,23 +1,19 @@
 <!--
 description: "Use Cecil as a PHP library."
 date: 2023-12-13
-updated: 2025-06-20
+updated: 2026-06-13
 -->
 # Library
 
-You can use Cecil as a [PHP](https://www.php.net) library.
+Cecil provides a simple PHP API to build your website.
+
+You can read the [API documentation](https://cecil.app/documentation/library/api/namespaces/cecil.html) for more details.
 
 ## Installation
 
 ```bash
 composer require cecil/cecil
 ```
-
-## API
-
-Cecil provides a simple PHP API to build your website.
-
-You can read the [API documentation](https://cecil.app/documentation/library/api/namespaces/cecil.html) for more details.
 
 ## Usage
 
@@ -50,8 +46,37 @@ require_once 'vendor/autoload.php';
 use Cecil\Builder;
 
 // Build with the website with the `config.php` configuration file
-Cecil::create(require('config.php'))->build();
+Builder::create(require('config.php'))->build();
 
 // Preview locally
 exec('php -S localhost:8000 -t _site');
+```
+
+### Doctor services
+
+You can also run doctor checks through dedicated domain services, without using CLI commands.
+
+```php
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Cecil\Builder;
+use Cecil\Doctor\SeoDoctor;
+use Cecil\Doctor\SiteDoctor;
+
+$builder = Builder::create(require 'config.php')
+    ->setSourceDir(__DIR__)
+    ->setDestinationDir(__DIR__);
+
+$siteDoctor = new SiteDoctor();
+$diagnosis = $siteDoctor->diagnose($builder, __DIR__, ['cecil.yml']);
+
+$seoDoctor = new SeoDoctor();
+$seoAudit = $seoDoctor->audit($builder, [
+    'page' => '',
+    'include_virtual' => false,
+]);
+
+var_dump($diagnosis['errors'], $seoAudit['summary']);
 ```

--- a/docs/8-Library.md
+++ b/docs/8-Library.md
@@ -45,7 +45,7 @@ require_once 'vendor/autoload.php';
 
 use Cecil\Builder;
 
-// Build with the website with the `config.php` configuration file
+// Build the website with the `config.php` configuration file
 Builder::create(require('config.php'))->build();
 
 // Preview locally

--- a/src/Command/Doctor.php
+++ b/src/Command/Doctor.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Cecil\Command;
 
-use Cecil\Builder;
-use Cecil\Config;
-use Cecil\Util;
+use Cecil\Doctor\SiteDoctor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -64,7 +62,8 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $builder = $this->getBuilder();
-        $config = $builder->getConfig();
+        $doctor = new SiteDoctor();
+        $diagnosis = $doctor->diagnose($builder, (string) $this->getPath(), $this->getConfigFiles());
 
         $this->io->title('Diagnose site configuration');
 
@@ -72,12 +71,7 @@ EOF
         $table
             ->setHeaderTitle('Environment')
             ->setHeaders(['Item', 'Value'])
-            ->setRows([
-                ['Cecil version', Builder::getVersion()],
-                ['PHP version', PHP_VERSION],
-                ['OS', PHP_OS_FAMILY],
-                ['Working directory', $this->getPath()],
-            ])
+            ->setRows($diagnosis['environment'])
         ;
         $table->setStyle('box')->render();
 
@@ -85,104 +79,31 @@ EOF
         $table
             ->setHeaderTitle('Paths')
             ->setHeaders(['Item', 'Value'])
-            ->setRows([
-                ['Config files', $this->formatConfigFiles()],
-                ['Pages', $config->getPagesPath()],
-                ['Layouts', $config->getLayoutsPath()],
-                ['Assets', $config->getAssetsPath()],
-                ['Static', $config->getStaticPath()],
-                ['Output', $config->getOutputPath()],
-                ['Cache', $this->getCachePathDisplay($config)],
-            ])
+            ->setRows($diagnosis['paths'])
         ;
         $table->setStyle('box')->render();
 
-        $checks = [];
-        $warnings = 0;
-        $errors = 0;
-
-        $baseUrlRaw = trim((string) $config->get('baseurl'));
-        $baseUrlValid = false;
-        if ($baseUrlRaw === '') {
-            $this->addCheck($checks, 'Base URL', false, 'Configured', 'Not set', 'warning', $warnings, $errors);
-        } else {
-            try {
-                $baseUrlNormalized = self::validateUrl($baseUrlRaw);
-                $baseUrlValid = true;
-                $this->addCheck($checks, 'Base URL', true, $baseUrlNormalized, 'Invalid URL', 'error', $warnings, $errors);
-            } catch (\Exception $e) {
-                $this->addCheck($checks, 'Base URL', false, 'Configured', $e->getMessage(), 'error', $warnings, $errors);
-            }
+        $rows = [];
+        foreach ($diagnosis['checks'] as $check) {
+            $rows[] = [
+                $check['item'],
+                $this->formatStatus($check['status']),
+                $check['details'],
+            ];
         }
-
-        $this->addCheck($checks, 'Canonical URL mode', !$config->isEnabled('canonicalurl') || $baseUrlValid, $config->isEnabled('canonicalurl') ? 'Enabled (base URL is valid)' : 'Disabled', 'Enabled but base URL is missing or invalid', 'error', $warnings, $errors);
-
-        $this->addCheck($checks, 'Pages directory', is_dir($config->getPagesPath()), 'Found', 'Missing', 'warning', $warnings, $errors);
-
-        $this->addCheck($checks, 'Data directory', is_dir($config->getDataPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
-        $this->addCheck($checks, 'Assets directory', is_dir($config->getAssetsPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
-        $this->addCheck($checks, 'Static directory', is_dir($config->getStaticPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
-
-        $themeConfigured = false;
-        $themeStatus = true;
-        $themeDetails = 'None configured';
-        try {
-            $themes = $config->getTheme();
-            if ($themes !== null) {
-                $themeConfigured = true;
-                $themeDetails = implode(', ', $themes);
-                $config->hasTheme();
-            }
-        } catch (\Exception $e) {
-            $themeStatus = false;
-            $themeDetails = $e->getMessage();
-        }
-
-        $this->addCheck($checks, 'Layouts directory', is_dir($config->getLayoutsPath()) || ($themeConfigured && $themeStatus), 'Found or provided by a theme', 'Missing and no theme configured', 'error', $warnings, $errors);
-
-        [$outputWritable, $outputDetails] = $this->checkDirectoryWritable($config->getOutputPath());
-        $this->addCheck($checks, 'Output directory', $outputWritable, $outputDetails, $outputDetails, 'error', $warnings, $errors);
-
-        if ($config->isEnabled('cache')) {
-            $cachePath = $this->getCachePathDisplay($config);
-            if ($cachePath === 'Undefined') {
-                $this->addCheck($checks, 'Cache directory', false, 'Configured', 'The cache directory (`cache.dir`) is not defined.', 'error', $warnings, $errors);
-            } else {
-                [$cacheWritable, $cacheDetails] = $this->checkDirectoryWritable($cachePath);
-                $this->addCheck($checks, 'Cache directory', $cacheWritable, $cacheDetails, $cacheDetails, 'error', $warnings, $errors);
-            }
-        } else {
-            $this->addCheck($checks, 'Cache directory', true, 'Not required (cache is disabled)', 'Not required (cache is disabled)', 'warning', $warnings, $errors);
-        }
-
-        $this->addCheck($checks, 'Cache', $config->isEnabled('cache'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
-        $this->addCheck($checks, 'Templates cache', $config->isEnabled('cache.templates'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
-        $this->addCheck($checks, 'Translations cache', $config->isEnabled('cache.translations'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
-
-        $this->addCheck($checks, 'PHP extension: fileinfo', \extension_loaded('fileinfo'), 'Loaded', 'Missing', 'error', $warnings, $errors);
-        $this->addCheck($checks, 'PHP extension: gd', \extension_loaded('gd'), 'Loaded', 'Missing', 'error', $warnings, $errors);
-        $this->addCheck($checks, 'PHP extension: mbstring', \extension_loaded('mbstring'), 'Loaded', 'Missing', 'error', $warnings, $errors);
-
-        [$formatsStatus, $formatsDetails] = $this->checkOutputFormatsMapping($config);
-        $this->addCheck($checks, 'Output formats mapping', $formatsStatus, $formatsDetails, $formatsDetails, 'error', $warnings, $errors);
-
-        [$languagesStatus, $languagesDetails] = $this->checkLanguagesConfiguration($config);
-        $this->addCheck($checks, 'Languages configuration', $languagesStatus, $languagesDetails, $languagesDetails, 'error', $warnings, $errors);
-
-        $this->addCheck($checks, 'Theme(s)', $themeStatus, $themeDetails, $themeDetails, 'error', $warnings, $errors);
 
         $table = new Table($output);
         $table
             ->setHeaderTitle('Checks')
             ->setHeaders(['Item', 'Status', 'Details'])
-            ->setRows($checks)
+            ->setRows($rows)
         ;
         $table->setStyle('box')->render();
 
-        if ($errors > 0) {
-            $this->io->error(\sprintf('%d error(s) found.', $errors));
-        } elseif ($warnings > 0) {
-            $this->io->warning(\sprintf('%d warning(s) found.', $warnings));
+        if ($diagnosis['errors'] > 0) {
+            $this->io->error(\sprintf('%d error(s) found.', $diagnosis['errors']));
+        } elseif ($diagnosis['warnings'] > 0) {
+            $this->io->warning(\sprintf('%d warning(s) found.', $diagnosis['warnings']));
         } else {
             $this->io->success('No problems found.');
         }
@@ -191,156 +112,14 @@ EOF
     }
 
     /**
-     * Adds a health check row.
-     *
-     * @param array<int, array<int, string>> $checks
+     * Formats status from domain diagnostics for console output.
      */
-    private function addCheck(
-        array &$checks,
-        string $label,
-        bool $success,
-        string $successDetails,
-        string $failureDetails,
-        string $failureSeverity,
-        int &$warnings,
-        int &$errors
-    ): void {
-        if ($success) {
-            $checks[] = [$label, '<info>OK</info>', $successDetails];
-
-            return;
-        }
-
-        if ($failureSeverity === 'error') {
-            $errors++;
-            $status = '<error>FAIL</error>';
-        } else {
-            $warnings++;
-            $status = '<comment>WARN</comment>';
-        }
-
-        $checks[] = [$label, $status, $failureDetails];
-    }
-
-    /**
-     * Formats the list of configuration files.
-     */
-    private function formatConfigFiles(): string
+    private function formatStatus(string $status): string
     {
-        $configFiles = $this->getConfigFiles();
-        if (empty($configFiles)) {
-            return 'None';
-        }
-
-        return implode(",\n", $configFiles);
-    }
-
-    /**
-     * Returns the configured cache path without creating directories.
-     */
-    private function getCachePathDisplay(Config $config): string
-    {
-        $cacheDir = (string) $config->get('cache.dir');
-        if ($cacheDir === '') {
-            return 'Undefined';
-        }
-
-        if (Util\File::getFS()->isAbsolutePath($cacheDir)) {
-            return Util::joinFile($cacheDir, 'cecil');
-        }
-
-        return Util::joinFile($config->getDestinationDir(), $cacheDir);
-    }
-
-    /**
-     * Checks if a directory exists or can be created and is writable.
-     *
-     * @return array{0: bool, 1: string}
-     */
-    private function checkDirectoryWritable(string $directory): array
-    {
-        if ($directory === '') {
-            return [false, 'Directory path is empty'];
-        }
-
-        if (file_exists($directory) && !is_dir($directory)) {
-            return [false, 'Path exists and is not a directory'];
-        }
-
-        if (is_dir($directory)) {
-            $writable = is_writable($directory);
-
-            return [$writable, $writable ? 'Writable' : 'Not writable'];
-        }
-
-        $parent = $directory;
-        while (!is_dir($parent)) {
-            $nextParent = \dirname($parent);
-            if ($nextParent === $parent) {
-                return [false, 'Cannot determine parent directory'];
-            }
-            $parent = $nextParent;
-        }
-
-        $parentWritable = is_writable($parent);
-
-        return [$parentWritable, $parentWritable ? 'Creatable (parent writable)' : 'Not creatable (parent not writable)'];
-    }
-
-    /**
-     * Checks that page type formats reference existing output formats.
-     *
-     * @return array{0: bool, 1: string}
-     */
-    private function checkOutputFormatsMapping(Config $config): array
-    {
-        $available = [];
-        foreach ((array) $config->get('output.formats') as $format) {
-            if (\is_array($format) && isset($format['name']) && \is_string($format['name']) && trim($format['name']) !== '') {
-                $available[] = $format['name'];
-            }
-        }
-
-        if (empty($available)) {
-            return [false, 'No output format defined'];
-        }
-
-        $available = array_values(array_unique($available));
-        $missing = [];
-        foreach ((array) $config->get('output.pagetypeformats') as $pageType => $formats) {
-            foreach ((array) $formats as $format) {
-                if (!\in_array($format, $available, true)) {
-                    $missing[] = \sprintf('%s:%s', (string) $pageType, (string) $format);
-                }
-            }
-        }
-
-        if (!empty($missing)) {
-            return [false, \sprintf('Unknown format reference(s): %s', implode(', ', array_unique($missing)))];
-        }
-
-        return [true, \sprintf('%d format(s), mapping is coherent', \count($available))];
-    }
-
-    /**
-     * Checks language configuration consistency.
-     *
-     * @return array{0: bool, 1: string}
-     */
-    private function checkLanguagesConfiguration(Config $config): array
-    {
-        try {
-            $default = $config->getLanguageDefault();
-            $languages = $config->getLanguages();
-            $codes = array_column($languages, 'code');
-
-            if (\count($codes) !== \count(array_unique($codes))) {
-                return [false, 'Duplicate language codes found'];
-            }
-
-            return [true, \sprintf('%d language(s), default: %s', \count($languages), $default)];
-        } catch (\Exception $e) {
-            return [false, $e->getMessage()];
-        }
+        return match ($status) {
+            'error' => '<error>FAIL</error>',
+            'warning' => '<comment>WARN</comment>',
+            default => '<info>OK</info>',
+        };
     }
 }

--- a/src/Command/DoctorSeo.php
+++ b/src/Command/DoctorSeo.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Cecil\Command;
 
-use Cecil\Builder;
-use Cecil\Collection\Page\Page;
-use Cecil\Renderer\Page as PageRenderer;
+use Cecil\Doctor\SeoDoctor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,25 +30,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DoctorSeo extends AbstractCommand
 {
-    /** Default configuration thresholds */
-    private const DEFAULT_CONFIG = [
-        'title' => ['min' => 30, 'max' => 60 ],
-        'description' => ['min' => 120, 'max' => 160 ],
-        'content' => ['min_words' => 300 ],
-        'checks' => [
-            'title' => true,
-            'description' => true,
-            'canonical' => true,
-            'h1' => true,
-            'og_tags' => true,
-            'img_alt' => true,
-            'content_length' => true,
-            'lang_attribute' => true,
-        ],
-    ];
-
-    private array $thresholds = [];
-    private array $checks = [];
     private bool $includeVirtual = false;
     private string $format = 'text';
 
@@ -128,135 +107,52 @@ EOF
         }
 
         $builder = $this->getBuilder();
-        $config = $builder->getConfig();
-
-        // Load thresholds from configuration
-        $this->loadConfiguration($config);
+        $doctor = new SeoDoctor();
 
         if ($this->format !== 'json') {
             $this->io->title('Building site in dry-run mode for SEO audit');
         }
-        $builder->build([
-            'dry-run' => true,
+        $result = $doctor->audit($builder, [
             'page' => (string) ($input->getOption('page') ?? ''),
-            'render-subset' => '',
-            'drafts' => false,
+            'include_virtual' => $this->includeVirtual,
         ]);
-
-        // Filter pages: only published and rendered, exclude virtual by default
-        $pages = $builder->getPages()->filter(function (Page $page) {
-            if ($page->getVariable('published') !== true) {
-                return false;
-            }
-            if (!isset($page->getRendered()['html']['output'])) {
-                return false;
-            }
-            // Exclude virtual pages (paginated, taxonomies) unless --include-virtual
-            if (!$this->includeVirtual && $page->isVirtual()) {
-                return false;
-            }
-            return true;
-        });
-
-        $findings = [];
-        $counts = [
-            'bad' => 0,
-            'ok' => 0,
-            'feedback' => 0,
-        ];
-        $healthyPages = 0;
-
-        /** @var Page $page */
-        foreach ($pages as $page) {
-            $pageFindings = $this->auditPage($builder, $page);
-            if (empty($pageFindings)) {
-                $healthyPages++;
-
-                continue;
-            }
-
-            foreach ($pageFindings as $finding) {
-                $counts[$finding['level']]++;
-                $findings[] = [
-                    'page' => $this->getPageLabel($builder, $page),
-                    'level' => $finding['level'],
-                    'check' => $finding['check'],
-                    'details' => $finding['details'],
-                ];
-            }
-        }
 
         // Output results based on format
         if ($this->format === 'json') {
-            $this->outputJson($output, $pages, $findings, $counts, $healthyPages);
+            $this->outputJson($output, $result);
         } else {
-            $this->outputText($output, $findings, $counts, $healthyPages);
+            $this->outputText($output, $result);
         }
 
         return Command::SUCCESS;
     }
 
     /**
-     * Load audit configuration from Cecil config.
-     */
-    private function loadConfiguration(\Cecil\Config $config): void
-    {
-        $seoConfig = (array) $config->get('doctor.seo') ?? [];
-
-        // Merge with defaults
-        $this->thresholds = [
-            'title_min' => $seoConfig['title']['min'] ?? self::DEFAULT_CONFIG['title']['min'],
-            'title_max' => $seoConfig['title']['max'] ?? self::DEFAULT_CONFIG['title']['max'],
-            'description_min' => $seoConfig['description']['min'] ?? self::DEFAULT_CONFIG['description']['min'],
-            'description_max' => $seoConfig['description']['max'] ?? self::DEFAULT_CONFIG['description']['max'],
-            'min_word_count' => $seoConfig['content']['min_words'] ?? self::DEFAULT_CONFIG['content']['min_words'],
-        ];
-
-        $this->checks = array_merge(
-            self::DEFAULT_CONFIG['checks'],
-            (array) ($seoConfig['checks'] ?? [])
-        );
-    }
-
-    /**
      * Output results in JSON format.
      */
-    private function outputJson(OutputInterface $output, \Cecil\Collection\Page\Collection $pages, array $findings, array $counts, int $healthyPages): void
+    private function outputJson(OutputInterface $output, array $result): void
     {
-        $result = [
-            'summary' => [
-                'pages_audited' => \count($pages),
-                'pages_without_findings' => $healthyPages,
-                'bad_count' => $counts['bad'],
-                'ok_count' => $counts['ok'],
-                'feedback_count' => $counts['feedback'],
-            ],
-            'findings' => $findings,
-        ];
-
-        $output->writeln(json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $output->writeln(\json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 
     /**
      * Output results in text format (tables).
      */
-    private function outputText(OutputInterface $output, array $findings, array $counts, int $healthyPages): void
+    private function outputText(OutputInterface $output, array $result): void
     {
-        $pagesWithFindings = [];
-        foreach ($findings as $finding) {
-            $pagesWithFindings[$finding['page']] = true;
-        }
+        $summaryData = $result['summary'];
+        $findings = $result['findings'];
 
         $summary = new Table($output);
         $summary
             ->setHeaderTitle('SEO audit summary')
             ->setHeaders(['Metric', 'Value'])
             ->setRows([
-                ['Pages audited', (string) ($healthyPages + \count($pagesWithFindings))],
-                ['Pages without findings', (string) $healthyPages],
-                ['Bad', (string) $counts['bad']],
-                ['OK', (string) $counts['ok']],
-                ['Feedback', (string) $counts['feedback']],
+                ['Pages audited', (string) $summaryData['pages_audited']],
+                ['Pages without findings', (string) $summaryData['pages_without_findings']],
+                ['Bad', (string) $summaryData['bad_count']],
+                ['OK', (string) $summaryData['ok_count']],
+                ['Feedback', (string) $summaryData['feedback_count']],
             ])
         ;
         $summary->setStyle('box')->render();
@@ -281,155 +177,19 @@ EOF
             $table->setStyle('box')->render();
         }
 
-        if ($counts['bad'] > 0) {
-            $this->io->error(\sprintf('SEO audit found %d bad issue(s).', $counts['bad']));
+        if ($summaryData['bad_count'] > 0) {
+            $this->io->error(\sprintf('SEO audit found %d bad issue(s).', $summaryData['bad_count']));
 
             return;
         }
 
-        if ($counts['ok'] > 0 || $counts['feedback'] > 0) {
-            $this->io->warning(\sprintf('SEO audit found %d improvement(s).', $counts['ok'] + $counts['feedback']));
+        if ($summaryData['ok_count'] > 0 || $summaryData['feedback_count'] > 0) {
+            $this->io->warning(\sprintf('SEO audit found %d improvement(s).', $summaryData['ok_count'] + $summaryData['feedback_count']));
 
             return;
         }
 
         $this->io->success('No SEO issues found.');
-    }
-
-    /**
-     * @return array<int, array{level: string, check: string, details: string}>
-     */
-    private function auditPage(Builder $builder, Page $page): array
-    {
-        $html = (string) $page->getRendered()['html']['output'];
-        $xpath = $this->createXPath($html);
-        if ($xpath === null) {
-            return [[
-                'level' => 'bad',
-                'check' => 'Rendered HTML',
-                'details' => 'The page could not be parsed as HTML.',
-            ]];
-        }
-
-        $findings = [];
-
-        // Check: Title tag
-        if ($this->checks['title']) {
-            $title = $this->getFirstNodeText($xpath, '//title');
-            if ($title === '') {
-                $findings[] = $this->createFinding('bad', 'Title tag', 'Missing <title> element.');
-            } else {
-                $titleLength = mb_strlen($title);
-                if ($titleLength < $this->thresholds['title_min'] || $titleLength > $this->thresholds['title_max']) {
-                    $findings[] = $this->createFinding(
-                        'ok',
-                        'Title length',
-                        \sprintf('Current length: %d characters. Recommended range: %d-%d.', $titleLength, $this->thresholds['title_min'], $this->thresholds['title_max'])
-                    );
-                }
-            }
-        }
-
-        // Check: Meta description
-        if ($this->checks['description']) {
-            $description = $this->getFirstNodeText($xpath, "//meta[translate(@name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = 'description']/@content");
-            if ($description === '') {
-                $findings[] = $this->createFinding('bad', 'Meta description', 'Missing meta description.');
-            } else {
-                $descriptionLength = mb_strlen($description);
-                if ($descriptionLength < $this->thresholds['description_min'] || $descriptionLength > $this->thresholds['description_max']) {
-                    $findings[] = $this->createFinding(
-                        'ok',
-                        'Meta description length',
-                        \sprintf('Current length: %d characters. Recommended range: %d-%d.', $descriptionLength, $this->thresholds['description_min'], $this->thresholds['description_max'])
-                    );
-                }
-            }
-        }
-
-        // Check: Canonical URL
-        if ($this->checks['canonical']) {
-            $canonical = $this->getFirstNodeText($xpath, "//link[contains(concat(' ', translate(normalize-space(@rel), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), ' '), ' canonical ')]/@href");
-            if ($canonical === '') {
-                $level = $builder->getConfig()->isEnabled('canonicalurl') ? 'bad' : 'feedback';
-                $details = $builder->getConfig()->isEnabled('canonicalurl')
-                    ? 'Missing canonical link while canonical URLs are enabled.'
-                    : 'No canonical link found in the rendered page.';
-                $findings[] = $this->createFinding($level, 'Canonical URL', $details);
-            }
-        }
-
-        // Check: Lang attribute
-        if ($this->checks['lang_attribute']) {
-            $lang = $this->getFirstNodeText($xpath, '/html/@lang');
-            if ($lang === '') {
-                $findings[] = $this->createFinding('feedback', 'HTML lang attribute', 'Missing lang attribute on the <html> element.');
-            }
-        }
-
-        // Check: H1 heading structure
-        if ($this->checks['h1']) {
-            $h1Count = $this->countNodes($xpath, '//h1');
-            if ($h1Count === 0) {
-                $findings[] = $this->createFinding('bad', 'Heading structure', 'Missing <h1> element.');
-            }
-            if ($h1Count > 1) {
-                $findings[] = $this->createFinding('ok', 'Heading structure', \sprintf('Found %d <h1> elements.', $h1Count));
-            }
-        }
-
-        // Check: Open Graph tags
-        if ($this->checks['og_tags']) {
-            if ($this->getFirstNodeText($xpath, "//meta[@property='og:title']/@content") === '') {
-                $findings[] = $this->createFinding('feedback', 'Open Graph title', 'Missing og:title meta tag.');
-            }
-            if ($this->getFirstNodeText($xpath, "//meta[@property='og:description']/@content") === '') {
-                $findings[] = $this->createFinding('feedback', 'Open Graph description', 'Missing og:description meta tag.');
-            }
-            if ($this->getFirstNodeText($xpath, "//meta[@property='og:image']/@content") === '') {
-                $findings[] = $this->createFinding('feedback', 'Open Graph image', 'Missing og:image meta tag.');
-            }
-        }
-
-        // Check: Image alt attributes
-        if ($this->checks['img_alt']) {
-            $missingAltImages = $this->countNodes($xpath, "//img[not(@alt) or normalize-space(@alt) = '']");
-            if ($missingAltImages > 0) {
-                $findings[] = $this->createFinding('ok', 'Images alt text', \sprintf('%d image(s) are missing an alt attribute.', $missingAltImages));
-            }
-        }
-
-        // Check: Content length
-        if ($this->checks['content_length']) {
-            $wordCount = $this->countWords($this->getBodyText($xpath, $html));
-            if ($wordCount < $this->thresholds['min_word_count']) {
-                $findings[] = $this->createFinding('feedback', 'Content length', \sprintf('Estimated body length: %d words.', $wordCount));
-            }
-        }
-
-        return $findings;
-    }
-
-    /**
-     * @return array{level: string, check: string, details: string}
-     */
-    private function createFinding(string $level, string $check, string $details): array
-    {
-        return [
-            'level' => $level,
-            'check' => $check,
-            'details' => $details,
-        ];
-    }
-
-    private function getPageLabel(Builder $builder, Page $page): string
-    {
-        $path = (new PageRenderer($builder, $page))->getPath('html');
-        if ($path === '') {
-            return '/';
-        }
-
-        return '/' . ltrim($path, '/');
     }
 
     private function formatLevel(string $level): string
@@ -439,72 +199,5 @@ EOF
             'ok' => '<comment>OK</comment>',
             default => '<info>Feedback</info>',
         };
-    }
-
-    private function createXPath(string $html): ?\DOMXPath
-    {
-        if (trim($html) === '') {
-            return null;
-        }
-
-        $useInternalErrors = libxml_use_internal_errors(true);
-        $document = new \DOMDocument('1.0', 'UTF-8');
-        $loaded = $document->loadHTML('<?xml encoding="UTF-8">' . $html, LIBXML_NOERROR | LIBXML_NOWARNING | LIBXML_NONET);
-        libxml_clear_errors();
-        libxml_use_internal_errors($useInternalErrors);
-        if ($loaded === false) {
-            return null;
-        }
-
-        return new \DOMXPath($document);
-    }
-
-    private function getFirstNodeText(\DOMXPath $xpath, string $query): string
-    {
-        $nodes = $xpath->query($query);
-        if ($nodes === false || $nodes->length === 0) {
-            return '';
-        }
-
-        return $this->normalizeText((string) $nodes->item(0)?->textContent);
-    }
-
-    private function countNodes(\DOMXPath $xpath, string $query): int
-    {
-        $nodes = $xpath->query($query);
-        if ($nodes === false) {
-            return 0;
-        }
-
-        return $nodes->length;
-    }
-
-    private function getBodyText(\DOMXPath $xpath, string $html): string
-    {
-        $body = $this->getFirstNodeText($xpath, '//body');
-        if ($body !== '') {
-            return $body;
-        }
-
-        return $this->normalizeText((string) strip_tags($html));
-    }
-
-    private function countWords(string $text): int
-    {
-        if ($text === '') {
-            return 0;
-        }
-
-        preg_match_all("/[\\p{L}\\p{N}']+/u", $text, $matches);
-
-        return \count($matches[0]);
-    }
-
-    private function normalizeText(string $text): string
-    {
-        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        $text = preg_replace('/\s+/u', ' ', $text);
-
-        return trim((string) $text);
     }
 }

--- a/src/Doctor/SeoDoctor.php
+++ b/src/Doctor/SeoDoctor.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Doctor;
+
+use Cecil\Builder;
+use Cecil\Collection\Page\Page;
+use Cecil\Renderer\Page as PageRenderer;
+
+/**
+ * SEO audit domain service.
+ */
+class SeoDoctor
+{
+    /** Default configuration thresholds */
+    private const DEFAULT_CONFIG = [
+        'title' => ['min' => 30, 'max' => 60],
+        'description' => ['min' => 120, 'max' => 160],
+        'content' => ['min_words' => 300],
+        'checks' => [
+            'title' => true,
+            'description' => true,
+            'canonical' => true,
+            'h1' => true,
+            'og_tags' => true,
+            'img_alt' => true,
+            'content_length' => true,
+            'lang_attribute' => true,
+        ],
+    ];
+
+    /**
+     * @param array{page?: string, include_virtual?: bool} $options
+     *
+     * @return array{
+     *   summary: array{
+     *     pages_audited: int,
+     *     pages_without_findings: int,
+     *     bad_count: int,
+     *     ok_count: int,
+     *     feedback_count: int
+     *   },
+     *   findings: array<int, array{page: string, level: string, check: string, details: string}>
+     * }
+     */
+    public function audit(Builder $builder, array $options = []): array
+    {
+        $includeVirtual = (bool) ($options['include_virtual'] ?? false);
+        $page = (string) ($options['page'] ?? '');
+
+        [$thresholds, $checks] = $this->loadConfiguration($builder);
+
+        $builder->build([
+            'dry-run' => true,
+            'page' => $page,
+            'render-subset' => '',
+            'drafts' => false,
+        ]);
+
+        $pages = $builder->getPages()->filter(function (Page $currentPage) use ($includeVirtual) {
+            if ($currentPage->getVariable('published') !== true) {
+                return false;
+            }
+            if (!isset($currentPage->getRendered()['html']['output'])) {
+                return false;
+            }
+            if (!$includeVirtual && $currentPage->isVirtual()) {
+                return false;
+            }
+
+            return true;
+        });
+
+        $findings = [];
+        $counts = [
+            'bad' => 0,
+            'ok' => 0,
+            'feedback' => 0,
+        ];
+        $healthyPages = 0;
+
+        /** @var Page $currentPage */
+        foreach ($pages as $currentPage) {
+            $pageFindings = $this->auditPage($builder, $currentPage, $thresholds, $checks);
+            if (empty($pageFindings)) {
+                $healthyPages++;
+
+                continue;
+            }
+
+            foreach ($pageFindings as $finding) {
+                $counts[$finding['level']]++;
+                $findings[] = [
+                    'page' => $this->getPageLabel($builder, $currentPage),
+                    'level' => $finding['level'],
+                    'check' => $finding['check'],
+                    'details' => $finding['details'],
+                ];
+            }
+        }
+
+        return [
+            'summary' => [
+                'pages_audited' => \count($pages),
+                'pages_without_findings' => $healthyPages,
+                'bad_count' => $counts['bad'],
+                'ok_count' => $counts['ok'],
+                'feedback_count' => $counts['feedback'],
+            ],
+            'findings' => $findings,
+        ];
+    }
+
+    /**
+     * @return array{0: array{title_min: int, title_max: int, description_min: int, description_max: int, min_word_count: int}, 1: array<string, bool>}
+     */
+    private function loadConfiguration(Builder $builder): array
+    {
+        $seoConfig = (array) ($builder->getConfig()->get('doctor.seo') ?? []);
+
+        $thresholds = [
+            'title_min' => (int) ($seoConfig['title']['min'] ?? self::DEFAULT_CONFIG['title']['min']),
+            'title_max' => (int) ($seoConfig['title']['max'] ?? self::DEFAULT_CONFIG['title']['max']),
+            'description_min' => (int) ($seoConfig['description']['min'] ?? self::DEFAULT_CONFIG['description']['min']),
+            'description_max' => (int) ($seoConfig['description']['max'] ?? self::DEFAULT_CONFIG['description']['max']),
+            'min_word_count' => (int) ($seoConfig['content']['min_words'] ?? self::DEFAULT_CONFIG['content']['min_words']),
+        ];
+
+        $checks = \array_merge(
+            self::DEFAULT_CONFIG['checks'],
+            (array) ($seoConfig['checks'] ?? [])
+        );
+
+        return [$thresholds, $checks];
+    }
+
+    /**
+     * @param array{title_min: int, title_max: int, description_min: int, description_max: int, min_word_count: int} $thresholds
+     * @param array<string, bool> $checks
+     *
+     * @return array<int, array{level: string, check: string, details: string}>
+     */
+    private function auditPage(Builder $builder, Page $page, array $thresholds, array $checks): array
+    {
+        $html = (string) $page->getRendered()['html']['output'];
+        $xpath = $this->createXPath($html);
+        if ($xpath === null) {
+            return [[
+                'level' => 'bad',
+                'check' => 'Rendered HTML',
+                'details' => 'The page could not be parsed as HTML.',
+            ]];
+        }
+
+        $findings = [];
+
+        if (($checks['title'] ?? false) === true) {
+            $title = $this->getFirstNodeText($xpath, '//title');
+            if ($title === '') {
+                $findings[] = $this->createFinding('bad', 'Title tag', 'Missing <title> element.');
+            } else {
+                $titleLength = \mb_strlen($title);
+                if ($titleLength < $thresholds['title_min'] || $titleLength > $thresholds['title_max']) {
+                    $findings[] = $this->createFinding(
+                        'ok',
+                        'Title length',
+                        \sprintf('Current length: %d characters. Recommended range: %d-%d.', $titleLength, $thresholds['title_min'], $thresholds['title_max'])
+                    );
+                }
+            }
+        }
+
+        if (($checks['description'] ?? false) === true) {
+            $description = $this->getFirstNodeText($xpath, "//meta[translate(@name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = 'description']/@content");
+            if ($description === '') {
+                $findings[] = $this->createFinding('bad', 'Meta description', 'Missing meta description.');
+            } else {
+                $descriptionLength = \mb_strlen($description);
+                if ($descriptionLength < $thresholds['description_min'] || $descriptionLength > $thresholds['description_max']) {
+                    $findings[] = $this->createFinding(
+                        'ok',
+                        'Meta description length',
+                        \sprintf('Current length: %d characters. Recommended range: %d-%d.', $descriptionLength, $thresholds['description_min'], $thresholds['description_max'])
+                    );
+                }
+            }
+        }
+
+        if (($checks['canonical'] ?? false) === true) {
+            $canonical = $this->getFirstNodeText($xpath, "//link[contains(concat(' ', translate(normalize-space(@rel), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), ' '), ' canonical ')]/@href");
+            if ($canonical === '') {
+                $level = $builder->getConfig()->isEnabled('canonicalurl') ? 'bad' : 'feedback';
+                $details = $builder->getConfig()->isEnabled('canonicalurl')
+                    ? 'Missing canonical link while canonical URLs are enabled.'
+                    : 'No canonical link found in the rendered page.';
+                $findings[] = $this->createFinding($level, 'Canonical URL', $details);
+            }
+        }
+
+        if (($checks['lang_attribute'] ?? false) === true) {
+            $lang = $this->getFirstNodeText($xpath, '/html/@lang');
+            if ($lang === '') {
+                $findings[] = $this->createFinding('feedback', 'HTML lang attribute', 'Missing lang attribute on the <html> element.');
+            }
+        }
+
+        if (($checks['h1'] ?? false) === true) {
+            $h1Count = $this->countNodes($xpath, '//h1');
+            if ($h1Count === 0) {
+                $findings[] = $this->createFinding('bad', 'Heading structure', 'Missing <h1> element.');
+            }
+            if ($h1Count > 1) {
+                $findings[] = $this->createFinding('ok', 'Heading structure', \sprintf('Found %d <h1> elements.', $h1Count));
+            }
+        }
+
+        if (($checks['og_tags'] ?? false) === true) {
+            if ($this->getFirstNodeText($xpath, "//meta[@property='og:title']/@content") === '') {
+                $findings[] = $this->createFinding('feedback', 'Open Graph title', 'Missing og:title meta tag.');
+            }
+            if ($this->getFirstNodeText($xpath, "//meta[@property='og:description']/@content") === '') {
+                $findings[] = $this->createFinding('feedback', 'Open Graph description', 'Missing og:description meta tag.');
+            }
+            if ($this->getFirstNodeText($xpath, "//meta[@property='og:image']/@content") === '') {
+                $findings[] = $this->createFinding('feedback', 'Open Graph image', 'Missing og:image meta tag.');
+            }
+        }
+
+        if (($checks['img_alt'] ?? false) === true) {
+            $missingAltImages = $this->countNodes($xpath, "//img[not(@alt) or normalize-space(@alt) = '']");
+            if ($missingAltImages > 0) {
+                $findings[] = $this->createFinding('ok', 'Images alt text', \sprintf('%d image(s) are missing an alt attribute.', $missingAltImages));
+            }
+        }
+
+        if (($checks['content_length'] ?? false) === true) {
+            $wordCount = $this->countWords($this->getBodyText($xpath, $html));
+            if ($wordCount < $thresholds['min_word_count']) {
+                $findings[] = $this->createFinding('feedback', 'Content length', \sprintf('Estimated body length: %d words.', $wordCount));
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return array{level: string, check: string, details: string}
+     */
+    private function createFinding(string $level, string $check, string $details): array
+    {
+        return [
+            'level' => $level,
+            'check' => $check,
+            'details' => $details,
+        ];
+    }
+
+    private function getPageLabel(Builder $builder, Page $page): string
+    {
+        $path = (new PageRenderer($builder, $page))->getPath('html');
+        if ($path === '') {
+            return '/';
+        }
+
+        return '/' . \ltrim($path, '/');
+    }
+
+    private function createXPath(string $html): ?\DOMXPath
+    {
+        if (\trim($html) === '') {
+            return null;
+        }
+
+        $useInternalErrors = \libxml_use_internal_errors(true);
+        $document = new \DOMDocument('1.0', 'UTF-8');
+        $loaded = $document->loadHTML('<?xml encoding="UTF-8">' . $html, LIBXML_NOERROR | LIBXML_NOWARNING | LIBXML_NONET);
+        \libxml_clear_errors();
+        \libxml_use_internal_errors($useInternalErrors);
+        if ($loaded === false) {
+            return null;
+        }
+
+        return new \DOMXPath($document);
+    }
+
+    private function getFirstNodeText(\DOMXPath $xpath, string $query): string
+    {
+        $nodes = $xpath->query($query);
+        if ($nodes === false || $nodes->length === 0) {
+            return '';
+        }
+
+        return $this->normalizeText((string) $nodes->item(0)?->textContent);
+    }
+
+    private function countNodes(\DOMXPath $xpath, string $query): int
+    {
+        $nodes = $xpath->query($query);
+        if ($nodes === false) {
+            return 0;
+        }
+
+        return $nodes->length;
+    }
+
+    private function getBodyText(\DOMXPath $xpath, string $html): string
+    {
+        $body = $this->getFirstNodeText($xpath, '//body');
+        if ($body !== '') {
+            return $body;
+        }
+
+        return $this->normalizeText((string) \strip_tags($html));
+    }
+
+    private function countWords(string $text): int
+    {
+        if ($text === '') {
+            return 0;
+        }
+
+        \preg_match_all("/[\\p{L}\\p{N}']+/u", $text, $matches);
+
+        return \count($matches[0]);
+    }
+
+    private function normalizeText(string $text): string
+    {
+        $text = \html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = \preg_replace('/\s+/u', ' ', $text);
+
+        return \trim((string) $text);
+    }
+}

--- a/src/Doctor/SiteDoctor.php
+++ b/src/Doctor/SiteDoctor.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Doctor;
+
+use Cecil\Builder;
+use Cecil\Config;
+use Cecil\Util;
+use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * Site diagnosis domain service.
+ */
+class SiteDoctor
+{
+    /**
+     * @param array<int, string> $configFiles
+     *
+     * @return array{
+     *   environment: array<int, array{0: string, 1: string}>,
+     *   paths: array<int, array{0: string, 1: string}>,
+     *   checks: array<int, array{item: string, status: string, details: string}>,
+     *   warnings: int,
+     *   errors: int
+     * }
+     */
+    public function diagnose(Builder $builder, string $workingDirectory, array $configFiles): array
+    {
+        $config = $builder->getConfig();
+
+        $checks = [];
+        $warnings = 0;
+        $errors = 0;
+
+        $baseUrlRaw = \trim((string) $config->get('baseurl'));
+        $baseUrlValid = false;
+        if ($baseUrlRaw === '') {
+            $this->addCheck($checks, 'Base URL', false, 'Configured', 'Not set', 'warning', $warnings, $errors);
+        } else {
+            try {
+                $baseUrlNormalized = $this->validateUrl($baseUrlRaw);
+                $baseUrlValid = true;
+                $this->addCheck($checks, 'Base URL', true, $baseUrlNormalized, 'Invalid URL', 'error', $warnings, $errors);
+            } catch (\Exception $e) {
+                $this->addCheck($checks, 'Base URL', false, 'Configured', $e->getMessage(), 'error', $warnings, $errors);
+            }
+        }
+
+        $this->addCheck($checks, 'Canonical URL mode', !$config->isEnabled('canonicalurl') || $baseUrlValid, $config->isEnabled('canonicalurl') ? 'Enabled (base URL is valid)' : 'Disabled', 'Enabled but base URL is missing or invalid', 'error', $warnings, $errors);
+
+        $this->addCheck($checks, 'Pages directory', \is_dir($config->getPagesPath()), 'Found', 'Missing', 'warning', $warnings, $errors);
+        $this->addCheck($checks, 'Data directory', \is_dir($config->getDataPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
+        $this->addCheck($checks, 'Assets directory', \is_dir($config->getAssetsPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
+        $this->addCheck($checks, 'Static directory', \is_dir($config->getStaticPath()), 'Found', 'Missing (optional)', 'warning', $warnings, $errors);
+
+        $themeConfigured = false;
+        $themeStatus = true;
+        $themeDetails = 'None configured';
+        try {
+            $themes = $config->getTheme();
+            if ($themes !== null) {
+                $themeConfigured = true;
+                $themeDetails = \implode(', ', $themes);
+                $config->hasTheme();
+            }
+        } catch (\Exception $e) {
+            $themeStatus = false;
+            $themeDetails = $e->getMessage();
+        }
+
+        $this->addCheck($checks, 'Layouts directory', \is_dir($config->getLayoutsPath()) || ($themeConfigured && $themeStatus), 'Found or provided by a theme', 'Missing and no theme configured', 'error', $warnings, $errors);
+
+        [$outputWritable, $outputDetails] = $this->checkDirectoryWritable($config->getOutputPath());
+        $this->addCheck($checks, 'Output directory', $outputWritable, $outputDetails, $outputDetails, 'error', $warnings, $errors);
+
+        if ($config->isEnabled('cache')) {
+            $cachePath = $this->getCachePathDisplay($config);
+            if ($cachePath === 'Undefined') {
+                $this->addCheck($checks, 'Cache directory', false, 'Configured', 'The cache directory (`cache.dir`) is not defined.', 'error', $warnings, $errors);
+            } else {
+                [$cacheWritable, $cacheDetails] = $this->checkDirectoryWritable($cachePath);
+                $this->addCheck($checks, 'Cache directory', $cacheWritable, $cacheDetails, $cacheDetails, 'error', $warnings, $errors);
+            }
+        } else {
+            $this->addCheck($checks, 'Cache directory', true, 'Not required (cache is disabled)', 'Not required (cache is disabled)', 'warning', $warnings, $errors);
+        }
+
+        $this->addCheck($checks, 'Cache', $config->isEnabled('cache'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
+        $this->addCheck($checks, 'Templates cache', $config->isEnabled('cache.templates'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
+        $this->addCheck($checks, 'Translations cache', $config->isEnabled('cache.translations'), 'Enabled', 'Disabled', 'warning', $warnings, $errors);
+
+        $this->addCheck($checks, 'PHP extension: fileinfo', \extension_loaded('fileinfo'), 'Loaded', 'Missing', 'error', $warnings, $errors);
+        $this->addCheck($checks, 'PHP extension: gd', \extension_loaded('gd'), 'Loaded', 'Missing', 'error', $warnings, $errors);
+        $this->addCheck($checks, 'PHP extension: mbstring', \extension_loaded('mbstring'), 'Loaded', 'Missing', 'error', $warnings, $errors);
+
+        [$formatsStatus, $formatsDetails] = $this->checkOutputFormatsMapping($config);
+        $this->addCheck($checks, 'Output formats mapping', $formatsStatus, $formatsDetails, $formatsDetails, 'error', $warnings, $errors);
+
+        [$languagesStatus, $languagesDetails] = $this->checkLanguagesConfiguration($config);
+        $this->addCheck($checks, 'Languages configuration', $languagesStatus, $languagesDetails, $languagesDetails, 'error', $warnings, $errors);
+
+        $this->addCheck($checks, 'Theme(s)', $themeStatus, $themeDetails, $themeDetails, 'error', $warnings, $errors);
+
+        return [
+            'environment' => [
+                ['Cecil version', Builder::getVersion()],
+                ['PHP version', PHP_VERSION],
+                ['OS', PHP_OS_FAMILY],
+                ['Working directory', $workingDirectory],
+            ],
+            'paths' => [
+                ['Config files', $this->formatConfigFiles($configFiles)],
+                ['Pages', $config->getPagesPath()],
+                ['Layouts', $config->getLayoutsPath()],
+                ['Assets', $config->getAssetsPath()],
+                ['Static', $config->getStaticPath()],
+                ['Output', $config->getOutputPath()],
+                ['Cache', $this->getCachePathDisplay($config)],
+            ],
+            'checks' => $checks,
+            'warnings' => $warnings,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param array<int, array{item: string, status: string, details: string}> $checks
+     */
+    private function addCheck(
+        array &$checks,
+        string $label,
+        bool $success,
+        string $successDetails,
+        string $failureDetails,
+        string $failureSeverity,
+        int &$warnings,
+        int &$errors
+    ): void {
+        if ($success) {
+            $checks[] = [
+                'item' => $label,
+                'status' => 'ok',
+                'details' => $successDetails,
+            ];
+
+            return;
+        }
+
+        if ($failureSeverity === 'error') {
+            $errors++;
+            $status = 'error';
+        } else {
+            $warnings++;
+            $status = 'warning';
+        }
+
+        $checks[] = [
+            'item' => $label,
+            'status' => $status,
+            'details' => $failureDetails,
+        ];
+    }
+
+    /**
+     * @param array<int, string> $configFiles
+     */
+    private function formatConfigFiles(array $configFiles): string
+    {
+        if (empty($configFiles)) {
+            return 'None';
+        }
+
+        return \implode(",\n", $configFiles);
+    }
+
+    /**
+     * Returns the configured cache path without creating directories.
+     */
+    private function getCachePathDisplay(Config $config): string
+    {
+        $cacheDir = (string) $config->get('cache.dir');
+        if ($cacheDir === '') {
+            return 'Undefined';
+        }
+
+        if (Util\File::getFS()->isAbsolutePath($cacheDir)) {
+            return Util::joinFile($cacheDir, 'cecil');
+        }
+
+        return Util::joinFile($config->getDestinationDir(), $cacheDir);
+    }
+
+    /**
+     * Checks if a directory exists or can be created and is writable.
+     *
+     * @return array{0: bool, 1: string}
+     */
+    private function checkDirectoryWritable(string $directory): array
+    {
+        if ($directory === '') {
+            return [false, 'Directory path is empty'];
+        }
+
+        if (\file_exists($directory) && !\is_dir($directory)) {
+            return [false, 'Path exists and is not a directory'];
+        }
+
+        if (\is_dir($directory)) {
+            $writable = \is_writable($directory);
+
+            return [$writable, $writable ? 'Writable' : 'Not writable'];
+        }
+
+        $parent = $directory;
+        while (!\is_dir($parent)) {
+            $nextParent = \dirname($parent);
+            if ($nextParent === $parent) {
+                return [false, 'Cannot determine parent directory'];
+            }
+            $parent = $nextParent;
+        }
+
+        $parentWritable = \is_writable($parent);
+
+        return [$parentWritable, $parentWritable ? 'Creatable (parent writable)' : 'Not creatable (parent not writable)'];
+    }
+
+    /**
+     * Checks that page type formats reference existing output formats.
+     *
+     * @return array{0: bool, 1: string}
+     */
+    private function checkOutputFormatsMapping(Config $config): array
+    {
+        $available = [];
+        foreach ((array) $config->get('output.formats') as $format) {
+            if (\is_array($format) && isset($format['name']) && \is_string($format['name']) && \trim($format['name']) !== '') {
+                $available[] = $format['name'];
+            }
+        }
+
+        if (empty($available)) {
+            return [false, 'No output format defined'];
+        }
+
+        $available = \array_values(\array_unique($available));
+        $missing = [];
+        foreach ((array) $config->get('output.pagetypeformats') as $pageType => $formats) {
+            foreach ((array) $formats as $format) {
+                if (!\in_array($format, $available, true)) {
+                    $missing[] = \sprintf('%s:%s', (string) $pageType, (string) $format);
+                }
+            }
+        }
+
+        if (!empty($missing)) {
+            return [false, \sprintf('Unknown format reference(s): %s', \implode(', ', \array_unique($missing)))];
+        }
+
+        return [true, \sprintf('%d format(s), mapping is coherent', \count($available))];
+    }
+
+    /**
+     * Checks language configuration consistency.
+     *
+     * @return array{0: bool, 1: string}
+     */
+    private function checkLanguagesConfiguration(Config $config): array
+    {
+        try {
+            $default = $config->getLanguageDefault();
+            $languages = $config->getLanguages();
+            $codes = \array_column($languages, 'code');
+
+            if (\count($codes) !== \count(\array_unique($codes))) {
+                return [false, 'Duplicate language codes found'];
+            }
+
+            return [true, \sprintf('%d language(s), default: %s', \count($languages), $default)];
+        } catch (\Exception $e) {
+            return [false, $e->getMessage()];
+        }
+    }
+
+    /**
+     * Validate URL.
+     */
+    private function validateUrl(string $url): string
+    {
+        if ($url === '/') {
+            return $url;
+        }
+
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($url, new Url());
+        if (\count($violations) > 0) {
+            foreach ($violations as $violation) {
+                throw new \RuntimeException($violation->getMessage());
+            }
+        }
+
+        return \rtrim($url, '/') . '/';
+    }
+}


### PR DESCRIPTION
This pull request refactors the implementation of the "doctor" and "SEO doctor" commands to use new domain service classes (`SiteDoctor` and `SeoDoctor`) for diagnostics and audits, and updates the documentation to reflect these changes. The changes simplify the command code, delegate checks and audits to dedicated classes, and provide examples for using these services directly from PHP code.

Key changes include:

**Command Refactoring and Domain Service Integration**

* The `Doctor` command (`src/Command/Doctor.php`) now delegates all diagnostic logic to the new `SiteDoctor` domain service, removing all inline check logic and related helper methods. The command simply formats and outputs the results provided by `SiteDoctor`. [[1]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18L16-R16) [[2]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18L67-R106) [[3]](diffhunk://#diff-64df53eea031af260169cda2fc14db6721331f562c3e3c5cc0fdd6ddc2dd7b18L194-R123)
* The `DoctorSeo` command (`src/Command/DoctorSeo.php`) is refactored to use the new `SeoDoctor` domain service for SEO audits. All logic for thresholds, checks, and findings aggregation is removed from the command and handled by `SeoDoctor`. Output methods are updated to consume the new result structure. [[1]](diffhunk://#diff-c3d09f91373e3ac65e69ff1a9adf4bf4ab4588169948250b5e5e14b7a602831bL16-R16) [[2]](diffhunk://#diff-c3d09f91373e3ac65e69ff1a9adf4bf4ab4588169948250b5e5e14b7a602831bL35-L53) [[3]](diffhunk://#diff-c3d09f91373e3ac65e69ff1a9adf4bf4ab4588169948250b5e5e14b7a602831bL131-R155)

**Documentation Updates**

* The English (`docs/8-Library.md`) and French (`docs/8-Library.fr.md`) library documentation are updated to:
  - Clarify the usage of Cecil's PHP API.
  - Show how to use the new `SiteDoctor` and `SeoDoctor` services directly in user code, with example snippets for running diagnostics and audits without CLI commands. [[1]](diffhunk://#diff-b6b724eaabe4454669ef7f3daa5f52470a5b9e48b9348d614adf00cbb067509aL4-L21) [[2]](diffhunk://#diff-b6b724eaabe4454669ef7f3daa5f52470a5b9e48b9348d614adf00cbb067509aL53-R82) [[3]](diffhunk://#diff-da7b416d02e951ef6650223d39c97b56fde617491d713dd7362c49832f308e0dR5-L22) [[4]](diffhunk://#diff-da7b416d02e951ef6650223d39c97b56fde617491d713dd7362c49832f308e0dL32-R35) [[5]](diffhunk://#diff-da7b416d02e951ef6650223d39c97b56fde617491d713dd7362c49832f308e0dL53-R84)

**API Usage Consistency**

* All references to the deprecated `Cecil::create()` are updated to use `Builder::create()` for consistency and clarity in both documentation and code examples. [[1]](diffhunk://#diff-b6b724eaabe4454669ef7f3daa5f52470a5b9e48b9348d614adf00cbb067509aL53-R82) [[2]](diffhunk://#diff-da7b416d02e951ef6650223d39c97b56fde617491d713dd7362c49832f308e0dL53-R84)

These changes improve maintainability by separating concerns, making diagnostics and audits reusable across different contexts, and providing clearer documentation for users and developers.