### PR TITLE
perf: cache Parsedown/highlighter/image processing and add asset dedup metrics

### DIFF
--- a/docs/api/classes/Cecil-Builder.html
+++ b/docs/api/classes/Cecil-Builder.html
@@ -280,6 +280,27 @@ Builder::create($config)-&gt;build();
 </h4>
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/Cecil-Builder.html#property_assetRegistry">$assetRegistry</a>
+    <span>
+                        &nbsp;: array&lt;string, <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&gt;            </span>
+</dt>
+<dd>In-memory registry used to deduplicate asset objects during a build.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/Cecil-Builder.html#property_assetRegistryHits">$assetRegistryHits</a>
+    <span>
+                        &nbsp;: int            </span>
+</dt>
+<dd>Counter for asset registry cache hits during conversion steps.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/Cecil-Builder.html#property_assetRegistryMisses">$assetRegistryMisses</a>
+    <span>
+                        &nbsp;: int            </span>
+</dt>
+<dd>Counter for asset registry cache misses (new assets created) during conversion steps.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/Cecil-Builder.html#property_assets">$assets</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
@@ -427,6 +448,13 @@ Builder::create($config)-&gt;build();
 <dd>Creates a new Builder instance.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a class="" href="classes/Cecil-Builder.html#method_getAssetRegistryStats">getAssetRegistryStats()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Returns asset registry deduplication statistics.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a class="" href="classes/Cecil-Builder.html#method_getAssetsList">getAssetsList()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
@@ -537,6 +565,13 @@ Builder::create($config)-&gt;build();
                                 &nbsp;: bool    </span>
 </dt>
 <dd>Returns debug mode state.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a class="" href="classes/Cecil-Builder.html#method_rememberAsset">rememberAsset()</a>
+    <span>
+                                &nbsp;: <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>    </span>
+</dt>
+<dd>Returns an Asset from the registry or stores a newly created one.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a class="" href="classes/Cecil-Builder.html#method_setConfig">setConfig()</a>
@@ -931,6 +966,120 @@ Each step is a class that implements the StepInterface.</p>
             -protected
                                                                     "
 >
+    <h4 class="phpdocumentor-element__name" id="property_assetRegistry">
+        $assetRegistry
+        <a href="classes/Cecil-Builder.html#property_assetRegistry" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">159</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">In-memory registry used to deduplicate asset objects during a build.</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">protected</span>
+            <span class="phpdocumentor-signature__type">array&lt;string, <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&gt;</span>
+    <span class="phpdocumentor-signature__name">$assetRegistry</span>
+     = <span class="phpdocumentor-signature__default-value">[]</span></code>
+
+    
+    
+    
+
+        
+        
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+                                                                    "
+>
+    <h4 class="phpdocumentor-element__name" id="property_assetRegistryHits">
+        $assetRegistryHits
+        <a href="classes/Cecil-Builder.html#property_assetRegistryHits" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">164</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Counter for asset registry cache hits during conversion steps.</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">protected</span>
+            <span class="phpdocumentor-signature__type">int</span>
+    <span class="phpdocumentor-signature__name">$assetRegistryHits</span>
+     = <span class="phpdocumentor-signature__default-value">0</span></code>
+
+    
+    
+    
+
+        
+        
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+                                                                    "
+>
+    <h4 class="phpdocumentor-element__name" id="property_assetRegistryMisses">
+        $assetRegistryMisses
+        <a href="classes/Cecil-Builder.html#property_assetRegistryMisses" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">169</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Counter for asset registry cache misses (new assets created) during conversion steps.</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">protected</span>
+            <span class="phpdocumentor-signature__type">int</span>
+    <span class="phpdocumentor-signature__name">$assetRegistryMisses</span>
+     = <span class="phpdocumentor-signature__default-value">0</span></code>
+
+    
+    
+    
+
+        
+        
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+                                                                    "
+>
     <h4 class="phpdocumentor-element__name" id="property_assets">
         $assets
         <a href="classes/Cecil-Builder.html#property_assets" class="headerlink"><i class="fas fa-link"></i></a>
@@ -982,7 +1131,7 @@ It is used to keep track of assets that need to be processed or copied.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">225</span>
 
     </aside>
 
@@ -1213,7 +1362,7 @@ It can be set to an array or a Config instance.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">189</span>
+    <span class="phpdocumentor-element-found-in__line">204</span>
 
     </aside>
 
@@ -1310,7 +1459,7 @@ It can be set to any PSR-3 compliant logger.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">164</span>
+    <span class="phpdocumentor-element-found-in__line">179</span>
 
     </aside>
 
@@ -1367,7 +1516,7 @@ It is used to manage navigation menus across different languages in the website.
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">196</span>
+    <span class="phpdocumentor-element-found-in__line">211</span>
 
     </aside>
 
@@ -1507,7 +1656,7 @@ It is an instance of PagesCollection, which is a custom collection class for man
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">181</span>
+    <span class="phpdocumentor-element-found-in__line">196</span>
 
     </aside>
 
@@ -1588,7 +1737,7 @@ It handles the rendering of templates and the application of data to those templ
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">174</span>
+    <span class="phpdocumentor-element-found-in__line">189</span>
 
     </aside>
 
@@ -1645,7 +1794,7 @@ It is used to manage taxonomies (like categories, tags) across different languag
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">201</span>
+    <span class="phpdocumentor-element-found-in__line">216</span>
 
     </aside>
 
@@ -1688,7 +1837,7 @@ It is used to manage taxonomies (like categories, tags) across different languag
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">216</span>
+    <span class="phpdocumentor-element-found-in__line">231</span>
 
     </aside>
 
@@ -1739,7 +1888,7 @@ It is used to manage taxonomies (like categories, tags) across different languag
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">484</span>
+    <span class="phpdocumentor-element-found-in__line">509</span>
 
     </aside>
 
@@ -1784,7 +1933,7 @@ It is used to manage taxonomies (like categories, tags) across different languag
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">252</span>
+    <span class="phpdocumentor-element-found-in__line">267</span>
 
     </aside>
 
@@ -1851,7 +2000,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">237</span>
+    <span class="phpdocumentor-element-found-in__line">252</span>
 
     </aside>
 
@@ -1882,6 +2031,45 @@ It also collects metrics about the build process, such as duration and memory us
             -public
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_getAssetRegistryStats">
+        getAssetRegistryStats()
+        <a href="classes/Cecil-Builder.html#method_getAssetRegistryStats" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">539</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Returns asset registry deduplication statistics.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">getAssetRegistryStats</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+    
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_getAssetsList">
         getAssetsList()
         <a href="classes/Cecil-Builder.html#method_getAssetsList" class="headerlink"><i class="fas fa-link"></i></a>
@@ -1890,7 +2078,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">494</span>
+    <span class="phpdocumentor-element-found-in__line">554</span>
 
     </aside>
 
@@ -1929,7 +2117,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">581</span>
+    <span class="phpdocumentor-element-found-in__line">641</span>
 
     </aside>
 
@@ -1968,7 +2156,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">403</span>
+    <span class="phpdocumentor-element-found-in__line">428</span>
 
     </aside>
 
@@ -2007,7 +2195,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">332</span>
+    <span class="phpdocumentor-element-found-in__line">357</span>
 
     </aside>
 
@@ -2046,7 +2234,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">435</span>
+    <span class="phpdocumentor-element-found-in__line">460</span>
 
     </aside>
 
@@ -2095,7 +2283,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">387</span>
+    <span class="phpdocumentor-element-found-in__line">412</span>
 
     </aside>
 
@@ -2134,7 +2322,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">510</span>
+    <span class="phpdocumentor-element-found-in__line">570</span>
 
     </aside>
 
@@ -2183,7 +2371,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">550</span>
+    <span class="phpdocumentor-element-found-in__line">610</span>
 
     </aside>
 
@@ -2222,7 +2410,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">476</span>
+    <span class="phpdocumentor-element-found-in__line">501</span>
 
     </aside>
 
@@ -2261,7 +2449,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">419</span>
+    <span class="phpdocumentor-element-found-in__line">444</span>
 
     </aside>
 
@@ -2300,7 +2488,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">542</span>
+    <span class="phpdocumentor-element-found-in__line">602</span>
 
     </aside>
 
@@ -2339,7 +2527,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">460</span>
+    <span class="phpdocumentor-element-found-in__line">485</span>
 
     </aside>
 
@@ -2378,7 +2566,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">526</span>
+    <span class="phpdocumentor-element-found-in__line">586</span>
 
     </aside>
 
@@ -2427,7 +2615,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">560</span>
+    <span class="phpdocumentor-element-found-in__line">620</span>
 
     </aside>
 
@@ -2480,7 +2668,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">366</span>
+    <span class="phpdocumentor-element-found-in__line">391</span>
 
     </aside>
 
@@ -2515,7 +2703,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">395</span>
+    <span class="phpdocumentor-element-found-in__line">420</span>
 
     </aside>
 
@@ -2546,6 +2734,64 @@ It also collects metrics about the build process, such as duration and memory us
             -public
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_rememberAsset">
+        rememberAsset()
+        <a href="classes/Cecil-Builder.html#method_rememberAsset" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">520</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Returns an Asset from the registry or stores a newly created one.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">rememberAsset</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$cacheKey</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">callable&nbsp;</span><span class="phpdocumentor-signature__argument__name">$factory</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+        <section class="phpdocumentor-description"><p>Tracks hit/miss statistics for performance analysis.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$cacheKey</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$factory</span>
+                : <span class="phpdocumentor-argument-list__argument__type">callable</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_setConfig">
         setConfig()
         <a href="classes/Cecil-Builder.html#method_setConfig" class="headerlink"><i class="fas fa-link"></i></a>
@@ -2554,7 +2800,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">312</span>
+    <span class="phpdocumentor-element-found-in__line">337</span>
 
     </aside>
 
@@ -2603,7 +2849,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">427</span>
+    <span class="phpdocumentor-element-found-in__line">452</span>
 
     </aside>
 
@@ -2648,7 +2894,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">356</span>
+    <span class="phpdocumentor-element-found-in__line">381</span>
 
     </aside>
 
@@ -2697,7 +2943,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">379</span>
+    <span class="phpdocumentor-element-found-in__line">404</span>
 
     </aside>
 
@@ -2742,7 +2988,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">502</span>
+    <span class="phpdocumentor-element-found-in__line">562</span>
 
     </aside>
 
@@ -2787,7 +3033,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">468</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
@@ -2832,7 +3078,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">411</span>
+    <span class="phpdocumentor-element-found-in__line">436</span>
 
     </aside>
 
@@ -2877,7 +3123,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">534</span>
+    <span class="phpdocumentor-element-found-in__line">594</span>
 
     </aside>
 
@@ -2922,7 +3168,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">344</span>
+    <span class="phpdocumentor-element-found-in__line">369</span>
 
     </aside>
 
@@ -2971,7 +3217,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">452</span>
+    <span class="phpdocumentor-element-found-in__line">477</span>
 
     </aside>
 
@@ -3016,7 +3262,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">518</span>
+    <span class="phpdocumentor-element-found-in__line">578</span>
 
     </aside>
 
@@ -3061,7 +3307,7 @@ It also collects metrics about the build process, such as duration and memory us
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Builder.php"><a href="files/src-builder.html"><abbr title="src/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">589</span>
+    <span class="phpdocumentor-element-found-in__line">649</span>
 
     </aside>
 
@@ -3118,6 +3364,9 @@ It also collects metrics about the build process, such as duration and memory us
                             <li class="phpdocumentor-on-this-page-section__title">Properties</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
