### PR TITLE
feat: add doctor:frontmatter command

### DIFF
--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -341,31 +341,6 @@ Options:
       --include-virtual Include virtual pages (paginated, taxonomies) in audit
 ```
 
-## doctor:frontmatter
-
-Valide la syntaxe du front matter des pages.
-
-```plaintext
-Description:
-  Validates pages front matter syntax
-
-Usage:
-  doctor:frontmatter|doctor:fm [options] [--] [<path>]
-
-Arguments:
-  path                  Use the given path as working directory
-
-Options:
-  -c, --config=CONFIG   Set the path to an extra configuration file
-  -p, --page=PAGE       Validate a single page relative to the pages directory
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction  Do not ask any interactive question
-  -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
-  -V, --version         Display this application version
-  -v|vv|vvv             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-```
-
 La commande construit le site en mode dry-run, puis audite le HTML rendu avec un jeu de contrôles ciblés : balise title, meta description, URL canonique, structure des titres, balises Open Graph, attributs alt des images et longueur estimée du contenu.
 
 Par défaut, les pages virtuelles (paginées, pages de taxonomie) sont exclues de l'audit. Utilisez `--include-virtual` pour les inclure.
@@ -391,4 +366,29 @@ doctor:
       img_alt: true
       content_length: true
       lang_attribute: true
+```
+
+## doctor:frontmatter
+
+Valide la syntaxe du front matter des pages.
+
+```plaintext
+Description:
+  Validates pages front matter syntax
+
+Usage:
+  doctor:frontmatter|doctor:fm [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Validate a single page relative to the pages directory
+      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction  Do not ask any interactive question
+  -h, --help            Display help for the given command. When no command is given display help for the list command
+  -q, --quiet           Do not output any message
+  -V, --version         Display this application version
+  -v|vv|vvv             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```

--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -2,7 +2,7 @@
 title: Commandes
 description: "Liste des commandes disponibles."
 date: 2026-03-27
-updated: 2026-06-13
+updated: 2026-06-15
 slug: commandes
 -->
 # Commandes
@@ -17,6 +17,7 @@ Available commands:
   clear:output               Removes output directory
   clear:tmp                  Removes temporary directory
   doctor                     Diagnoses the site configuration
+  doctor:frontmatter         [doctor:fm] Validates pages front matter syntax
   doctor:seo                 Audits rendered HTML pages for common SEO issues
   edit                       [open] Open pages directory with the editor
   help                       Display help for a command
@@ -338,6 +339,31 @@ Options:
   -p, --page=PAGE       Audit a single page relative to the pages directory
       --format=FORMAT   Output format: text (default) or json
       --include-virtual Include virtual pages (paginated, taxonomies) in audit
