### PR TITLE
perf: record layout cache stats and display metrics

### DIFF
--- a/src/BuildContextInterface.php
+++ b/src/BuildContextInterface.php
@@ -110,4 +110,9 @@ interface BuildContextInterface
      * Returns Renderer object.
      */
     public function getRenderer(): \Cecil\Renderer\Twig;
+
+    /**
+     * Records a layout cache access during rendering.
+     */
+    public function recordLayoutCacheAccess(bool $hit): void;
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -168,6 +168,16 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
      */
     protected $assetRegistryMisses = 0;
     /**
+     * Counter for layout resolution cache hits during render step.
+     * @var int
+     */
+    protected $layoutCacheHits = 0;
+    /**
+     * Counter for layout resolution cache misses during render step.
+     * @var int
+     */
+    protected $layoutCacheMisses = 0;
+    /**
      * Menus collection.
      * This is an associative array that holds menus for different languages.
      * Each key is a language code, and the value is a Collection\Menu\Collection instance
@@ -280,6 +290,8 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
         $this->assetRegistry = [];
         $this->assetRegistryHits = 0;
         $this->assetRegistryMisses = 0;
+        $this->layoutCacheHits = 0;
+        $this->layoutCacheMisses = 0;
 
         // set build ID
         self::$buildId = hash('adler32', date('YmdHis') . self::$version);
@@ -324,6 +336,8 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
 
         // store asset registry metrics
         $this->metrics['registry'] = $this->getAssetRegistryStats();
+        // store layout cache metrics
+        $this->metrics['layout_cache'] = $this->getLayoutCacheStats();
 
         // log final build notice
         $this->getLogger()->notice(\sprintf('Built in %s (%s)', $this->metrics['total']['duration'], $this->metrics['total']['memory']));
@@ -544,6 +558,35 @@ class Builder implements BuildContextInterface, LoggerAwareInterface
             'total' => $this->assetRegistryHits + $this->assetRegistryMisses,
             'deduplication_ratio' => $this->assetRegistryHits + $this->assetRegistryMisses > 0
                 ? round(($this->assetRegistryHits / ($this->assetRegistryHits + $this->assetRegistryMisses)) * 100, 2)
+                : 0.0,
+        ];
+    }
+
+    /**
+     * Records a layout cache access during render step.
+     */
+    public function recordLayoutCacheAccess(bool $hit): void
+    {
+        if ($hit) {
+            $this->layoutCacheHits++;
+
+            return;
+        }
+
+        $this->layoutCacheMisses++;
+    }
+
+    /**
+     * Returns layout cache statistics.
+     */
+    public function getLayoutCacheStats(): array
+    {
+        return [
+            'hits' => $this->layoutCacheHits,
+            'misses' => $this->layoutCacheMisses,
+            'total' => $this->layoutCacheHits + $this->layoutCacheMisses,
+            'hit_rate' => $this->layoutCacheHits + $this->layoutCacheMisses > 0
+                ? round(($this->layoutCacheHits / ($this->layoutCacheHits + $this->layoutCacheMisses)) * 100, 2)
                 : 0.0,
         ];
     }

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -267,8 +267,8 @@ EOF
         // add asset registry deduplication stats if available
         if (isset($metrics['registry']) && $metrics['registry']['total'] > 0) {
             $optimizationRows[] = [
-                '<fg=cyan>Assets deduplication</>',
-                \sprintf('%d created, %d reused', $metrics['registry']['misses'], $metrics['registry']['hits']),
+                'Assets deduplication',
+                \sprintf('%d created / %d reused', $metrics['registry']['misses'], $metrics['registry']['hits']),
                 \sprintf('<fg=green>%.1f%% hit rate</>', $metrics['registry']['deduplication_ratio']),
             ];
         }
@@ -276,8 +276,8 @@ EOF
         // add layout cache stats if available
         if (isset($metrics['layout_cache']) && $metrics['layout_cache']['total'] > 0) {
             $optimizationRows[] = [
-                '<fg=cyan>Layouts cache</>',
-                \sprintf('%d misses, %d hits', $metrics['layout_cache']['misses'], $metrics['layout_cache']['hits']),
+                'Layouts cache',
+                \sprintf('%d misses / %d hits', $metrics['layout_cache']['misses'], $metrics['layout_cache']['hits']),
                 \sprintf('<fg=green>%.1f%% hit rate</>', $metrics['layout_cache']['hit_rate']),
             ];
         }