+                                                    <li class=""><a href="classes/Cecil-Builder.html#property_assetRegistry">$assetRegistry</a></li>
+                                                    <li class=""><a href="classes/Cecil-Builder.html#property_assetRegistryHits">$assetRegistryHits</a></li>
+                                                    <li class=""><a href="classes/Cecil-Builder.html#property_assetRegistryMisses">$assetRegistryMisses</a></li>
                                                     <li class=""><a href="classes/Cecil-Builder.html#property_assets">$assets</a></li>
                                                     <li class=""><a href="classes/Cecil-Builder.html#property_buildId">$buildId</a></li>
                                                     <li class=""><a href="classes/Cecil-Builder.html#property_config">$config</a></li>
@@ -3144,6 +3393,7 @@ It also collects metrics about the build process, such as duration and memory us
                                             <li class=""><a href="classes/Cecil-Builder.html#method_addToAssetsList">addToAssetsList()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_build">build()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_create">create()</a></li>
+                                            <li class=""><a href="classes/Cecil-Builder.html#method_getAssetRegistryStats">getAssetRegistryStats()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_getAssetsList">getAssetsList()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_getBuildId">getBuildId()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_getBuildOptions">getBuildOptions()</a></li>
@@ -3160,6 +3410,7 @@ It also collects metrics about the build process, such as duration and memory us
                                             <li class=""><a href="classes/Cecil-Builder.html#method_getVersion">getVersion()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_importThemesConfig">importThemesConfig()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_isDebug">isDebug()</a></li>
+                                            <li class=""><a href="classes/Cecil-Builder.html#method_rememberAsset">rememberAsset()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_setConfig">setConfig()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_setData">setData()</a></li>
                                             <li class=""><a href="classes/Cecil-Builder.html#method_setDestinationDir">setDestinationDir()</a></li>

--- a/docs/api/classes/Cecil-Command-Build.html
+++ b/docs/api/classes/Cecil-Command-Build.html
@@ -172,7 +172,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/Build.php"><a href="files/src-command-build.html"><abbr title="src/Command/Build.php">Build.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">37</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -942,7 +942,7 @@ It also allows building a specific page or a subset of pages, clearing the cache
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/Build.php"><a href="files/src-command-build.html"><abbr title="src/Command/Build.php">Build.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">42</span>
+    <span class="phpdocumentor-element-found-in__line">41</span>
 
     </aside>
 
@@ -977,7 +977,7 @@ It also allows building a specific page or a subset of pages, clearing the cache
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/Build.php"><a href="files/src-command-build.html"><abbr title="src/Command/Build.php">Build.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">101</span>
+    <span class="phpdocumentor-element-found-in__line">100</span>
 
     </aside>
 
@@ -1407,7 +1407,7 @@ It also allows building a specific page or a subset of pages, clearing the cache
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/Build.php"><a href="files/src-command-build.html"><abbr title="src/Command/Build.php">Build.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">209</span>
 
     </aside>
 
@@ -1459,7 +1459,7 @@ It also allows building a specific page or a subset of pages, clearing the cache
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/Build.php"><a href="files/src-command-build.html"><abbr title="src/Command/Build.php">Build.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">281</span>
+    <span class="phpdocumentor-element-found-in__line">290</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Command-DoctorSeo.html
+++ b/docs/api/classes/Cecil-Command-DoctorSeo.html
@@ -1595,7 +1595,7 @@ pages for a focused set of SEO checks inspired by editorial audit tools.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/DoctorSeo.php"><a href="files/src-command-doctorseo.html"><abbr title="src/Command/DoctorSeo.php">DoctorSeo.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">183</span>
+    <span class="phpdocumentor-element-found-in__line">184</span>
 
     </aside>
 
@@ -1650,7 +1650,7 @@ pages for a focused set of SEO checks inspired by editorial audit tools.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/DoctorSeo.php"><a href="files/src-command-doctorseo.html"><abbr title="src/Command/DoctorSeo.php">DoctorSeo.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">161</span>
+    <span class="phpdocumentor-element-found-in__line">162</span>
 
     </aside>
 
@@ -1705,7 +1705,7 @@ pages for a focused set of SEO checks inspired by editorial audit tools.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/DoctorSeo.php"><a href="files/src-command-doctorseo.html"><abbr title="src/Command/DoctorSeo.php">DoctorSeo.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">272</span>
+    <span class="phpdocumentor-element-found-in__line">277</span>
 
     </aside>
 
@@ -1805,7 +1805,7 @@ pages for a focused set of SEO checks inspired by editorial audit tools.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/DoctorSeo.php"><a href="files/src-command-doctorseo.html"><abbr title="src/Command/DoctorSeo.php">DoctorSeo.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">218</span>
+    <span class="phpdocumentor-element-found-in__line">219</span>
 
     </aside>
 
@@ -1857,7 +1857,7 @@ pages for a focused set of SEO checks inspired by editorial audit tools.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/DoctorSeo.php"><a href="files/src-command-doctorseo.html"><abbr title="src/Command/DoctorSeo.php">DoctorSeo.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">281</span>
+    <span class="phpdocumentor-element-found-in__line">286</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Command-ShowContent.html
+++ b/docs/api/classes/Cecil-Command-ShowContent.html
@@ -172,7 +172,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/ShowContent.php"><a href="files/src-command-showcontent.html"><abbr title="src/Command/ShowContent.php">ShowContent.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">35</span>
+    <span class="phpdocumentor-element-found-in__line">34</span>
 
     </aside>
 
@@ -370,11 +370,25 @@ It supports displaying content from specified directories and can filter files b
 <dd>Opens path with editor.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
-    <a class="" href="classes/Cecil-Command-ShowContent.html#method_getFilesTree">getFilesTree()</a>
+    <a class="" href="classes/Cecil-Command-ShowContent.html#method_buildSubdirectoryStructure">buildSubdirectoryStructure()</a>
     <span>
-                                &nbsp;: <a href="classes/Cecil-Command-ShowContent-FilenameRecursiveTreeIterator.html"><abbr title="\Cecil\Command\ShowContent\FilenameRecursiveTreeIterator">FilenameRecursiveTreeIterator</abbr></a>    </span>
+                                &nbsp;: array&lt;string, mixed&gt;    </span>
 </dt>
-<dd>Returns a console displayable tree of files.</dd>
+<dd>Build subdirectory tree structure recursively.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Command-ShowContent.html#method_buildTreeStructure">buildTreeStructure()</a>
+    <span>
+                                &nbsp;: array&lt;string, mixed&gt;    </span>
+</dt>
+<dd>Build a tree structure (array) from the directory, filtering by file extensions.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Command-ShowContent.html#method_getSortedItems">getSortedItems()</a>
+    <span>
+                                &nbsp;: array&lt;int, <abbr title="\SplFileInfo">SplFileInfo</abbr>&gt;    </span>
+</dt>
+<dd>Get sorted items (files first, then directories) from a directory.</dd>
 
     </dl>
 
@@ -935,7 +949,7 @@ It supports displaying content from specified directories and can filter files b
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/ShowContent.php"><a href="files/src-command-showcontent.html"><abbr title="src/Command/ShowContent.php">ShowContent.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -970,7 +984,7 @@ It supports displaying content from specified directories and can filter files b
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/ShowContent.php"><a href="files/src-command-showcontent.html"><abbr title="src/Command/ShowContent.php">ShowContent.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 
@@ -1406,23 +1420,23 @@ It supports displaying content from specified directories and can filter files b
             -private
                                                         "
 >
-    <h4 class="phpdocumentor-element__name" id="method_getFilesTree">
-        getFilesTree()
-        <a href="classes/Cecil-Command-ShowContent.html#method_getFilesTree" class="headerlink"><i class="fas fa-link"></i></a>
+    <h4 class="phpdocumentor-element__name" id="method_buildSubdirectoryStructure">
+        buildSubdirectoryStructure()
+        <a href="classes/Cecil-Command-ShowContent.html#method_buildSubdirectoryStructure" class="headerlink"><i class="fas fa-link"></i></a>
 
     </h4>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Command/ShowContent.php"><a href="files/src-command-showcontent.html"><abbr title="src/Command/ShowContent.php">ShowContent.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">118</span>
+    <span class="phpdocumentor-element-found-in__line">147</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Returns a console displayable tree of files.</p>
+        <p class="phpdocumentor-summary">Build subdirectory tree structure recursively.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-                    <span class="phpdocumentor-signature__name">getFilesTree</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$contentType</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Command-ShowContent-FilenameRecursiveTreeIterator.html"><abbr title="\Cecil\Command\ShowContent\FilenameRecursiveTreeIterator">FilenameRecursiveTreeIterator</abbr></a></span></code>
+                    <span class="phpdocumentor-signature__name">buildSubdirectoryStructure</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$path</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowedExtensions</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$excludedDirs</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string, mixed&gt;</span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -1431,8 +1445,22 @@ It supports displaying content from specified directories and can filter files b
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-argument-list__argument__name">$contentType</span>
+                <span class="phpdocumentor-argument-list__argument__name">$path</span>
                 : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$allowedExtensions</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$excludedDirs</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 
@@ -1440,9 +1468,65 @@ It supports displaying content from specified directories and can filter files b
             </dl>
 
     
-    <h5 class="phpdocumentor-tag-list__heading" id="method_getFilesTree_tags">
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">array&lt;string, mixed&gt;</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_buildTreeStructure">
+        buildTreeStructure()
+        <a href="classes/Cecil-Command-ShowContent.html#method_buildTreeStructure" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Command/ShowContent.php"><a href="files/src-command-showcontent.html"><abbr title="src/Command/ShowContent.php">ShowContent.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">114</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Build a tree structure (array) from the directory, filtering by file extensions.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">buildTreeStructure</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$path</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowedExtensions</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string, mixed&gt;</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$path</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$allowedExtensions</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="method_buildTreeStructure_tags">
         Tags
-        <a href="classes/Cecil-Command-ShowContent.html#method_getFilesTree_tags" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/Cecil-Command-ShowContent.html#method_buildTreeStructure_tags" class="headerlink"><i class="fas fa-link"></i></a>
 
     </h5>
     <dl class="phpdocumentor-tag-list">
@@ -1459,7 +1543,56 @@ It supports displaying content from specified directories and can filter files b
     
             <section>
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-        <span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Command-ShowContent-FilenameRecursiveTreeIterator.html"><abbr title="\Cecil\Command\ShowContent\FilenameRecursiveTreeIterator">FilenameRecursiveTreeIterator</abbr></a></span>
+        <span class="phpdocumentor-signature__response_type">array&lt;string, mixed&gt;</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getSortedItems">
+        getSortedItems()
+        <a href="classes/Cecil-Command-ShowContent.html#method_getSortedItems" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Command/ShowContent.php"><a href="files/src-command-showcontent.html"><abbr title="src/Command/ShowContent.php">ShowContent.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">173</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Get sorted items (files first, then directories) from a directory.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getSortedItems</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$path</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;int, <abbr title="\SplFileInfo">SplFileInfo</abbr>&gt;</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$path</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">array&lt;int, <abbr title="\SplFileInfo">SplFileInfo</abbr>&gt;</span>
             </section>
 
 </article>
@@ -1519,7 +1652,9 @@ It supports displaying content from specified directories and can filter files b
                                             <li class=""><a href="classes/Cecil-Command-AbstractCommand.html#method_locateAdditionalConfigFiles">locateAdditionalConfigFiles()</a></li>
                                             <li class=""><a href="classes/Cecil-Command-AbstractCommand.html#method_locateConfigFile">locateConfigFile()</a></li>
                                             <li class=""><a href="classes/Cecil-Command-AbstractCommand.html#method_openEditor">openEditor()</a></li>