+```
+
+## doctor:frontmatter
+
+Valide la syntaxe du front matter des pages.
+
+```plaintext
+Description:
+  Validates pages front matter syntax
+
+Usage:
+  doctor:frontmatter|doctor:fm [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Validate a single page relative to the pages directory
+      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction  Do not ask any interactive question
+  -h, --help            Display help for the given command. When no command is given display help for the list command
+  -q, --quiet           Do not output any message
+  -V, --version         Display this application version
+  -v|vv|vvv             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
 La commande construit le site en mode dry-run, puis audite le HTML rendu avec un jeu de contrôles ciblés : balise title, meta description, URL canonique, structure des titres, balises Open Graph, attributs alt des images et longueur estimée du contenu.

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -1,7 +1,7 @@
 <!--
 description: "List of available commands."
 date: 2020-12-19
-updated: 2026-06-13
+updated: 2026-06-15
 -->
 # Commands
 
@@ -15,6 +15,7 @@ Available commands:
   clear:output               Removes output directory
   clear:tmp                  Removes temporary directory
   doctor                     Diagnoses the site configuration
+  doctor:frontmatter         [doctor:fm] Validates pages front matter syntax
   doctor:seo                 Audits rendered HTML pages for common SEO issues
   edit                       [open] Open pages directory with the editor
   help                       Display help for a command
@@ -336,6 +337,31 @@ Options:
   -p, --page=PAGE       Audit a single page relative to the pages directory
       --format=FORMAT   Output format: text (default) or json
       --include-virtual Include virtual pages (paginated, taxonomies) in audit
+```
+
+## doctor:frontmatter
+
+Validates pages front matter syntax.
+
+```plaintext
+Description:
+  Validates pages front matter syntax
+
+Usage:
+  doctor:frontmatter|doctor:fm [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Validate a single page relative to the pages directory
+      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction  Do not ask any interactive question
+  -h, --help            Display help for the given command. When no command is given display help for the list command
+  -q, --quiet           Do not output any message
+  -V, --version         Display this application version
+  -v|vv|vvv             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
 The command builds the site in dry-run mode, then audits the rendered HTML output for a focused set of checks: title tag, meta description, canonical URL, heading structure, Open Graph tags, image alt attributes and estimated content length.

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -339,31 +339,6 @@ Options:
       --include-virtual Include virtual pages (paginated, taxonomies) in audit
 ```
 
-## doctor:frontmatter
-
-Validates pages front matter syntax.
-
-```plaintext
-Description:
-  Validates pages front matter syntax
-
-Usage:
-  doctor:frontmatter|doctor:fm [options] [--] [<path>]
-
-Arguments:
-  path                  Use the given path as working directory
-
-Options:
-  -c, --config=CONFIG   Set the path to an extra configuration file
-  -p, --page=PAGE       Validate a single page relative to the pages directory
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction  Do not ask any interactive question
-  -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
-  -V, --version         Display this application version
-  -v|vv|vvv             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-```
-
 The command builds the site in dry-run mode, then audits the rendered HTML output for a focused set of checks: title tag, meta description, canonical URL, heading structure, Open Graph tags, image alt attributes and estimated content length.
 
 By default, virtual pages (paginated, taxonomy pages) are excluded from the audit. Use `--include-virtual` to include them.
@@ -389,4 +364,29 @@ doctor:
       img_alt: true
       content_length: true
       lang_attribute: true
+```
+
+## doctor:frontmatter
+
+Validates pages front matter syntax.
+
+```plaintext
+Description:
+  Validates pages front matter syntax
+
+Usage:
+  doctor:frontmatter|doctor:fm [options] [--] [<path>]
+
+Arguments:
+  path                  Use the given path as working directory
+
+Options:
+  -c, --config=CONFIG   Set the path to an extra configuration file
+  -p, --page=PAGE       Validate a single page relative to the pages directory
+      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction  Do not ask any interactive question
+  -h, --help            Display help for the given command. When no command is given display help for the list command
+  -q, --quiet           Do not output any message
+  -V, --version         Display this application version
+  -v|vv|vvv             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```

--- a/src/Application.php
+++ b/src/Application.php
@@ -64,6 +64,7 @@ class Application extends BaseApplication
             new Command\CacheClearTemplates(),
             new Command\CacheClearTranslations(),
             new Command\Doctor(),
+            new Command\DoctorFrontmatter(),
             new Command\DoctorSeo(),
             new Command\ShowContent(),
             new Command\ShowConfig(),

--- a/src/Command/DoctorFrontmatter.php
+++ b/src/Command/DoctorFrontmatter.php
@@ -133,9 +133,9 @@ EOF
      */
     private function formatFileLink(string $label, string $absolutePath): string
     {
-        $normalizedPath = \str_replace('\\', '/', $absolutePath);
-        $uriPath = \preg_match('/^[A-Za-z]:\//', $normalizedPath) ? '/' . $normalizedPath : $normalizedPath;
-        $encodedPath = \implode('/', \array_map(static fn (string $segment): string => \str_replace('%3A', ':', \rawurlencode($segment)), \explode('/', $uriPath)));
+        $normalizedPath = str_replace('\\', '/', $absolutePath);
+        $uriPath = preg_match('/^[A-Za-z]:\//', $normalizedPath) ? '/' . $normalizedPath : $normalizedPath;
+        $encodedPath = implode('/', array_map(static fn (string $segment): string => str_replace('%3A', ':', rawurlencode($segment)), explode('/', $uriPath)));
 
         return \sprintf('<href=file://%s>%s</>', $encodedPath, $label);
     }

--- a/src/Command/DoctorFrontmatter.php
+++ b/src/Command/DoctorFrontmatter.php
@@ -133,9 +133,9 @@ EOF
      */
     private function formatFileLink(string $label, string $absolutePath): string
     {
-        $normalizedPath = str_replace('\\', '/', $absolutePath);
-        $uriPath = preg_match('/^[A-Za-z]:\//', $normalizedPath) ? '/' . $normalizedPath : $normalizedPath;
-        $encodedPath = implode('/', array_map(static fn (string $segment): string => rawurlencode($segment), explode('/', $uriPath)));
+        $normalizedPath = \str_replace('\\', '/', $absolutePath);
+        $uriPath = \preg_match('/^[A-Za-z]:\//', $normalizedPath) ? '/' . $normalizedPath : $normalizedPath;
+        $encodedPath = \implode('/', \array_map(static fn (string $segment): string => \str_replace('%3A', ':', \rawurlencode($segment)), \explode('/', $uriPath)));
 
         return \sprintf('<href=file://%s>%s</>', $encodedPath, $label);
     }

--- a/src/Command/DoctorFrontmatter.php
+++ b/src/Command/DoctorFrontmatter.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Command;
+
+use Cecil\Doctor\FrontmatterDoctor;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Front matter doctor command.
+ *
+ * This command validates front matter syntax for all pages found in the
+ * configured pages directory, using the configured front matter format.
+ */
+class DoctorFrontmatter extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('doctor:frontmatter')
+            ->setAliases(['doctor:fm'])
+            ->setDescription('Validates pages front matter syntax')
+            ->setDefinition([
+                new InputArgument('path', InputArgument::OPTIONAL, 'Use the given path as working directory'),
+                new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set the path to an extra configuration file'),
+                new InputOption('page', 'p', InputOption::VALUE_REQUIRED, 'Validate a single page relative to the pages directory'),
+            ])
+            ->setHelp(
+                <<<'EOF'
+The <info>%command.name%</> command validates front matter syntax for pages.
+
+  <info>%command.full_name%</>
+  <info>%command.full_name% path/to/the/working/directory</>
+
+To validate a single page, run:
+
+  <info>%command.full_name% --page=blog/post.md</>
+
+To inspect a site with an extra configuration file, run:
+
+  <info>%command.full_name% --config=config.yml</>
+EOF
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $builder = $this->getBuilder();
+        $doctor = new FrontmatterDoctor();
+        $diagnosis = $doctor->diagnose($builder, [
+            'page' => (string) ($input->getOption('page') ?? ''),
+        ]);
+
+        $this->io->title('Front matter audit summary');
+
+        $summary = $diagnosis['summary'];
+        $summaryTable = new Table($output);
+        $summaryTable
+            ->setHeaders(['Metric', 'Value'])
+            ->setRows([
+                ['Files scanned', (string) $summary['files_scanned']],
+                ['Files with front matter', (string) $summary['files_with_frontmatter']],
+                ['Valid front matter', (string) $summary['valid_frontmatters']],
+                ['Invalid front matter', (string) $summary['invalid_frontmatters']],
+                ['Files without front matter', (string) $summary['files_without_frontmatter']],
+            ])
+        ;
+        $summaryTable->setStyle('box')->render();
+
+        if (!empty($diagnosis['findings'])) {
+            $rows = [];
+            foreach ($diagnosis['findings'] as $finding) {
+                $rows[] = [
+                    $this->formatFileLink($finding['file'], $finding['file_absolute']),
+                    $this->formatStatus($finding['status']),
+                    $finding['line'] !== null ? (string) $finding['line'] : '-',
+                    $finding['details'],
+                ];
+            }
+
+            $detailsTable = new Table($output);
+            $detailsTable
+                ->setHeaders(['File', 'Status', 'Line', 'Details'])
+                ->setRows($rows)
+            ;
+            $detailsTable->setStyle('box')->render();
+        }
+
+        if ($summary['invalid_frontmatters'] > 0) {
+            $this->io->error(\sprintf('%d error(s) found.', $summary['invalid_frontmatters']));
+        } else {
+            $this->io->success('No front matter errors found.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Formats status for console output.
+     */
+    private function formatStatus(string $status): string
+    {
+        return match ($status) {
+            'error' => '<error>FAIL</error>',
+            'warning' => '<comment>WARN</comment>',
+            default => '<info>OK</info>',
+        };
+    }
+
+    /**
+     * Formats a clickable file label using console hyperlinks.
+     */
+    private function formatFileLink(string $label, string $absolutePath): string
+    {
+        $normalizedPath = str_replace('\\', '/', $absolutePath);
+        $uriPath = preg_match('/^[A-Za-z]:\//', $normalizedPath) ? '/' . $normalizedPath : $normalizedPath;
+        $encodedPath = implode('/', array_map(static fn (string $segment): string => rawurlencode($segment), explode('/', $uriPath)));
+
+        return \sprintf('<href=file://%s>%s</>', $encodedPath, $label);
+    }
+}

--- a/src/Command/DoctorFrontmatter.php
+++ b/src/Command/DoctorFrontmatter.php
@@ -81,9 +81,9 @@ EOF
             ->setRows([
                 ['Files scanned', (string) $summary['files_scanned']],
                 ['Files with front matter', (string) $summary['files_with_frontmatter']],
-                ['Valid front matter', (string) $summary['valid_frontmatters']],
-                ['Invalid front matter', (string) $summary['invalid_frontmatters']],
                 ['Files without front matter', (string) $summary['files_without_frontmatter']],
+                ['Files with valid front matter', (string) $summary['valid_frontmatters']],
+                ['Errors in front matter', (string) $summary['invalid_frontmatters']],
             ])
         ;
         $summaryTable->setStyle('box')->render();

--- a/src/Doctor/FrontmatterDoctor.php
+++ b/src/Doctor/FrontmatterDoctor.php
@@ -26,6 +26,8 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 class FrontmatterDoctor
 {
+    private const MAX_ERRORS_PER_FILE = 20;
+
     /**
      * @param array{page?: string} $options
      *
@@ -97,18 +99,21 @@ class FrontmatterDoctor
 
             $filesWithFrontmatter++;
 
-            try {
-                $converter->convertFrontmatter($frontmatter, $format);
+            $fileErrors = $this->collectFrontmatterErrors($converter, $frontmatter, $format);
+            if (empty($fileErrors)) {
                 $validFrontmatters++;
-            } catch (RuntimeException $e) {
-                $invalidFrontmatters++;
 
+                continue;
+            }
+
+            $invalidFrontmatters += \count($fileErrors);
+            foreach ($fileErrors as $error) {
                 $findings[] = [
                     'file' => $fileRelativePath,
                     'file_absolute' => $fileAbsolutePath,
-                    'line' => $e->getLine() > 0 ? $e->getLine() : null,
+                    'line' => $error['line'],
                     'status' => 'error',
-                    'details' => $e->getMessage(),
+                    'details' => $error['details'],
                 ];
             }
         }
@@ -123,5 +128,71 @@ class FrontmatterDoctor
             ],
             'findings' => $findings,
         ];
+    }
+
+    /**
+     * @return array<int, array{line: int|null, details: string}>
+     */
+    private function collectFrontmatterErrors(Converter $converter, string $frontmatter, string $format): array
+    {
+        if ($format !== 'yaml') {
+            try {
+                $converter->convertFrontmatter($frontmatter, $format);
+
+                return [];
+            } catch (RuntimeException $e) {
+                return [[
+                    'line' => $e->getLine() > 0 ? $e->getLine() : null,
+                    'details' => $e->getMessage(),
+                ]];
+            }
+        }
+
+        // For YAML, retry parsing while removing the failing line to expose additional errors.
+        $workingLines = preg_split('/\r\n|\r|\n/', $frontmatter) ?: [];
+        $lineMap = [];
+        $lineCount = \count($workingLines);
+        for ($line = 1; $line <= $lineCount; $line++) {
+            $lineMap[] = $line;
+        }
+
+        $errors = [];
+        $seen = [];
+        $attempts = 0;
+
+        while (!empty($workingLines) && $attempts < self::MAX_ERRORS_PER_FILE) {
+            $attempts++;
+
+            try {
+                $converter->convertFrontmatter(implode("\n", $workingLines), $format);
+
+                break;
+            } catch (RuntimeException $e) {
+                $reportedLine = $e->getLine() > 0 ? $e->getLine() : null;
+                $originalLine = null;
+                if ($reportedLine !== null && isset($lineMap[$reportedLine - 1])) {
+                    $originalLine = $lineMap[$reportedLine - 1];
+                }
+
+                $fingerprint = \sprintf('%s|%s', $e->getMessage(), (string) ($originalLine ?? 0));
+                if (!isset($seen[$fingerprint])) {
+                    $seen[$fingerprint] = true;
+                    $errors[] = [
+                        'line' => $originalLine,
+                        'details' => $e->getMessage(),
+                    ];
+                }
+
+                if ($reportedLine === null || !isset($lineMap[$reportedLine - 1])) {
+                    break;
+                }
+
+                unset($workingLines[$reportedLine - 1], $lineMap[$reportedLine - 1]);
+                $workingLines = array_values($workingLines);
+                $lineMap = array_values($lineMap);
+            }
+        }
+
+        return $errors;
     }
 }

--- a/src/Doctor/FrontmatterDoctor.php
+++ b/src/Doctor/FrontmatterDoctor.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Doctor;
+
+use Cecil\Builder;
+use Cecil\Collection\Page\Page;
+use Cecil\Converter\Converter;
+use Cecil\Exception\RuntimeException;
+use Cecil\Step\Pages\Load as PagesLoadStep;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Front matter diagnosis domain service.
+ */
+class FrontmatterDoctor
+{
+    /**
+     * @param array{page?: string} $options
+     *
+     * @return array{
+     *   summary: array{files_scanned: int, files_with_frontmatter: int, valid_frontmatters: int, invalid_frontmatters: int, files_without_frontmatter: int},
+        *   findings: array<int, array{file: string, file_absolute: string, line: int|null, status: string, details: string}>
+     * }
+     */
+    public function diagnose(Builder $builder, array $options = []): array
+    {
+        $page = (string) ($options['page'] ?? '');
+        $step = new PagesLoadStep($builder);
+        $step->init(['page' => $page]);
+        if ($step->canProcess()) {
+            $step->process();
+        }
+
+        $files = $builder->getPagesFiles();
+        if (!$files instanceof Finder) {
+            return [
+                'summary' => [
+                    'files_scanned' => 0,
+                    'files_with_frontmatter' => 0,
+                    'valid_frontmatters' => 0,
+                    'invalid_frontmatters' => 0,
+                    'files_without_frontmatter' => 0,
+                ],
+                'findings' => [],
+            ];
+        }
+
+        $format = (string) $builder->getConfig()->get('pages.frontmatter');
+        $converter = new Converter($builder);
+
+        $filesScanned = 0;
+        $filesWithFrontmatter = 0;
+        $validFrontmatters = 0;
+        $invalidFrontmatters = 0;
+        $filesWithoutFrontmatter = 0;
+        $findings = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($files as $file) {
+            $filesScanned++;
+            $fileRelativePath = $file->getRelativePathname();
+            $fileAbsolutePath = $file->getRealPath() ?: $file->getPathname();
+
+            try {
+                $parsedPage = (new Page($file))->parse();
+            } catch (RuntimeException $e) {
+                $invalidFrontmatters++;
+                $findings[] = [
+                    'file' => $fileRelativePath,
+                    'file_absolute' => $fileAbsolutePath,
+                    'line' => $e->getLine() > 0 ? $e->getLine() : null,
+                    'status' => 'error',
+                    'details' => $e->getMessage(),
+                ];
+
+                continue;
+            }
+
+            $frontmatter = $parsedPage->getFrontmatter();
+            if ($frontmatter === null || trim($frontmatter) === '') {
+                $filesWithoutFrontmatter++;
+
+                continue;
+            }
+
+            $filesWithFrontmatter++;
+
+            try {
+                $converter->convertFrontmatter($frontmatter, $format);
+                $validFrontmatters++;
+            } catch (RuntimeException $e) {
+                $invalidFrontmatters++;
+
+                $findings[] = [
+                    'file' => $fileRelativePath,
+                    'file_absolute' => $fileAbsolutePath,
+                    'line' => $e->getLine() > 0 ? $e->getLine() : null,
+                    'status' => 'error',
+                    'details' => $e->getMessage(),
+                ];
+            }
+        }
+
+        return [
+            'summary' => [
+                'files_scanned' => $filesScanned,
+                'files_with_frontmatter' => $filesWithFrontmatter,
+                'valid_frontmatters' => $validFrontmatters,
+                'invalid_frontmatters' => $invalidFrontmatters,
+                'files_without_frontmatter' => $filesWithoutFrontmatter,
+            ],
+            'findings' => $findings,
+        ];
+    }
+}

--- a/src/Doctor/FrontmatterDoctor.php
+++ b/src/Doctor/FrontmatterDoctor.php
@@ -33,7 +33,7 @@ class FrontmatterDoctor
      *
      * @return array{
      *   summary: array{files_scanned: int, files_with_frontmatter: int, valid_frontmatters: int, invalid_frontmatters: int, files_without_frontmatter: int},
-        *   findings: array<int, array{file: string, file_absolute: string, line: int|null, status: string, details: string}>
+     *   findings: array<int, array{file: string, file_absolute: string, line: int|null, status: string, details: string}>
      * }
      */
     public function diagnose(Builder $builder, array $options = []): array

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -140,6 +140,12 @@ class IntegrationCliTests extends IntegrationTests
         self::assertStringContainsString('Front matter audit summary', $output);
         self::assertStringContainsString('error(s) found', $output);
         self::assertStringContainsString('invalid-frontmatter.md', $output);
+        self::assertStringContainsString('File', $output);
+        self::assertStringContainsString('Status', $output);
+        self::assertStringContainsString('Line', $output);
+        self::assertStringContainsString('FAIL', $output);
+        self::assertStringContainsString('Malformed inline YAML string', $output);
+        self::assertStringNotContainsString('tests\\demo\\pages\\invalid-frontmatter.md', $output);
     }
 
     public function testDoctorFrontmatterAlias(): void
@@ -158,6 +164,49 @@ class IntegrationCliTests extends IntegrationTests
         self::assertTrue($retval < 1);
         self::assertStringContainsString('Front matter audit summary', $output);
         self::assertStringContainsString('invalid-frontmatter-alias.md', $output);
+        self::assertStringContainsString('error(s) found', $output);
+        self::assertStringContainsString('Status', $output);
+        self::assertStringContainsString('Line', $output);
+    }
+
+    public function testDoctorFrontmatterMultipleErrorsInSingleFile(): void
+    {
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
+        self::assertTrue($retval < 1);
+
+        $invalidPage = Util::joinFile(__DIR__, 'demo', 'pages', 'invalid-frontmatter-multiple.md');
+        file_put_contents($invalidPage, "---\ntitle: \"Unclosed\nitems: [a, b\nbad: key: value\n---\n\nBody\n");
+
+        $output = [];
+        exec('php ./bin/cecil doctor:frontmatter tests/demo 2>&1', $output, $retval);
+        $output = implode("\n", $output);
+        echo $output;
+
+        self::assertTrue($retval < 1);
+        self::assertStringContainsString('invalid-frontmatter-multiple.md', $output);
+        self::assertGreaterThanOrEqual(3, substr_count($output, 'invalid-frontmatter-multiple.md'));
+        self::assertStringContainsString('3 error(s) found', $output);
+        self::assertStringContainsString('line 3 (near "bad: key: value")', $output);
+        self::assertStringContainsString('line 2 (near "items: [a, b")', $output);
+        self::assertStringContainsString('line 1 (near "title: "Unclosed")', $output);
+    }
+
+    public function testDoctorFrontmatterNoErrors(): void
+    {
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
+        self::assertTrue($retval < 1);
+
+        $output = [];
+        exec('php ./bin/cecil doctor:frontmatter tests/demo 2>&1', $output, $retval);
+        $output = implode("\n", $output);
+        echo $output;
+
+        self::assertTrue($retval < 1);
+        self::assertStringContainsString('Front matter audit summary', $output);
+        self::assertStringContainsString('No front matter errors found.', $output);
+        self::assertStringNotContainsString('FAIL', $output);
+        self::assertStringContainsString('Invalid front matter', $output);
+        self::assertStringContainsString('│ 0', $output);
     }
 
     public function testServeBackgroundWithPidFile(): void

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -123,6 +123,43 @@ class IntegrationCliTests extends IntegrationTests
         self::assertStringContainsString('SEO audit summary', $output);
     }
 
+    public function testDoctorFrontmatter(): void
+    {
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
+        self::assertTrue($retval < 1);
+
+        $invalidPage = Util::joinFile(__DIR__, 'demo', 'pages', 'invalid-frontmatter.md');
+        file_put_contents($invalidPage, "---\ntitle: \"Unclosed\n---\n\nBody\n");
+
+        $output = [];
+        exec('php ./bin/cecil doctor:frontmatter tests/demo 2>&1', $output, $retval);
+        $output = implode("\n", $output);
+        echo $output;
+
+        self::assertTrue($retval < 1);
+        self::assertStringContainsString('Front matter audit summary', $output);
+        self::assertStringContainsString('error(s) found', $output);
+        self::assertStringContainsString('invalid-frontmatter.md', $output);
+    }
+
+    public function testDoctorFrontmatterAlias(): void
+    {
+        exec('php ./bin/cecil new:site tests/demo --demo -n -f 2>&1', $output, $retval);
+        self::assertTrue($retval < 1);
+
+        $invalidPage = Util::joinFile(__DIR__, 'demo', 'pages', 'invalid-frontmatter-alias.md');
+        file_put_contents($invalidPage, "---\ntitle: \"Unclosed\n---\n\nBody\n");
+
+        $output = [];
+        exec('php ./bin/cecil doctor:fm tests/demo 2>&1', $output, $retval);
+        $output = implode("\n", $output);
+        echo $output;
+
+        self::assertTrue($retval < 1);
+        self::assertStringContainsString('Front matter audit summary', $output);
+        self::assertStringContainsString('invalid-frontmatter-alias.md', $output);
+    }
+
     public function testServeBackgroundWithPidFile(): void
     {
         $this->markTestSkipped('Skipping serve background test because it is not reliable in CI environments');

--- a/tests/IntegrationCliTests.php
+++ b/tests/IntegrationCliTests.php
@@ -205,7 +205,7 @@ class IntegrationCliTests extends IntegrationTests
         self::assertStringContainsString('Front matter audit summary', $output);
         self::assertStringContainsString('No front matter errors found.', $output);
         self::assertStringNotContainsString('FAIL', $output);
-        self::assertStringContainsString('Invalid front matter', $output);
+        self::assertStringContainsString('Errors in front matter', $output);
         self::assertStringContainsString('│ 0', $output);
     }
 


### PR DESCRIPTION
This pull request introduces a new CLI command for validating the front matter syntax in pages, along with its documentation and comprehensive integration tests. The main addition is the `doctor:frontmatter` (alias `doctor:fm`) command, which audits all or specific page files for front matter issues and provides detailed error reporting. The documentation in both English and French is updated to describe this new feature, and new tests ensure its correctness and robustness.

**New Command: Front Matter Validation**

* Added a new CLI command `doctor:frontmatter` (alias `doctor:fm`) to validate the syntax of front matter in page files. The command outputs a summary and details of any errors found, including file name, status, line number, and error details. (`src/Command/DoctorFrontmatter.php` [[1]](diffhunk://#diff-505569b2e78d9d9c95d62d1b6d38279bfe8077b2cb3c9d54c5198633d8ea32b9R1-R142) `src/Application.php` [[2]](diffhunk://#diff-00ce90757b1e2f4249d3e36b770c52ad59fbc9d6f7148a08d1f2a896fcedb08fR67)
* Implemented the core logic for front matter diagnostics, including detection of multiple syntax errors in YAML front matter, and detailed error reporting with line numbers. (`src/Doctor/FrontmatterDoctor.php` [src/Doctor/FrontmatterDoctor.phpR1-R198](diffhunk://#diff-057b503d812f64ddaa69c7009986249cf1c75aec2c225f5dee80ab72bd05bafbR1-R198))

**Documentation Updates**

* Updated both English and French command documentation to include `doctor:frontmatter`, its description, usage, arguments, and options. (`docs/5-Commands.md` [[1]](diffhunk://#diff-bd7c60a0fa61e1cf76dcbf196248b4ec468d0a0a3608c57722f21875fab757bfL4-R4) [[2]](diffhunk://#diff-bd7c60a0fa61e1cf76dcbf196248b4ec468d0a0a3608c57722f21875fab757bfR18) [[3]](diffhunk://#diff-bd7c60a0fa61e1cf76dcbf196248b4ec468d0a0a3608c57722f21875fab757bfR368-R392); `docs/5-Commands.fr.md` [[4]](diffhunk://#diff-1638e6e2e8f4b5d62b381c99b8d35aaf69ed4944f4bdab06c0cce3e50a53d190L5-R5) [[5]](diffhunk://#diff-1638e6e2e8f4b5d62b381c99b8d35aaf69ed4944f4bdab06c0cce3e50a53d190R20) [[6]](diffhunk://#diff-1638e6e2e8f4b5d62b381c99b8d35aaf69ed4944f4bdab06c0cce3e50a53d190R370-R394)

**Testing**

* Added integration tests to verify the new command, its alias, error reporting for single and multiple errors, and correct handling of valid files. These tests ensure the command works as expected in various scenarios. (`tests/IntegrationCliTests.php` [tests/IntegrationCliTests.phpR126-R211](diffhunk://#diff-4e9f94ad44d7d5ba729297df0de097d6f3ac268f670ffdd393c9740e51c52d70R126-R211))