@@ -296,7 +296,7 @@ EOF
         if ($optimizationRows !== []) {
             $table = new Table($output);
             $table
-                ->setHeaderTitle('Optimization metrics')
+                ->setHeaderTitle('Performance metrics')
                 ->setHeaders(['Metric', 'Value', 'Impact'])
                 ->setRows($optimizationRows)
             ;

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -262,13 +262,23 @@ EOF
         $rows[] = new TableSeparator();
         $rows[] = ['Total', $totalDurationDisplay, $metrics['total']['memory']];
 
+        $optimizationRows = [];
+
         // add asset registry deduplication stats if available
         if (isset($metrics['registry']) && $metrics['registry']['total'] > 0) {
-            $rows[] = new TableSeparator();
-            $rows[] = [
+            $optimizationRows[] = [
                 '<fg=cyan>Assets deduplication</>',
                 \sprintf('%d created, %d reused', $metrics['registry']['misses'], $metrics['registry']['hits']),
                 \sprintf('<fg=green>%.1f%% hit rate</>', $metrics['registry']['deduplication_ratio']),
+            ];
+        }
+
+        // add layout cache stats if available
+        if (isset($metrics['layout_cache']) && $metrics['layout_cache']['total'] > 0) {
+            $optimizationRows[] = [
+                '<fg=cyan>Layouts cache</>',
+                \sprintf('%d misses, %d hits', $metrics['layout_cache']['misses'], $metrics['layout_cache']['hits']),
+                \sprintf('<fg=green>%.1f%% hit rate</>', $metrics['layout_cache']['hit_rate']),
             ];
         }
 
@@ -282,6 +292,16 @@ EOF
             ->setRows($rows)
         ;
         $table->setStyle('box')->render();
+
+        if ($optimizationRows !== []) {
+            $table = new Table($output);
+            $table
+                ->setHeaderTitle('Optimization metrics')
+                ->setHeaders(['Metric', 'Value', 'Impact'])
+                ->setRows($optimizationRows)
+            ;
+            $table->setStyle('box')->render();
+        }
     }
 
     /**

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -269,7 +269,7 @@ EOF
             $optimizationRows[] = [
                 'Assets deduplication',
                 \sprintf('%d created / %d reused', $metrics['registry']['misses'], $metrics['registry']['hits']),
-                \sprintf('<fg=green>%.1f%% hit rate</>', $metrics['registry']['deduplication_ratio']),
+                \sprintf('%.1f%% hit rate', $metrics['registry']['deduplication_ratio']),
             ];
         }
 
@@ -278,7 +278,7 @@ EOF
             $optimizationRows[] = [
                 'Layouts cache',
                 \sprintf('%d misses / %d hits', $metrics['layout_cache']['misses'], $metrics['layout_cache']['hits']),
-                \sprintf('<fg=green>%.1f%% hit rate</>', $metrics['layout_cache']['hit_rate']),
+                \sprintf('%.1f%% hit rate', $metrics['layout_cache']['hit_rate']),
             ];
         }
 

--- a/src/Step/Pages/Render.php
+++ b/src/Step/Pages/Render.php
@@ -144,6 +144,8 @@ class Render extends AbstractStep
 
         // some cache to avoid multiple calls
         $cache = [];
+        $layoutCache = [];
+        $currentLanguage = null;
 
         /** @var Page $page */
         foreach ($pages as $page) {
@@ -152,22 +154,26 @@ class Render extends AbstractStep
 
             // l10n
             $language = $page->getVariable('language', $this->config->getLanguageDefault());
-            if (!isset($cache['locale'][$language])) {
-                $cache['locale'][$language] = $this->config->getLanguageProperty('locale', $language);
-            }
-            $this->builder->getRenderer()->setLocale($cache['locale'][$language]);
+            if ($currentLanguage !== $language) {
+                if (!isset($cache['locale'][$language])) {
+                    $cache['locale'][$language] = $this->config->getLanguageProperty('locale', $language);
+                }
+                $this->builder->getRenderer()->setLocale($cache['locale'][$language]);
 
-            // global site variables
-            if (!isset($cache['site'][$language])) {
-                $cache['site'][$language] = new Site($this->builder, $language);
-            }
-            $this->builder->getRenderer()->addGlobal('site', $cache['site'][$language]);
+                // global site variables
+                if (!isset($cache['site'][$language])) {
+                    $cache['site'][$language] = new Site($this->builder, $language);
+                }
+                $this->builder->getRenderer()->addGlobal('site', $cache['site'][$language]);
 
-            // global config raw variables
-            if (!isset($cache['config'][$language])) {
-                $cache['config'][$language] = new Config($this->builder, $language);
+                // global config raw variables
+                if (!isset($cache['config'][$language])) {
+                    $cache['config'][$language] = new Config($this->builder, $language);
+                }
+                $this->builder->getRenderer()->addGlobal('config', $cache['config'][$language]);
+
+                $currentLanguage = $language;
             }
-            $this->builder->getRenderer()->addGlobal('config', $cache['config'][$language]);
 
             // excluded format(s)?
             $formats = (array) $page->getVariable('output');
@@ -200,8 +206,14 @@ class Render extends AbstractStep
 
             // renders each output format
             foreach ($formats as $format) {
-                // search for the template
-                $layout = Layout::finder($page, $format, $this->config);
+                $layoutCacheKey = $this->getLayoutCacheKey($page, $format);
+                $layoutCacheHit = isset($layoutCache[$layoutCacheKey]);
+                if (!$layoutCacheHit) {
+                    // search for the template only once per layout profile
+                    $layoutCache[$layoutCacheKey] = Layout::finder($page, $format, $this->config);
+                }
+                $this->builder->recordLayoutCacheAccess($layoutCacheHit);
+                $layout = $layoutCache[$layoutCacheKey];
                 // renders with Twig
                 try {
                     $deprecations = [];
@@ -367,6 +379,25 @@ class Render extends AbstractStep
         }
 
         return $alternates;
+    }
+
+    /**
+     * Returns a deterministic cache key for layout resolution.
+     */
+    protected function getLayoutCacheKey(Page $page, string $format): string
+    {
+        return \md5(\serialize([
+            $format,
+            $page->getType(),
+            $page->getSection(),
+            $this->config->getLayoutSection($page->getSection()),
+            $page->getPath() === '',
+            $page->getVariable('layout'),
+            $page->getVariable('language', $this->config->getLanguageDefault()),
+            $page->getVariable('plural'),
+            $page->getVariable('singular'),
+            $page->getVariable('term'),
+        ]));
     }
 
     /**

--- a/src/Step/Pages/Render.php
+++ b/src/Step/Pages/Render.php
@@ -386,7 +386,7 @@ class Render extends AbstractStep
      */
     protected function getLayoutCacheKey(Page $page, string $format): string
     {
-        return \md5(\serialize([
+        return md5(serialize([
             $format,
             $page->getType(),
             $page->getSection(),

--- a/src/Step/Pages/Render.php
+++ b/src/Step/Pages/Render.php
@@ -392,7 +392,7 @@ class Render extends AbstractStep
             $page->getSection(),
             $this->config->getLayoutSection($page->getSection()),
             $page->getPath() === '',
-            $page->getVariable('layout'),
+            str_replace('.' . Layout::EXT, '', (string) $page->getVariable('layout')),
             $page->getVariable('language', $this->config->getLanguageDefault()),
             $page->getVariable('plural'),
             $page->getVariable('singular'),


### PR DESCRIPTION
This pull request introduces layout cache tracking and reporting to the build process, improving optimization visibility and performance diagnostics. The main changes include adding layout cache hit/miss tracking in the builder, integrating cache statistics into build metrics, and displaying these metrics in the CLI output. Additionally, layout resolution in page rendering now uses an in-memory cache to avoid redundant computations.

**Layout Cache Tracking and Reporting:**

* Added `layoutCacheHits` and `layoutCacheMisses` counters to the `Builder` class, with methods to record layout cache accesses and retrieve cache statistics. (`src/Builder.php`) [[1]](diffhunk://#diff-aaf0bc0443d3390951e65b1d6dadf6134554550b510609434969424757f1b6f9R170-R179) [[2]](diffhunk://#diff-aaf0bc0443d3390951e65b1d6dadf6134554550b510609434969424757f1b6f9R565-R593)
* Reset layout cache counters at the start of each build and included layout cache stats in the build metrics. (`src/Builder.php`) [[1]](diffhunk://#diff-aaf0bc0443d3390951e65b1d6dadf6134554550b510609434969424757f1b6f9R293-R294) [[2]](diffhunk://#diff-aaf0bc0443d3390951e65b1d6dadf6134554550b510609434969424757f1b6f9R339-R340)
* Updated `BuildContextInterface` to include the `recordLayoutCacheAccess` method, ensuring consistent tracking across implementations. (`src/BuildContextInterface.php`)

**Page Rendering Optimization:**

* Implemented an in-memory layout cache in the page rendering step, using a deterministic cache key to avoid redundant layout resolutions and record cache hits/misses. (`src/Step/Pages/Render.php`) [[1]](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR147-R148) [[2]](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR157) [[3]](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR175-R177) [[4]](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbL203-R216) [[5]](diffhunk://#diff-cfdff19f5c7a254b30c7b407427fac0c3181d6e36ea6d1c22505bceae0275ccbR384-R402)

**Build Metrics Display:**

* Enhanced the build command output to show layout cache statistics alongside asset registry stats in a new "Optimization metrics" table, improving visibility into build performance. (`src/Command/Build.php`) [[1]](diffhunk://#diff-7da763cf51b7fe35d72081b1f102ebb75a5c9b1fbf155f00e085715d4aa32c1aR265-R284) [[2]](diffhunk://#diff-7da763cf51b7fe35d72081b1f102ebb75a5c9b1fbf155f00e085715d4aa32c1aR295-R304)