-                                            <li class=""><a href="classes/Cecil-Command-ShowContent.html#method_getFilesTree">getFilesTree()</a></li>
+                                            <li class=""><a href="classes/Cecil-Command-ShowContent.html#method_buildSubdirectoryStructure">buildSubdirectoryStructure()</a></li>
+                                            <li class=""><a href="classes/Cecil-Command-ShowContent.html#method_buildTreeStructure">buildTreeStructure()</a></li>
+                                            <li class=""><a href="classes/Cecil-Command-ShowContent.html#method_getSortedItems">getSortedItems()</a></li>
                                     </ul>
             </li>
                     </ul>

--- a/docs/api/classes/Cecil-Converter-Converter.html
+++ b/docs/api/classes/Cecil-Converter-Converter.html
@@ -221,6 +221,13 @@ and to convert the body of content from Markdown to HTML.</p>
                         &nbsp;: <a href="classes/Cecil-Builder.html"><abbr title="\Cecil\Builder">Builder</abbr></a>            </span>
 </dt>
 
+            <dt class="phpdocumentor-table-of-contents__entry -property -private">
+    <a class="" href="classes/Cecil-Converter-Converter.html#property_parsedownCache">$parsedownCache</a>
+    <span>
+                        &nbsp;: array&lt;string, <a href="classes/Cecil-Converter-Parsedown.html"><abbr title="\Cecil\Converter\Parsedown">Parsedown</abbr></a>&gt;            </span>
+</dt>
+<dd>Parsedown instances keyed by language, shared across convertBody() calls.</dd>
+
     </dl>
 
 <h4 id="toc-methods">
@@ -327,6 +334,44 @@ and to convert the body of content from Markdown to HTML.</p>
         
 
 </article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -private
+                                                                    "
+>
+    <h4 class="phpdocumentor-element__name" id="property_parsedownCache">
+        $parsedownCache
+        <a href="classes/Cecil-Converter-Converter.html#property_parsedownCache" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Converter.php"><a href="files/src-converter-converter.html"><abbr title="src/Converter/Converter.php">Converter.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">59</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Parsedown instances keyed by language, shared across convertBody() calls.</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">private</span>
+            <span class="phpdocumentor-signature__type">array&lt;string, <a href="classes/Cecil-Converter-Parsedown.html"><abbr title="\Cecil\Converter\Parsedown">Parsedown</abbr></a>&gt;</span>
+    <span class="phpdocumentor-signature__name">$parsedownCache</span>
+     = <span class="phpdocumentor-signature__default-value">[]</span></code>
+
+    
+    
+    
+
+        
+        
+
+</article>
             </section>
 
             <section class="phpdocumentor-methods">
@@ -393,7 +438,7 @@ and to convert the body of content from Markdown to HTML.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Converter.php"><a href="files/src-converter-converter.html"><abbr title="src/Converter/Converter.php">Converter.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">58</span>
+    <span class="phpdocumentor-element-found-in__line">64</span>
 
     </aside>
 
@@ -519,7 +564,7 @@ and to convert the body of content from Markdown to HTML.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Converter.php"><a href="files/src-converter-converter.html"><abbr title="src/Converter/Converter.php">Converter.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">91</span>
+    <span class="phpdocumentor-element-found-in__line">100</span>
 
     </aside>
 
@@ -582,7 +627,7 @@ and to convert the body of content from Markdown to HTML.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Converter.php"><a href="files/src-converter-converter.html"><abbr title="src/Converter/Converter.php">Converter.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">127</span>
+    <span class="phpdocumentor-element-found-in__line">136</span>
 
     </aside>
 
@@ -645,7 +690,7 @@ and to convert the body of content from Markdown to HTML.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Converter.php"><a href="files/src-converter-converter.html"><abbr title="src/Converter/Converter.php">Converter.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">106</span>
+    <span class="phpdocumentor-element-found-in__line">115</span>
 
     </aside>
 
@@ -708,7 +753,7 @@ and to convert the body of content from Markdown to HTML.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Converter.php"><a href="files/src-converter-converter.html"><abbr title="src/Converter/Converter.php">Converter.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">70</span>
+    <span class="phpdocumentor-element-found-in__line">79</span>
 
     </aside>
 
@@ -780,6 +825,7 @@ and to convert the body of content from Markdown to HTML.</p>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                                                     <li class=""><a href="classes/Cecil-Converter-Converter.html#property_builder">$builder</a></li>
+                                                    <li class=""><a href="classes/Cecil-Converter-Converter.html#property_parsedownCache">$parsedownCache</a></li>
                                             </ul>
                 </li>
             

--- a/docs/api/classes/Cecil-Converter-Parsedown.html
+++ b/docs/api/classes/Cecil-Converter-Parsedown.html
@@ -233,15 +233,15 @@ and code highlighting.</p>
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a class="" href="classes/Cecil-Converter-Parsedown.html#property_assetCache">$assetCache</a>
-    <span>
-                        &nbsp;: array&lt;string, <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&gt;            </span>
-</dt>
-
-            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/Cecil-Converter-Parsedown.html#property_builder">$builder</a>
     <span>
                         &nbsp;: <a href="classes/Cecil-Builder.html"><abbr title="\Cecil\Builder">Builder</abbr></a>            </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#property_cacheBuildId">$cacheBuildId</a>
+    <span>
+                        &nbsp;: string|null            </span>
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
@@ -675,43 +675,6 @@ and code highlighting.</p>
             phpdocumentor-element
             -property
             -protected
-            -static                                                        "
->
-    <h4 class="phpdocumentor-element__name" id="property_assetCache">
-        $assetCache
-        <a href="classes/Cecil-Converter-Parsedown.html#property_assetCache" class="headerlink"><i class="fas fa-link"></i></a>
-
-        <span class="phpdocumentor-element__modifiers">
-                                            </span>
-    </h4>
-    <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
-    :
-    <span class="phpdocumentor-element-found-in__line">60</span>
-
-    </aside>
-
-    
-    
-    <code class="phpdocumentor-code phpdocumentor-signature ">
-        <span class="phpdocumentor-signature__visibility">protected</span>
-        <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&gt;</span>
-    <span class="phpdocumentor-signature__name">$assetCache</span>
-     = <span class="phpdocumentor-signature__default-value">[]</span></code>
-
-    
-    
-    
-
-        
-        
-
-</article>
-                    <article
-        class="
-            phpdocumentor-element
-            -property
-            -protected
                                                                     "
 >
     <h4 class="phpdocumentor-element__name" id="property_builder">
@@ -738,6 +701,45 @@ and code highlighting.</p>
 
     
     
+    
+
+        
+        
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+            -static                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_cacheBuildId">
+        $cacheBuildId
+        <a href="classes/Cecil-Converter-Parsedown.html#property_cacheBuildId" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">65</span>
+
+    </aside>
+
+    
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">protected</span>
+        <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">string|null</span>
+    <span class="phpdocumentor-signature__name">$cacheBuildId</span>
+     = <span class="phpdocumentor-signature__default-value">null</span></code>
+
+    
+        <section class="phpdocumentor-description"><p>Cache scope marker so static caches can be reset between builds.</p>
+</section>
+
     
 
         
@@ -836,7 +838,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">63</span>
+    <span class="phpdocumentor-element-found-in__line">60</span>
 
     </aside>
 
@@ -849,7 +851,9 @@ and code highlighting.</p>
      = <span class="phpdocumentor-signature__default-value">[]</span></code>
 
     
-    
+        <section class="phpdocumentor-description"><p>Stores image processing results to avoid redundant computations within a build.</p>
+</section>
+
     
 
         
@@ -873,7 +877,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">66</span>
+    <span class="phpdocumentor-element-found-in__line">68</span>
 
     </aside>
 
@@ -991,7 +995,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">70</span>
 
     </aside>
 
@@ -1042,7 +1046,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">607</span>
+    <span class="phpdocumentor-element-found-in__line">616</span>
 
     </aside>
 
@@ -1087,7 +1091,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">537</span>
+    <span class="phpdocumentor-element-found-in__line">546</span>
 
     </aside>
 
@@ -1132,7 +1136,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">560</span>
+    <span class="phpdocumentor-element-found-in__line">569</span>
 
     </aside>
 
@@ -1182,7 +1186,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">596</span>
+    <span class="phpdocumentor-element-found-in__line">605</span>
 
     </aside>
 
@@ -1226,7 +1230,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">581</span>
+    <span class="phpdocumentor-element-found-in__line">590</span>
 
     </aside>
 
@@ -1277,7 +1281,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">694</span>
+    <span class="phpdocumentor-element-found-in__line">703</span>
 
     </aside>
 
@@ -1328,7 +1332,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">243</span>
+    <span class="phpdocumentor-element-found-in__line">252</span>
 
     </aside>
 
@@ -1373,7 +1377,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">263</span>
+    <span class="phpdocumentor-element-found-in__line">272</span>
 
     </aside>
 
@@ -1418,7 +1422,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">112</span>
+    <span class="phpdocumentor-element-found-in__line">121</span>
 
     </aside>
 
@@ -1465,7 +1469,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">133</span>
+    <span class="phpdocumentor-element-found-in__line">142</span>
 
     </aside>
 
@@ -1510,7 +1514,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">213</span>
+    <span class="phpdocumentor-element-found-in__line">222</span>
 
     </aside>
 
@@ -1555,7 +1559,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">228</span>
+    <span class="phpdocumentor-element-found-in__line">237</span>
 
     </aside>
 
@@ -1600,7 +1604,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">641</span>
+    <span class="phpdocumentor-element-found-in__line">650</span>
 
     </aside>
 
@@ -1645,7 +1649,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">682</span>
+    <span class="phpdocumentor-element-found-in__line">691</span>
 
     </aside>
 
@@ -1696,7 +1700,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">895</span>
+    <span class="phpdocumentor-element-found-in__line">907</span>
 
     </aside>
 
@@ -1752,7 +1756,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">953</span>
+    <span class="phpdocumentor-element-found-in__line">965</span>
 
     </aside>
 
@@ -1801,7 +1805,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">853</span>
+    <span class="phpdocumentor-element-found-in__line">859</span>
 
     </aside>
 
@@ -1857,7 +1861,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">935</span>
+    <span class="phpdocumentor-element-found-in__line">947</span>
 
     </aside>
 
@@ -1913,7 +1917,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">807</span>
+    <span class="phpdocumentor-element-found-in__line">816</span>
 
     </aside>
 
@@ -1961,7 +1965,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">722</span>
+    <span class="phpdocumentor-element-found-in__line">731</span>
 
     </aside>
 
@@ -2016,7 +2020,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">787</span>
+    <span class="phpdocumentor-element-found-in__line">796</span>
 
     </aside>
 
@@ -2085,7 +2089,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">733</span>
+    <span class="phpdocumentor-element-found-in__line">742</span>
 
     </aside>
 
@@ -2133,7 +2137,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">742</span>
+    <span class="phpdocumentor-element-found-in__line">751</span>
 
     </aside>
 
@@ -2181,7 +2185,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">778</span>
+    <span class="phpdocumentor-element-found-in__line">787</span>
 
     </aside>
 
@@ -2236,7 +2240,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">769</span>
+    <span class="phpdocumentor-element-found-in__line">778</span>
 
     </aside>
 
@@ -2291,7 +2295,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">760</span>
+    <span class="phpdocumentor-element-found-in__line">769</span>
 
     </aside>
 
@@ -2346,7 +2350,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">819</span>
+    <span class="phpdocumentor-element-found-in__line">828</span>
 
     </aside>
 
@@ -2401,7 +2405,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">991</span>
+    <span class="phpdocumentor-element-found-in__line">1003</span>
 
     </aside>
 
@@ -2450,7 +2454,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">751</span>
+    <span class="phpdocumentor-element-found-in__line">760</span>
 
     </aside>
 
@@ -2498,7 +2502,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">706</span>
+    <span class="phpdocumentor-element-found-in__line">715</span>
 
     </aside>
 
@@ -2551,7 +2555,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">827</span>
+    <span class="phpdocumentor-element-found-in__line">836</span>
 
     </aside>
 
@@ -2607,7 +2611,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">840</span>
+    <span class="phpdocumentor-element-found-in__line">846</span>
 
     </aside>
 
@@ -2678,8 +2682,8 @@ and code highlighting.</p>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_inlineMarkerList">$inlineMarkerList</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_InlineTypes">$InlineTypes</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_specialCharacters">$specialCharacters</a></li>
-                                                    <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_assetCache">$assetCache</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_builder">$builder</a></li>
+                                                    <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_cacheBuildId">$cacheBuildId</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_config">$config</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_highlighter">$highlighter</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_imageProcessingCache">$imageProcessingCache</a></li>

--- a/docs/api/classes/Cecil-Converter-Parsedown.html
+++ b/docs/api/classes/Cecil-Converter-Parsedown.html
@@ -233,6 +233,12 @@ and code highlighting.</p>
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#property_assetCache">$assetCache</a>
+    <span>
+                        &nbsp;: array&lt;string, <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&gt;            </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/Cecil-Converter-Parsedown.html#property_builder">$builder</a>
     <span>
                         &nbsp;: <a href="classes/Cecil-Builder.html"><abbr title="\Cecil\Builder">Builder</abbr></a>            </span>
@@ -248,6 +254,13 @@ and code highlighting.</p>
     <a class="" href="classes/Cecil-Converter-Parsedown.html#property_highlighter">$highlighter</a>
     <span>
                         &nbsp;: <abbr title="\Highlight\Highlighter">Highlighter</abbr>            </span>
+</dt>
+<dd>Shared across all instances: registerAllLanguages() scans 185 files but $classMap is static</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#property_imageProcessingCache">$imageProcessingCache</a>
+    <span>
+                        &nbsp;: array&lt;string, mixed&gt;            </span>
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
@@ -409,6 +422,60 @@ and code highlighting.</p>
 <dd>Create a script element from a link element and an URL.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getAssetIdentity">getAssetIdentity()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCachedAsset">getCachedAsset()</a>
+    <span>
+                                &nbsp;: <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCachedDarkSourceAttributes">getCachedDarkSourceAttributes()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCachedDominantColor">getCachedDominantColor()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCachedLqip">getCachedLqip()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCachedSizes">getCachedSizes()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCachedSrcset">getCachedSrcset()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCachedSrcsetW">getCachedSrcsetW()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_getCacheKey">getCacheKey()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a class="" href="classes/Cecil-Converter-Parsedown.html#method_handleExternalLink">handleExternalLink()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
@@ -416,11 +483,31 @@ and code highlighting.</p>
 <dd>Handle an external link.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_isAnimatedGifCached">isAnimatedGifCached()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a class="" href="classes/Cecil-Converter-Parsedown.html#method_normalizePath">normalizePath()</a>
     <span>
                                 &nbsp;: string    </span>
 </dt>
 <dd>Turns a path relative to static or assets into a website relative path.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_rememberAsset">rememberAsset()</a>
+    <span>
+                                &nbsp;: <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>    </span>
+</dt>
+<dd>Memoize an Asset instance across Parsedown instances.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Converter-Parsedown.html#method_rememberImageProcessing">rememberImageProcessing()</a>
+    <span>
+                                &nbsp;: mixed    </span>
+</dt>
+<dd>Memoize an image-processing result across Parsedown instances.</dd>
 
     </dl>
 
@@ -588,6 +675,43 @@ and code highlighting.</p>
             phpdocumentor-element
             -property
             -protected
+            -static                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_assetCache">
+        $assetCache
+        <a href="classes/Cecil-Converter-Parsedown.html#property_assetCache" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">60</span>
+
+    </aside>
+
+    
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">protected</span>
+        <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, <a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&gt;</span>
+    <span class="phpdocumentor-signature__name">$assetCache</span>
+     = <span class="phpdocumentor-signature__default-value">[]</span></code>
+
+    
+    
+    
+
+        
+        
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
                                                                     "
 >
     <h4 class="phpdocumentor-element__name" id="property_builder">
@@ -662,7 +786,7 @@ and code highlighting.</p>
             phpdocumentor-element
             -property
             -protected
-                                                                    "
+            -static                                                        "
 >
     <h4 class="phpdocumentor-element__name" id="property_highlighter">
         $highlighter
@@ -678,13 +802,51 @@ and code highlighting.</p>
 
     </aside>
 
+        <p class="phpdocumentor-summary">Shared across all instances: registerAllLanguages() scans 185 files but $classMap is static</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">protected</span>
+        <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type"><abbr title="\Highlight\Highlighter">Highlighter</abbr></span>
+    <span class="phpdocumentor-signature__name">$highlighter</span>
+    </code>
+
+    
+    
+    
+
+        
+        
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+            -static                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_imageProcessingCache">
+        $imageProcessingCache
+        <a href="classes/Cecil-Converter-Parsedown.html#property_imageProcessingCache" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">63</span>
+
+    </aside>
+
     
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
         <span class="phpdocumentor-signature__visibility">protected</span>
-            <span class="phpdocumentor-signature__type"><abbr title="\Highlight\Highlighter">Highlighter</abbr></span>
-    <span class="phpdocumentor-signature__name">$highlighter</span>
-    </code>
+        <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, mixed&gt;</span>
+    <span class="phpdocumentor-signature__name">$imageProcessingCache</span>
+     = <span class="phpdocumentor-signature__default-value">[]</span></code>
 
     
     
@@ -711,7 +873,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">60</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 
@@ -829,7 +991,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">62</span>
+    <span class="phpdocumentor-element-found-in__line">68</span>
 
     </aside>
 
@@ -880,7 +1042,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">602</span>
+    <span class="phpdocumentor-element-found-in__line">607</span>
 
     </aside>
 
@@ -925,7 +1087,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">532</span>
+    <span class="phpdocumentor-element-found-in__line">537</span>
 
     </aside>
 
@@ -970,7 +1132,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">555</span>
+    <span class="phpdocumentor-element-found-in__line">560</span>
 
     </aside>
 
@@ -1020,7 +1182,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">591</span>
+    <span class="phpdocumentor-element-found-in__line">596</span>
 
     </aside>
 
@@ -1064,7 +1226,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">576</span>
+    <span class="phpdocumentor-element-found-in__line">581</span>
 
     </aside>
 
@@ -1115,7 +1277,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">689</span>
+    <span class="phpdocumentor-element-found-in__line">694</span>
 
     </aside>
 
@@ -1166,7 +1328,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">234</span>
+    <span class="phpdocumentor-element-found-in__line">243</span>
 
     </aside>
 
@@ -1211,7 +1373,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">254</span>
+    <span class="phpdocumentor-element-found-in__line">263</span>
 
     </aside>
 
@@ -1256,7 +1418,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">103</span>
+    <span class="phpdocumentor-element-found-in__line">112</span>
 
     </aside>
 
@@ -1303,7 +1465,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">124</span>
+    <span class="phpdocumentor-element-found-in__line">133</span>
 
     </aside>
 
@@ -1348,7 +1510,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">204</span>
+    <span class="phpdocumentor-element-found-in__line">213</span>
 
     </aside>
 
@@ -1393,7 +1555,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">219</span>
+    <span class="phpdocumentor-element-found-in__line">228</span>
 
     </aside>
 
@@ -1438,7 +1600,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">636</span>
+    <span class="phpdocumentor-element-found-in__line">641</span>
 
     </aside>
 
@@ -1483,7 +1645,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">677</span>
+    <span class="phpdocumentor-element-found-in__line">682</span>
 
     </aside>
 
@@ -1534,7 +1696,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">762</span>
+    <span class="phpdocumentor-element-found-in__line">895</span>
 
     </aside>
 
@@ -1590,7 +1752,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">820</span>
+    <span class="phpdocumentor-element-found-in__line">953</span>
 
     </aside>
 
@@ -1639,7 +1801,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">720</span>
+    <span class="phpdocumentor-element-found-in__line">853</span>
 
     </aside>
 
@@ -1695,7 +1857,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">802</span>
+    <span class="phpdocumentor-element-found-in__line">935</span>
 
     </aside>
 
@@ -1743,6 +1905,494 @@ and code highlighting.</p>
             -private
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_getAssetIdentity">
+        getAssetIdentity()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getAssetIdentity" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">807</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getAssetIdentity</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$asset</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$asset</span>
+                : <span class="phpdocumentor-argument-list__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">string</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCachedAsset">
+        getCachedAsset()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCachedAsset" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">722</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCachedAsset</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$path</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$assetOptions</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$path</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$assetOptions</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCachedDarkSourceAttributes">
+        getCachedDarkSourceAttributes()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCachedDarkSourceAttributes" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">787</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCachedDarkSourceAttributes</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$asset</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$darkSuffix</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$formats</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$options</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$asset</span>
+                : <span class="phpdocumentor-argument-list__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$darkSuffix</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$formats</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$options</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCachedDominantColor">
+        getCachedDominantColor()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCachedDominantColor" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">733</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCachedDominantColor</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$asset</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$asset</span>
+                : <span class="phpdocumentor-argument-list__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">string</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCachedLqip">
+        getCachedLqip()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCachedLqip" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">742</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCachedLqip</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$asset</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$asset</span>
+                : <span class="phpdocumentor-argument-list__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">string</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCachedSizes">
+        getCachedSizes()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCachedSizes" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">778</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCachedSizes</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$class</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$sizesConfig</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$class</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$sizesConfig</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">string</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCachedSrcset">
+        getCachedSrcset()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCachedSrcset" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">769</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCachedSrcset</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$asset</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$widths</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$asset</span>
+                : <span class="phpdocumentor-argument-list__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$widths</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">string</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCachedSrcsetW">
+        getCachedSrcsetW()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCachedSrcsetW" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">760</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCachedSrcsetW</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$asset</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$widths</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$asset</span>
+                : <span class="phpdocumentor-argument-list__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$widths</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">string</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getCacheKey">
+        getCacheKey()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_getCacheKey" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">819</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getCacheKey</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$prefix</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$payload</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$prefix</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$payload</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">string</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_handleExternalLink">
         handleExternalLink()
         <a href="classes/Cecil-Converter-Parsedown.html#method_handleExternalLink" class="headerlink"><i class="fas fa-link"></i></a>
@@ -1751,7 +2401,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">858</span>
+    <span class="phpdocumentor-element-found-in__line">991</span>
 
     </aside>
 
@@ -1792,6 +2442,54 @@ and code highlighting.</p>
             -private
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_isAnimatedGifCached">
+        isAnimatedGifCached()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_isAnimatedGifCached" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">751</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">isAnimatedGifCached</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$asset</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$asset</span>
+                : <span class="phpdocumentor-argument-list__argument__type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">bool</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_normalizePath">
         normalizePath()
         <a href="classes/Cecil-Converter-Parsedown.html#method_normalizePath" class="headerlink"><i class="fas fa-link"></i></a>
@@ -1800,7 +2498,7 @@ and code highlighting.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">701</span>
+    <span class="phpdocumentor-element-found-in__line">706</span>
 
     </aside>
 
@@ -1839,6 +2537,121 @@ and code highlighting.</p>
             </section>
 
 </article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_rememberAsset">
+        rememberAsset()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_rememberAsset" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">827</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Memoize an Asset instance across Parsedown instances.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">rememberAsset</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$payload</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">callable&nbsp;</span><span class="phpdocumentor-signature__argument__name">$factory</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$payload</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$factory</span>
+                : <span class="phpdocumentor-argument-list__argument__type">callable</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Asset.html"><abbr title="\Cecil\Asset">Asset</abbr></a></span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_rememberImageProcessing">
+        rememberImageProcessing()
+        <a href="classes/Cecil-Converter-Parsedown.html#method_rememberImageProcessing" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Converter/Parsedown.php"><a href="files/src-converter-parsedown.html"><abbr title="src/Converter/Parsedown.php">Parsedown.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">840</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Memoize an image-processing result across Parsedown instances.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">rememberImageProcessing</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$prefix</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$payload</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__type">callable&nbsp;</span><span class="phpdocumentor-signature__argument__name">$factory</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$prefix</span>
+                : <span class="phpdocumentor-argument-list__argument__type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$payload</span>
+                : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-argument-list__argument__name">$factory</span>
+                : <span class="phpdocumentor-argument-list__argument__type">callable</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+            </dl>
+
+    
+
+        
+    
+    
+</article>
             </section>
 
         
@@ -1865,9 +2678,11 @@ and code highlighting.</p>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_inlineMarkerList">$inlineMarkerList</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_InlineTypes">$InlineTypes</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_specialCharacters">$specialCharacters</a></li>
+                                                    <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_assetCache">$assetCache</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_builder">$builder</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_config">$config</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_highlighter">$highlighter</a></li>
+                                                    <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_imageProcessingCache">$imageProcessingCache</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_language">$language</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_regexAttribute">$regexAttribute</a></li>
                                                     <li class=""><a href="classes/Cecil-Converter-Parsedown.html#property_regexImage">$regexImage</a></li>
@@ -1896,8 +2711,20 @@ and code highlighting.</p>
                                             <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_createFigure">createFigure()</a></li>
                                             <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_createMediaFromLink">createMediaFromLink()</a></li>
                                             <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_createScriptFromLink">createScriptFromLink()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getAssetIdentity">getAssetIdentity()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCachedAsset">getCachedAsset()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCachedDarkSourceAttributes">getCachedDarkSourceAttributes()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCachedDominantColor">getCachedDominantColor()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCachedLqip">getCachedLqip()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCachedSizes">getCachedSizes()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCachedSrcset">getCachedSrcset()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCachedSrcsetW">getCachedSrcsetW()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_getCacheKey">getCacheKey()</a></li>
                                             <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_handleExternalLink">handleExternalLink()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_isAnimatedGifCached">isAnimatedGifCached()</a></li>
                                             <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_normalizePath">normalizePath()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_rememberAsset">rememberAsset()</a></li>
+                                            <li class=""><a href="classes/Cecil-Converter-Parsedown.html#method_rememberImageProcessing">rememberImageProcessing()</a></li>
                                     </ul>
             </li>
                     </ul>

--- a/docs/api/classes/Cecil-Step-Pages-Convert.html
+++ b/docs/api/classes/Cecil-Step-Pages-Convert.html
@@ -558,7 +558,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Pages/Convert.php"><a href="files/src-step-pages-convert.html"><abbr title="src/Step/Pages/Convert.php">Convert.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">112</span>
+    <span class="phpdocumentor-element-found-in__line">113</span>
 
     </aside>
 

--- a/docs/api/indices/files.html
+++ b/docs/api/indices/files.html
@@ -219,8 +219,6 @@
                                                         <h3>F</h3>
             <ul class="phpdocumentor-list">
                             <li><a href="files/src-util-file.html"><abbr title="src/Util/File.php">File.php</abbr></a></li>
-                            <li><a href="files/src-command-showcontent-fileextensionfilter.html"><abbr title="src/Command/ShowContent/FileExtensionFilter.php">FileExtensionFilter.php</abbr></a></li>
-                            <li><a href="files/src-command-showcontent-filenamerecursivetreeiterator.html"><abbr title="src/Command/ShowContent/FilenameRecursiveTreeIterator.php">FilenameRecursiveTreeIterator.php</abbr></a></li>
                             <li><a href="files/src-doctor-frontmatterdoctor.html"><abbr title="src/Doctor/FrontmatterDoctor.php">FrontmatterDoctor.php</abbr></a></li>
                         </ul>
                                                         <h3>G</h3>

--- a/docs/api/js/searchIndex.js
+++ b/docs/api/js/searchIndex.js
@@ -2516,46 +2516,6 @@ Search.appendIndex(
             "summary": "Converts\u0020an\u0020array\u0020to\u0020YAML.",
             "url": "classes/Cecil-Command-ShowConfig.html#method_arrayToYaml"
         },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FileExtensionFilter",
-            "name": "FileExtensionFilter",
-            "summary": "FileExtensionFilter\u0020class.",
-            "url": "classes/Cecil-Command-ShowContent-FileExtensionFilter.html"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FileExtensionFilter\u003A\u003A__construct\u0028\u0029",
-            "name": "__construct",
-            "summary": "",
-            "url": "classes/Cecil-Command-ShowContent-FileExtensionFilter.html#method___construct"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FileExtensionFilter\u003A\u003AgetChildren\u0028\u0029",
-            "name": "getChildren",
-            "summary": "Get\u0020children\u0020with\u0020allowed\u0020extensions.",
-            "url": "classes/Cecil-Command-ShowContent-FileExtensionFilter.html#method_getChildren"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FileExtensionFilter\u003A\u003Aaccept\u0028\u0029",
-            "name": "accept",
-            "summary": "Valid\u0020file\u0020with\u0020allowed\u0020extensions.",
-            "url": "classes/Cecil-Command-ShowContent-FileExtensionFilter.html#method_accept"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FileExtensionFilter\u003A\u003A\u0024allowedExt",
-            "name": "allowedExt",
-            "summary": "",
-            "url": "classes/Cecil-Command-ShowContent-FileExtensionFilter.html#property_allowedExt"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FileExtensionFilter\u003A\u003A\u0024excludedDir",
-            "name": "excludedDir",
-            "summary": "",
-            "url": "classes/Cecil-Command-ShowContent-FileExtensionFilter.html#property_excludedDir"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FilenameRecursiveTreeIterator",
-            "name": "FilenameRecursiveTreeIterator",
-            "summary": "FilenameRecursiveTreeIterator\u0020class.",
-            "url": "classes/Cecil-Command-ShowContent-FilenameRecursiveTreeIterator.html"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\\FilenameRecursiveTreeIterator\u003A\u003Acurrent\u0028\u0029",
-            "name": "current",
-            "summary": "",
-            "url": "classes/Cecil-Command-ShowContent-FilenameRecursiveTreeIterator.html#method_current"
-        },                {
             "fqsen": "\\Cecil\\Command\\ShowContent",
             "name": "ShowContent",
             "summary": "ShowContent\u0020command.",
@@ -2571,10 +2531,20 @@ Search.appendIndex(
             "summary": "\u007B\u0040inheritdoc\u007D",
             "url": "classes/Cecil-Command-ShowContent.html#method_execute"
         },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent\u003A\u003AgetFilesTree\u0028\u0029",
-            "name": "getFilesTree",
-            "summary": "Returns\u0020a\u0020console\u0020displayable\u0020tree\u0020of\u0020files.",
-            "url": "classes/Cecil-Command-ShowContent.html#method_getFilesTree"
+            "fqsen": "\\Cecil\\Command\\ShowContent\u003A\u003AbuildTreeStructure\u0028\u0029",
+            "name": "buildTreeStructure",
+            "summary": "Build\u0020a\u0020tree\u0020structure\u0020\u0028array\u0029\u0020from\u0020the\u0020directory,\u0020filtering\u0020by\u0020file\u0020extensions.",
+            "url": "classes/Cecil-Command-ShowContent.html#method_buildTreeStructure"
+        },                {
+            "fqsen": "\\Cecil\\Command\\ShowContent\u003A\u003AbuildSubdirectoryStructure\u0028\u0029",
+            "name": "buildSubdirectoryStructure",
+            "summary": "Build\u0020subdirectory\u0020tree\u0020structure\u0020recursively.",
+            "url": "classes/Cecil-Command-ShowContent.html#method_buildSubdirectoryStructure"
+        },                {
+            "fqsen": "\\Cecil\\Command\\ShowContent\u003A\u003AgetSortedItems\u0028\u0029",
+            "name": "getSortedItems",
+            "summary": "Get\u0020sorted\u0020items\u0020\u0028files\u0020first,\u0020then\u0020directories\u0029\u0020from\u0020a\u0020directory.",
+            "url": "classes/Cecil-Command-ShowContent.html#method_getSortedItems"
         },                {
             "fqsen": "\\Cecil\\Command\\Stop",
             "name": "Stop",
@@ -2991,6 +2961,11 @@ Search.appendIndex(
             "summary": "",
             "url": "classes/Cecil-Converter-Converter.html#property_builder"
         },                {
+            "fqsen": "\\Cecil\\Converter\\Converter\u003A\u003A\u0024parsedownCache",
+            "name": "parsedownCache",
+            "summary": "Parsedown\u0020instances\u0020keyed\u0020by\u0020language,\u0020shared\u0020across\u0020convertBody\u0028\u0029\u0020calls.",
+            "url": "classes/Cecil-Converter-Converter.html#property_parsedownCache"
+        },                {
             "fqsen": "\\Cecil\\Converter\\ConverterInterface",
             "name": "ConverterInterface",
             "summary": "Converter\u0020interface.",
@@ -3091,6 +3066,66 @@ Search.appendIndex(
             "summary": "Turns\u0020a\u0020path\u0020relative\u0020to\u0020static\u0020or\u0020assets\u0020into\u0020a\u0020website\u0020relative\u0020path.",
             "url": "classes/Cecil-Converter-Parsedown.html#method_normalizePath"
         },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCachedAsset\u0028\u0029",
+            "name": "getCachedAsset",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCachedAsset"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCachedDominantColor\u0028\u0029",
+            "name": "getCachedDominantColor",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCachedDominantColor"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCachedLqip\u0028\u0029",
+            "name": "getCachedLqip",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCachedLqip"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AisAnimatedGifCached\u0028\u0029",
+            "name": "isAnimatedGifCached",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_isAnimatedGifCached"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCachedSrcsetW\u0028\u0029",
+            "name": "getCachedSrcsetW",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCachedSrcsetW"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCachedSrcset\u0028\u0029",
+            "name": "getCachedSrcset",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCachedSrcset"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCachedSizes\u0028\u0029",
+            "name": "getCachedSizes",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCachedSizes"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCachedDarkSourceAttributes\u0028\u0029",
+            "name": "getCachedDarkSourceAttributes",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCachedDarkSourceAttributes"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetAssetIdentity\u0028\u0029",
+            "name": "getAssetIdentity",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getAssetIdentity"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AgetCacheKey\u0028\u0029",
+            "name": "getCacheKey",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_getCacheKey"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003ArememberAsset\u0028\u0029",
+            "name": "rememberAsset",
+            "summary": "Memoize\u0020an\u0020Asset\u0020instance\u0020across\u0020Parsedown\u0020instances.",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_rememberAsset"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003ArememberImageProcessing\u0028\u0029",
+            "name": "rememberImageProcessing",
+            "summary": "Memoize\u0020an\u0020image\u002Dprocessing\u0020result\u0020across\u0020Parsedown\u0020instances.",
+            "url": "classes/Cecil-Converter-Parsedown.html#method_rememberImageProcessing"
+        },                {
             "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003AcreateMediaFromLink\u0028\u0029",
             "name": "createMediaFromLink",
             "summary": "Create\u0020a\u0020media\u0020\u0028video\u0020or\u0020audio\u0029\u0020element\u0020from\u0020a\u0020link.",
@@ -3138,8 +3173,18 @@ Search.appendIndex(
         },                {
             "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024highlighter",
             "name": "highlighter",
-            "summary": "",
+            "summary": "Shared\u0020across\u0020all\u0020instances\u003A\u0020registerAllLanguages\u0028\u0029\u0020scans\u0020185\u0020files\u0020but\u0020\u0024classMap\u0020is\u0020static",
             "url": "classes/Cecil-Converter-Parsedown.html#property_highlighter"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024assetCache",
+            "name": "assetCache",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#property_assetCache"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024imageProcessingCache",
+            "name": "imageProcessingCache",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#property_imageProcessingCache"
         },                {
             "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024language",
             "name": "language",
@@ -5310,11 +5355,6 @@ Search.appendIndex(
             "name": "Console",
             "summary": "",
             "url": "namespaces/cecil-command-console.html"
-        },                {
-            "fqsen": "\\Cecil\\Command\\ShowContent",
-            "name": "ShowContent",
-            "summary": "",
-            "url": "namespaces/cecil-command-showcontent.html"
         },                {
             "fqsen": "\\Cecil\\Converter",
             "name": "Converter",

--- a/docs/api/js/searchIndex.js
+++ b/docs/api/js/searchIndex.js
@@ -636,6 +636,16 @@ Search.appendIndex(
             "summary": "Add\u0020an\u0020asset\u0020path\u0020to\u0020assets\u0020list.",
             "url": "classes/Cecil-Builder.html#method_addToAssetsList"
         },                {
+            "fqsen": "\\Cecil\\Builder\u003A\u003ArememberAsset\u0028\u0029",
+            "name": "rememberAsset",
+            "summary": "Returns\u0020an\u0020Asset\u0020from\u0020the\u0020registry\u0020or\u0020stores\u0020a\u0020newly\u0020created\u0020one.",
+            "url": "classes/Cecil-Builder.html#method_rememberAsset"
+        },                {
+            "fqsen": "\\Cecil\\Builder\u003A\u003AgetAssetRegistryStats\u0028\u0029",
+            "name": "getAssetRegistryStats",
+            "summary": "Returns\u0020asset\u0020registry\u0020deduplication\u0020statistics.",
+            "url": "classes/Cecil-Builder.html#method_getAssetRegistryStats"
+        },                {
             "fqsen": "\\Cecil\\Builder\u003A\u003AgetAssetsList\u0028\u0029",
             "name": "getAssetsList",
             "summary": "Returns\u0020list\u0020of\u0020assets\u0020path.",
@@ -775,6 +785,21 @@ Search.appendIndex(
             "name": "assets",
             "summary": "Assets\u0020path\u0020collection.",
             "url": "classes/Cecil-Builder.html#property_assets"
+        },                {
+            "fqsen": "\\Cecil\\Builder\u003A\u003A\u0024assetRegistry",
+            "name": "assetRegistry",
+            "summary": "In\u002Dmemory\u0020registry\u0020used\u0020to\u0020deduplicate\u0020asset\u0020objects\u0020during\u0020a\u0020build.",
+            "url": "classes/Cecil-Builder.html#property_assetRegistry"
+        },                {
+            "fqsen": "\\Cecil\\Builder\u003A\u003A\u0024assetRegistryHits",
+            "name": "assetRegistryHits",
+            "summary": "Counter\u0020for\u0020asset\u0020registry\u0020cache\u0020hits\u0020during\u0020conversion\u0020steps.",
+            "url": "classes/Cecil-Builder.html#property_assetRegistryHits"
+        },                {
+            "fqsen": "\\Cecil\\Builder\u003A\u003A\u0024assetRegistryMisses",
+            "name": "assetRegistryMisses",
+            "summary": "Counter\u0020for\u0020asset\u0020registry\u0020cache\u0020misses\u0020\u0028new\u0020assets\u0020created\u0029\u0020during\u0020conversion\u0020steps.",
+            "url": "classes/Cecil-Builder.html#property_assetRegistryMisses"
         },                {
             "fqsen": "\\Cecil\\Builder\u003A\u003A\u0024menus",
             "name": "menus",
@@ -3176,15 +3201,15 @@ Search.appendIndex(
             "summary": "Shared\u0020across\u0020all\u0020instances\u003A\u0020registerAllLanguages\u0028\u0029\u0020scans\u0020185\u0020files\u0020but\u0020\u0024classMap\u0020is\u0020static",
             "url": "classes/Cecil-Converter-Parsedown.html#property_highlighter"
         },                {
-            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024assetCache",
-            "name": "assetCache",
-            "summary": "",
-            "url": "classes/Cecil-Converter-Parsedown.html#property_assetCache"
-        },                {
             "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024imageProcessingCache",
             "name": "imageProcessingCache",
             "summary": "",
             "url": "classes/Cecil-Converter-Parsedown.html#property_imageProcessingCache"
+        },                {
+            "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024cacheBuildId",
+            "name": "cacheBuildId",
+            "summary": "",
+            "url": "classes/Cecil-Converter-Parsedown.html#property_cacheBuildId"
         },                {
             "fqsen": "\\Cecil\\Converter\\Parsedown\u003A\u003A\u0024language",
             "name": "language",

--- a/docs/api/namespaces/cecil-command.html
+++ b/docs/api/namespaces/cecil-command.html
@@ -169,7 +169,6 @@
 </h4>
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/cecil-command-console.html"><abbr title="\Cecil\Command\Console">Console</abbr></a></dt>
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/cecil-command-showcontent.html"><abbr title="\Cecil\Command\ShowContent">ShowContent</abbr></a></dt>
     </dl>
 
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -158,6 +158,16 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
      */
     protected $assetRegistry = [];
     /**
+     * Counter for asset registry cache hits during conversion steps.
+     * @var int
+     */
+    protected $assetRegistryHits = 0;
+    /**
+     * Counter for asset registry cache misses (new assets created) during conversion steps.
+     * @var int
+     */
+    protected $assetRegistryMisses = 0;
+    /**
      * Menus collection.
      * This is an associative array that holds menus for different languages.
      * Each key is a language code, and the value is a Collection\Menu\Collection instance
@@ -268,6 +278,8 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
 
         // reset in-memory registries for this build
         $this->assetRegistry = [];
+        $this->assetRegistryHits = 0;
+        $this->assetRegistryMisses = 0;
 
         // set build ID
         self::$buildId = hash('adler32', date('YmdHis') . self::$version);
@@ -309,6 +321,11 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
         $this->metrics['total']['duration'] = Util::convertDuration($totalDuration);
         $this->metrics['total']['duration_raw'] = round($totalDuration * 1000, 2);
         $this->metrics['total']['memory']   = Util::convertMemory(memory_get_usage() - $startMemory);
+
+        // store asset registry metrics
+        $this->metrics['registry'] = $this->getAssetRegistryStats();
+
+        // log final build notice
         $this->getLogger()->notice(\sprintf('Built in %s (%s)', $this->metrics['total']['duration'], $this->metrics['total']['memory']));
 
         return $this;
@@ -498,6 +515,7 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
 
     /**
      * Returns an Asset from the registry or stores a newly created one.
+     * Tracks hit/miss statistics for performance analysis.
      */
     public function rememberAsset(string $cacheKey, callable $factory): Asset
     {
@@ -507,9 +525,27 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
                 throw new RuntimeException(\sprintf('Asset registry factory must return an Asset ("%s" returned).', \get_debug_type($asset)));
             }
             $this->assetRegistry[$cacheKey] = $asset;
+            $this->assetRegistryMisses++;
+        } else {
+            $this->assetRegistryHits++;
         }
 
         return $this->assetRegistry[$cacheKey];
+    }
+
+    /**
+     * Returns asset registry deduplication statistics.
+     */
+    public function getAssetRegistryStats(): array
+    {
+        return [
+            'hits' => $this->assetRegistryHits,
+            'misses' => $this->assetRegistryMisses,
+            'total' => $this->assetRegistryHits + $this->assetRegistryMisses,
+            'deduplication_ratio' => $this->assetRegistryHits + $this->assetRegistryMisses > 0
+                ? round(($this->assetRegistryHits / ($this->assetRegistryHits + $this->assetRegistryMisses)) * 100, 2)
+                : 0.0,
+        ];
     }
 
     /**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -153,6 +153,11 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
      */
     protected $assets = [];
     /**
+     * In-memory registry used to deduplicate asset objects during a build.
+     * @var array<string, Asset>
+     */
+    protected $assetRegistry = [];
+    /**
      * Menus collection.
      * This is an associative array that holds menus for different languages.
      * Each key is a language code, and the value is a Collection\Menu\Collection instance
@@ -260,6 +265,9 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
 
         // merge options with defaults
         $this->options = array_merge(self::OPTIONS, $options);
+
+        // reset in-memory registries for this build
+        $this->assetRegistry = [];
 
         // set build ID
         self::$buildId = hash('adler32', date('YmdHis') . self::$version);
@@ -486,6 +494,22 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
         if (!\in_array($path, $this->assets, true)) {
             $this->assets[] = $path;
         }
+    }
+
+    /**
+     * Returns an Asset from the registry or stores a newly created one.
+     */
+    public function rememberAsset(string $cacheKey, callable $factory): Asset
+    {
+        if (!isset($this->assetRegistry[$cacheKey])) {
+            $asset = $factory();
+            if (!$asset instanceof Asset) {
+                throw new RuntimeException(\sprintf('Asset registry factory must return an Asset ("%s" returned).', \get_debug_type($asset)));
+            }
+            $this->assetRegistry[$cacheKey] = $asset;
+        }
+
+        return $this->assetRegistry[$cacheKey];
     }
 
     /**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -522,7 +522,7 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
         if (!isset($this->assetRegistry[$cacheKey])) {
             $asset = $factory();
             if (!$asset instanceof Asset) {
-                throw new RuntimeException(\sprintf('Asset registry factory must return an Asset ("%s" returned).', \get_debug_type($asset)));
+                throw new RuntimeException(\sprintf('Asset registry factory must return an Asset ("%s" returned).', get_debug_type($asset)));
             }
             $this->assetRegistry[$cacheKey] = $asset;
             $this->assetRegistryMisses++;

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Cecil\Command;
 
 use Cecil\Builder;
-use Cecil\Logger\ConsoleLogger;
 use Cecil\Logger\ProgressConsoleLogger;
 use Cecil\Util;
 use Psr\Log\LoggerInterface;
@@ -262,6 +261,16 @@ EOF
         }
         $rows[] = new TableSeparator();
         $rows[] = ['Total', $totalDurationDisplay, $metrics['total']['memory']];
+
+        // add asset registry deduplication stats if available
+        if (isset($metrics['registry']) && $metrics['registry']['total'] > 0) {
+            $rows[] = new TableSeparator();
+            $rows[] = [
+                '<fg=cyan>Assets deduplication</>',
+                \sprintf('%d created, %d reused', $metrics['registry']['misses'], $metrics['registry']['hits']),
+                \sprintf('<fg=green>%.1f%% hit rate</>', $metrics['registry']['deduplication_ratio']),
+            ];
+        }
 
         // save current metrics for next comparison
         Util\File::getFS()->dumpFile($metricsFile, (string) json_encode($currentMetricsToSave, JSON_PRETTY_PRINT));

--- a/src/Converter/Converter.php
+++ b/src/Converter/Converter.php
@@ -53,13 +53,22 @@ class Converter implements ConverterInterface
     }
 
     /**
+     * Parsedown instances keyed by language, shared across convertBody() calls.
+     * @var array<string, Parsedown>
+     */
+    private array $parsedownCache = [];
+
+    /**
      * {@inheritdoc}
      */
     public function convertBody(string $string, ?string $language = null): string
     {
-        $parsedown = new Parsedown($this->builder, ['language' => $language]);
+        $key = $language ?? '';
+        if (!isset($this->parsedownCache[$key])) {
+            $this->parsedownCache[$key] = new Parsedown($this->builder, ['language' => $language]);
+        }
 
-        return $parsedown->text($string);
+        return $this->parsedownCache[$key]->text($string);
     }
 
     /**

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -56,10 +56,12 @@ class Parsedown extends \ParsedownToc
     /** Shared across all instances: registerAllLanguages() scans 185 files but $classMap is static */
     protected static Highlighter $highlighter;
 
-    /** @var array<string, mixed> */
+    /** @var array<string, mixed> Stores image processing results to avoid redundant computations within a build. */
     protected static array $imageProcessingCache = [];
 
-    /** Cache scope marker so static caches can be reset between builds. */
+    /**
+     * @var string|null Cache scope marker so static caches can be reset between builds.
+     */
     protected static ?string $cacheBuildId = null;
 
     /** @var string|null */

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -721,96 +721,87 @@ class Parsedown extends \ParsedownToc
 
     private function getCachedAsset(string $path, array $assetOptions): Asset
     {
-        $cacheKey = $this->getCacheKey('asset', [
-            'path' => $path,
-            'options' => $assetOptions,
-        ]);
-        if (!isset(static::$assetCache[$cacheKey])) {
-            static::$assetCache[$cacheKey] = new Asset($this->builder, $path, $assetOptions);
-        }
-
-        return static::$assetCache[$cacheKey];
+        return $this->rememberAsset(
+            [
+                'path' => $path,
+                'options' => $assetOptions,
+            ],
+            fn () => new Asset($this->builder, $path, $assetOptions)
+        );
     }
 
     private function getCachedDominantColor(Asset $asset): string
     {
-        $cacheKey = $this->getCacheKey('dominant', ['asset' => $this->getAssetIdentity($asset)]);
-        if (!isset(static::$imageProcessingCache[$cacheKey])) {
-            static::$imageProcessingCache[$cacheKey] = Image::getDominantColor($asset);
-        }
-
-        return (string) static::$imageProcessingCache[$cacheKey];
+        return (string) $this->rememberImageProcessing(
+            'dominant',
+            ['asset' => $this->getAssetIdentity($asset)],
+            static fn () => Image::getDominantColor($asset)
+        );
     }
 
     private function getCachedLqip(Asset $asset): string
     {
-        $cacheKey = $this->getCacheKey('lqip', ['asset' => $this->getAssetIdentity($asset)]);
-        if (!isset(static::$imageProcessingCache[$cacheKey])) {
-            static::$imageProcessingCache[$cacheKey] = Image::getLqip($asset);
-        }
-
-        return (string) static::$imageProcessingCache[$cacheKey];
+        return (string) $this->rememberImageProcessing(
+            'lqip',
+            ['asset' => $this->getAssetIdentity($asset)],
+            static fn () => Image::getLqip($asset)
+        );
     }
 
     private function isAnimatedGifCached(Asset $asset): bool
     {
-        $cacheKey = $this->getCacheKey('animated', ['asset' => $this->getAssetIdentity($asset)]);
-        if (!isset(static::$imageProcessingCache[$cacheKey])) {
-            static::$imageProcessingCache[$cacheKey] = Image::isAnimatedGif($asset);
-        }
-
-        return (bool) static::$imageProcessingCache[$cacheKey];
+        return (bool) $this->rememberImageProcessing(
+            'animated',
+            ['asset' => $this->getAssetIdentity($asset)],
+            static fn () => Image::isAnimatedGif($asset)
+        );
     }
 
     private function getCachedSrcsetW(Asset $asset, array $widths): string
     {
-        $cacheKey = $this->getCacheKey('srcsetw', ['asset' => $this->getAssetIdentity($asset), 'widths' => $widths]);
-        if (!isset(static::$imageProcessingCache[$cacheKey])) {
-            static::$imageProcessingCache[$cacheKey] = Image::buildHtmlSrcsetW($asset, $widths);
-        }
-
-        return (string) static::$imageProcessingCache[$cacheKey];
+        return (string) $this->rememberImageProcessing(
+            'srcsetw',
+            ['asset' => $this->getAssetIdentity($asset), 'widths' => $widths],
+            static fn () => Image::buildHtmlSrcsetW($asset, $widths)
+        );
     }
 
     private function getCachedSrcset(Asset $asset, array $widths): string
     {
-        $cacheKey = $this->getCacheKey('srcset', ['asset' => $this->getAssetIdentity($asset), 'widths' => $widths]);
-        if (!isset(static::$imageProcessingCache[$cacheKey])) {
-            static::$imageProcessingCache[$cacheKey] = Image::buildHtmlSrcset($asset, $widths);
-        }
-
-        return (string) static::$imageProcessingCache[$cacheKey];
+        return (string) $this->rememberImageProcessing(
+            'srcset',
+            ['asset' => $this->getAssetIdentity($asset), 'widths' => $widths],
+            static fn () => Image::buildHtmlSrcset($asset, $widths)
+        );
     }
 
     private function getCachedSizes(string $class, array $sizesConfig): string
     {
-        $cacheKey = $this->getCacheKey('sizes', ['class' => $class, 'sizes' => $sizesConfig]);
-        if (!isset(static::$imageProcessingCache[$cacheKey])) {
-            static::$imageProcessingCache[$cacheKey] = Image::getHtmlSizes($class, $sizesConfig);
-        }
-
-        return (string) static::$imageProcessingCache[$cacheKey];
+        return (string) $this->rememberImageProcessing(
+            'sizes',
+            ['class' => $class, 'sizes' => $sizesConfig],
+            static fn () => Image::getHtmlSizes($class, $sizesConfig)
+        );
     }
 
     private function getCachedDarkSourceAttributes(Asset $asset, string $darkSuffix, array $formats, array $options): array
     {
-        $cacheKey = $this->getCacheKey('dark', [
-            'asset' => $this->getAssetIdentity($asset),
-            'suffix' => $darkSuffix,
-            'formats' => $formats,
-            'options' => $options,
-        ]);
-        if (!isset(static::$imageProcessingCache[$cacheKey])) {
-            static::$imageProcessingCache[$cacheKey] = Image::buildDarkSourceAttributes(
+        return (array) $this->rememberImageProcessing(
+            'dark',
+            [
+                'asset' => $this->getAssetIdentity($asset),
+                'suffix' => $darkSuffix,
+                'formats' => $formats,
+                'options' => $options,
+            ],
+            fn () => Image::buildDarkSourceAttributes(
                 $this->builder,
                 $asset,
                 $darkSuffix,
                 $formats,
                 $options
-            );
-        }
-
-        return (array) static::$imageProcessingCache[$cacheKey];
+            )
+        );
     }
 
     private function getAssetIdentity(Asset $asset): string
@@ -828,6 +819,32 @@ class Parsedown extends \ParsedownToc
     private function getCacheKey(string $prefix, array $payload): string
     {
         return \sprintf('%s_%s', $prefix, \hash('xxh128', \serialize($payload)));
+    }
+
+    /**
+     * Memoize an Asset instance across Parsedown instances.
+     */
+    private function rememberAsset(array $payload, callable $factory): Asset
+    {
+        $cacheKey = $this->getCacheKey('asset', $payload);
+        if (!isset(static::$assetCache[$cacheKey])) {
+            static::$assetCache[$cacheKey] = $factory();
+        }
+
+        return static::$assetCache[$cacheKey];
+    }
+
+    /**
+     * Memoize an image-processing result across Parsedown instances.
+     */
+    private function rememberImageProcessing(string $prefix, array $payload, callable $factory): mixed
+    {
+        $cacheKey = $this->getCacheKey($prefix, $payload);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = $factory();
+        }
+
+        return static::$imageProcessingCache[$cacheKey];
     }
 
     /**

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -56,9 +56,6 @@ class Parsedown extends \ParsedownToc
     /** Shared across all instances: registerAllLanguages() scans 185 files but $classMap is static */
     protected static Highlighter $highlighter;
 
-    /** @var array<string, Asset> */
-    protected static array $assetCache = [];
-
     /** @var array<string, mixed> */
     protected static array $imageProcessingCache = [];
 
@@ -827,11 +824,8 @@ class Parsedown extends \ParsedownToc
     private function rememberAsset(array $payload, callable $factory): Asset
     {
         $cacheKey = $this->getCacheKey('asset', $payload);
-        if (!isset(static::$assetCache[$cacheKey])) {
-            static::$assetCache[$cacheKey] = $factory();
-        }
 
-        return static::$assetCache[$cacheKey];
+        return $this->builder->rememberAsset($cacheKey, $factory);
     }
 
     /**
@@ -860,7 +854,10 @@ class Parsedown extends \ParsedownToc
         ];
         $block['element']['attributes'] = $link['element']['attributes'];
         unset($block['element']['attributes']['href']);
-        $block['element']['attributes']['src'] = new Url($this->builder, new Asset($this->builder, $link['element']['attributes']['href']));
+        $block['element']['attributes']['src'] = new Url(
+            $this->builder,
+            $this->getCachedAsset((string) $link['element']['attributes']['href'], [])
+        );
         switch ($type) {
             case 'video':
                 $block['element']['name'] = 'video';
@@ -872,7 +869,10 @@ class Parsedown extends \ParsedownToc
                     $block['element']['attributes']['playsinline'] = '';
                 }
                 if (isset($block['element']['attributes']['poster'])) {
-                    $block['element']['attributes']['poster'] = new Url($this->builder, new Asset($this->builder, $block['element']['attributes']['poster']));
+                    $block['element']['attributes']['poster'] = new Url(
+                        $this->builder,
+                        $this->getCachedAsset((string) $block['element']['attributes']['poster'], [])
+                    );
                 }
                 if (!\array_key_exists('style', $block['element']['attributes'])) {
                     $block['element']['attributes']['style'] = '';

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -59,6 +59,9 @@ class Parsedown extends \ParsedownToc
     /** @var array<string, mixed> */
     protected static array $imageProcessingCache = [];
 
+    /** Cache scope marker so static caches can be reset between builds. */
+    protected static ?string $cacheBuildId = null;
+
     /** @var string|null */
     protected $language;
 

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -53,8 +53,14 @@ class Parsedown extends \ParsedownToc
      */
     protected $regexImage = "~^!\[.*?\]\(.*?\)~";
 
-    /** @var Highlighter */
-    protected $highlighter;
+    /** Shared across all instances: registerAllLanguages() scans 185 files but $classMap is static */
+    protected static Highlighter $highlighter;
+
+    /** @var array<string, Asset> */
+    protected static array $assetCache = [];
+
+    /** @var array<string, mixed> */
+    protected static array $imageProcessingCache = [];
 
     /** @var string|null */
     protected $language;
@@ -76,7 +82,10 @@ class Parsedown extends \ParsedownToc
         $this->BlockTypes[':'][] = 'Note';
 
         // code highlight
-        $this->highlighter = new Highlighter();
+        // Instantiate once: registerAllLanguages() scans 185 JSON files but classMap is static
+        if (!isset(static::$highlighter)) {
+            static::$highlighter = new Highlighter();
+        }
 
         // options
         $options = array_merge([
@@ -262,7 +271,7 @@ class Parsedown extends \ParsedownToc
         unset($InlineImage['element']['attributes']['target'], $InlineImage['element']['attributes']['rel']);
 
         // normalize path
-        $InlineImage['element']['attributes']['src'] = $this->normalizePath($InlineImage['element']['attributes']['src']);
+        $InlineImage['element']['attributes']['src'] = $this->normalizePath((string) $InlineImage['element']['attributes']['src']);
 
         // should be lazy loaded?
         if ($this->config->isEnabled('pages.body.images.lazy') && !isset($InlineImage['element']['attributes']['loading'])) {
@@ -292,7 +301,7 @@ class Parsedown extends \ParsedownToc
             $assetOptions += ['fallback' => (string) $this->config->get('pages.body.images.remote.fallback')];
         }
         $assetOptions += ['language' => $this->language];
-        $asset = new Asset($this->builder, $InlineImage['element']['attributes']['src'], $assetOptions);
+        $asset = $this->getCachedAsset((string) $InlineImage['element']['attributes']['src'], $assetOptions);
         $InlineImage['element']['attributes']['src'] = new Url($this->builder, $asset);
         $width = $asset['width'];
 
@@ -356,14 +365,14 @@ class Parsedown extends \ParsedownToc
             $InlineImage['element']['attributes']['style'] = trim($InlineImage['element']['attributes']['style'], ';');
             switch ($InlineImage['element']['attributes']['placeholder']) {
                 case 'color':
-                    $InlineImage['element']['attributes']['style'] .= \sprintf(';max-width:100%%;height:auto;background-color:%s;', Image::getDominantColor($assetResized ?? $asset));
+                    $InlineImage['element']['attributes']['style'] .= \sprintf(';max-width:100%%;height:auto;background-color:%s;', $this->getCachedDominantColor($assetResized ?? $asset));
                     break;
                 case 'lqip':
                     // aborts if animated GIF for performance reasons
-                    if (Image::isAnimatedGif($assetResized ?? $asset)) {
+                    if ($this->isAnimatedGifCached($assetResized ?? $asset)) {
                         break;
                     }
-                    $InlineImage['element']['attributes']['style'] .= \sprintf(';max-width:100%%;height:auto;background-image:url(%s);background-repeat:no-repeat;background-position:center;background-size:cover;', Image::getLqip($asset));
+                    $InlineImage['element']['attributes']['style'] .= \sprintf(';max-width:100%%;height:auto;background-image:url(%s);background-repeat:no-repeat;background-position:center;background-size:cover;', $this->getCachedLqip($asset));
                     break;
             }
             unset($InlineImage['element']['attributes']['placeholder']);
@@ -377,13 +386,10 @@ class Parsedown extends \ParsedownToc
         if ($this->config->isEnabled('pages.body.images.responsive')) {
             try {
                 if (
-                    $srcset = Image::buildHtmlSrcsetW(
-                        $assetResized ?? $asset,
-                        $this->config->getAssetsImagesWidths()
-                    )
+                    $srcset = $this->getCachedSrcsetW($assetResized ?? $asset, $this->config->getAssetsImagesWidths())
                 ) {
                     $InlineImage['element']['attributes']['srcset'] = $srcset;
-                    $sizes = Image::getHtmlSizes($InlineImage['element']['attributes']['class'] ?? '', (array) $this->config->getAssetsImagesSizes());
+                    $sizes = $this->getCachedSizes($InlineImage['element']['attributes']['class'] ?? '', (array) $this->config->getAssetsImagesSizes());
                     $InlineImage['element']['attributes']['sizes'] = $sizes;
                 }
             } catch (\Exception $e) {
@@ -422,7 +428,7 @@ class Parsedown extends \ParsedownToc
         ) {
             try {
                 // abord if InlineImage is an animated GIF
-                if (Image::isAnimatedGif($assetResized ?? $asset)) {
+                if ($this->isAnimatedGifCached($assetResized ?? $asset)) {
                     $filepath = Util::joinFile($this->config->getOutputPath(), $assetResized['path'] ?? $asset['path'] ?? '');
                     throw new RuntimeException(\sprintf('Asset "%s" is not converted (animated GIF).', $filepath));
                 }
@@ -433,7 +439,7 @@ class Parsedown extends \ParsedownToc
                         $assetConverted = ($assetResized ?? $asset)->convert($format);
                         // build responsive images?
                         if ($this->config->isEnabled('pages.body.images.responsive')) {
-                            $srcset = Image::buildHtmlSrcset($assetConverted, $this->config->getAssetsImagesWidths());
+                            $srcset = $this->getCachedSrcset($assetConverted, $this->config->getAssetsImagesWidths());
                         }
                         // if not, use default image as srcset
                         if (empty($srcset)) {
@@ -481,8 +487,7 @@ class Parsedown extends \ParsedownToc
         // dark color-scheme variant: auto-detect `{filename}{suffix}.{ext}` alongside the source image
         $darkSuffix = (string) $this->config->get('pages.body.images.dark_suffix');
         if (!empty($darkSuffix)) {
-            $darkSourceAttributes = Image::buildDarkSourceAttributes(
-                $this->builder,
+            $darkSourceAttributes = $this->getCachedDarkSourceAttributes(
                 $asset,
                 $darkSuffix,
                 $formats,
@@ -615,7 +620,7 @@ class Parsedown extends \ParsedownToc
             $code = $block['element']['element']['text'];
             $languageClass = $block['element']['element']['attributes']['class'];
             $language = explode('-', $languageClass);
-            $highlighted = $this->highlighter->highlight($language[1], $code);
+            $highlighted = static::$highlighter->highlight($language[1], $code);
             $block['element']['element']['attributes']['class'] = vsprintf('%s hljs %s', [
                 $languageClass,
                 $highlighted->language,
@@ -712,6 +717,117 @@ class Parsedown extends \ParsedownToc
         }
 
         return $matches[3];
+    }
+
+    private function getCachedAsset(string $path, array $assetOptions): Asset
+    {
+        $cacheKey = $this->getCacheKey('asset', [
+            'path' => $path,
+            'options' => $assetOptions,
+        ]);
+        if (!isset(static::$assetCache[$cacheKey])) {
+            static::$assetCache[$cacheKey] = new Asset($this->builder, $path, $assetOptions);
+        }
+
+        return static::$assetCache[$cacheKey];
+    }
+
+    private function getCachedDominantColor(Asset $asset): string
+    {
+        $cacheKey = $this->getCacheKey('dominant', ['asset' => $this->getAssetIdentity($asset)]);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = Image::getDominantColor($asset);
+        }
+
+        return (string) static::$imageProcessingCache[$cacheKey];
+    }
+
+    private function getCachedLqip(Asset $asset): string
+    {
+        $cacheKey = $this->getCacheKey('lqip', ['asset' => $this->getAssetIdentity($asset)]);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = Image::getLqip($asset);
+        }
+
+        return (string) static::$imageProcessingCache[$cacheKey];
+    }
+
+    private function isAnimatedGifCached(Asset $asset): bool
+    {
+        $cacheKey = $this->getCacheKey('animated', ['asset' => $this->getAssetIdentity($asset)]);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = Image::isAnimatedGif($asset);
+        }
+
+        return (bool) static::$imageProcessingCache[$cacheKey];
+    }
+
+    private function getCachedSrcsetW(Asset $asset, array $widths): string
+    {
+        $cacheKey = $this->getCacheKey('srcsetw', ['asset' => $this->getAssetIdentity($asset), 'widths' => $widths]);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = Image::buildHtmlSrcsetW($asset, $widths);
+        }
+
+        return (string) static::$imageProcessingCache[$cacheKey];
+    }
+
+    private function getCachedSrcset(Asset $asset, array $widths): string
+    {
+        $cacheKey = $this->getCacheKey('srcset', ['asset' => $this->getAssetIdentity($asset), 'widths' => $widths]);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = Image::buildHtmlSrcset($asset, $widths);
+        }
+
+        return (string) static::$imageProcessingCache[$cacheKey];
+    }
+
+    private function getCachedSizes(string $class, array $sizesConfig): string
+    {
+        $cacheKey = $this->getCacheKey('sizes', ['class' => $class, 'sizes' => $sizesConfig]);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = Image::getHtmlSizes($class, $sizesConfig);
+        }
+
+        return (string) static::$imageProcessingCache[$cacheKey];
+    }
+
+    private function getCachedDarkSourceAttributes(Asset $asset, string $darkSuffix, array $formats, array $options): array
+    {
+        $cacheKey = $this->getCacheKey('dark', [
+            'asset' => $this->getAssetIdentity($asset),
+            'suffix' => $darkSuffix,
+            'formats' => $formats,
+            'options' => $options,
+        ]);
+        if (!isset(static::$imageProcessingCache[$cacheKey])) {
+            static::$imageProcessingCache[$cacheKey] = Image::buildDarkSourceAttributes(
+                $this->builder,
+                $asset,
+                $darkSuffix,
+                $formats,
+                $options
+            );
+        }
+
+        return (array) static::$imageProcessingCache[$cacheKey];
+    }
+
+    private function getAssetIdentity(Asset $asset): string
+    {
+        return \sprintf(
+            '%s|%s|%s|%sx%s',
+            (string) $asset['path'],
+            (string) $asset['hash'],
+            (string) $asset['subtype'],
+            (string) ($asset['width'] ?? ''),
+            (string) ($asset['height'] ?? '')
+        );
+    }
+
+    private function getCacheKey(string $prefix, array $payload): string
+    {
+        return \sprintf('%s_%s', $prefix, \hash('xxh128', \serialize($payload)));
     }
 
     /**

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -827,7 +827,7 @@ class Parsedown extends \ParsedownToc
 
     private function getCacheKey(string $prefix, array $payload): string
     {
-        return \sprintf('%s_%s', $prefix, \hash('xxh128', \serialize($payload)));
+        return \sprintf('%s_%s', $prefix, hash('xxh128', serialize($payload)));
     }
 
     /**

--- a/src/Converter/Parsedown.php
+++ b/src/Converter/Parsedown.php
@@ -87,6 +87,13 @@ class Parsedown extends \ParsedownToc
             static::$highlighter = new Highlighter();
         }
 
+        // reset static caches when the build ID changes (e.g. watch mode with multiple builds)
+        $currentBuildId = Builder::getBuildId();
+        if (static::$cacheBuildId !== $currentBuildId) {
+            static::$imageProcessingCache = [];
+            static::$cacheBuildId = $currentBuildId;
+        }
+
         // options
         $options = array_merge([
             'selectors' => (array) $this->config->get('pages.body.toc'),

--- a/src/Step/Pages/Convert.php
+++ b/src/Step/Pages/Convert.php
@@ -66,13 +66,14 @@ class Convert extends AbstractStep
 
         $total = \count($this->builder->getPages());
         $count = 0;
+        $converter = new Converter($this->builder);
         /** @var Page $page */
         foreach ($this->builder->getPages() as $page) {
             if (!$page->isVirtual()) {
                 $count++;
 
                 try {
-                    $convertedPage = $this->convertPage($this->builder, $page);
+                    $convertedPage = $this->convertPage($this->builder, $page, converter: $converter);
                     // set default language (ex: "en") if necessary
                     if ($convertedPage->getVariable('language') === null) {
                         $convertedPage->setVariable('language', $this->config->getLanguageDefault());


### PR DESCRIPTION
This PR improves build performance by introducing caching and deduplication at key points of the content/asset pipeline, and by surfacing new metrics in the `build --metrics` output.

## What changed

- Added an in-memory asset registry in the builder to deduplicate `Asset` objects during a build.
- Added asset-registry counters (`hits`, `misses`) and exposed them in build metrics.
- Extended `build --metrics` table with an "Assets deduplication" row (created/reused + hit rate).
- Added a per-language Parsedown instance cache in the converter (reused across `convertBody()` calls).
- Switched the syntax highlighter to a shared static instance in Parsedown integration.
- Added caching for expensive image-processing operations (dominant color, LQIP, animated GIF detection, srcset/sizes, dark variant attributes).
- Refactored image/asset handling paths to reuse cached results while preserving existing behavior.
- Regenerated API docs impacted by these code changes.

## Why

Large sites repeatedly hit the same markdown and image transformation paths during one build.
This PR reduces duplicate work by:
- reusing parser/highlighter instances,
- memoizing image-processing results,
- deduplicating asset construction.

The goal is faster builds with lower redundant CPU/IO work.

## Impact

- Faster build times, especially on sites with many images and repeated markdown patterns.
- Better observability with explicit deduplication metrics in CLI output.
- No intended functional change to rendered site output.

## Backward compatibility

- No breaking CLI or config change.
- Existing options and build flow remain unchanged.

## Validation

- Static analysis passed: `composer code:analyse`.
- PHPUnit suites passed locally (`phpunit` runs used during verification).

## Notes

- API documentation files were updated to reflect new/changed internals.