### PR TITLE
feat: add incremental build option to serve

### DIFF
--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -2,7 +2,7 @@
 title: Commandes
 description: "Liste des commandes disponibles."
 date: 2026-03-27
-updated: 2026-06-15
+updated: 2026-06-18
 slug: commandes
 -->
 # Commandes
@@ -170,6 +170,7 @@ Options:
       --host=HOST                  Server host [default: "localhost"]
       --port=PORT                  Server port [default: "8000"]
   -w, --watch|--no-watch           Enable (or disable --no-watch) changes watcher (enabled by default)
+    -i, --incremental                Enable incremental builds (rebuild only changed pages)
   -d, --drafts                     Include drafts
       --optimize|--no-optimize     Enable (or disable --no-optimize) optimization of generated files
   -c, --config=CONFIG              Set the path to extra config files (comma-separated)
@@ -195,6 +196,12 @@ Help:
     cecil.phar serve --open
     cecil.phar serve --drafts
     cecil.phar serve --no-watch
+
+  To speed up local development you can enable incremental builds with the --incremental option.
+  When only content pages change, Cecil rebuilds just those pages instead of the whole website;
+  any other change (layout, data, config, theme, static or asset file) triggers a full rebuild:
+
+    cecil.phar serve --incremental
 
   You can use a custom host and port by using the --host and --port options:
 

--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -170,7 +170,7 @@ Options:
       --host=HOST                  Server host [default: "localhost"]
       --port=PORT                  Server port [default: "8000"]
   -w, --watch|--no-watch           Enable (or disable --no-watch) changes watcher (enabled by default)
-    -i, --incremental                Enable incremental builds (rebuild only changed pages)
+  -i, --incremental                Enable incremental builds (rebuild only changed pages)
   -d, --drafts                     Include drafts
       --optimize|--no-optimize     Enable (or disable --no-optimize) optimization of generated files
   -c, --config=CONFIG              Set the path to extra config files (comma-separated)

--- a/docs/5-Commands.fr.md
+++ b/docs/5-Commands.fr.md
@@ -198,8 +198,9 @@ Help:
     cecil.phar serve --no-watch
 
   To speed up local development you can enable incremental builds with the --incremental option.
-  When only content pages change, Cecil rebuilds just those pages instead of the whole website;
-  any other change (layout, data, config, theme, static or asset file) triggers a full rebuild:
+  When content pages change, Cecil rebuilds just those pages.
+  When templates change, Cecil rebuilds only pages using those templates (including Twig dependencies such as extends/include).
+  Any other change (data, config, static or asset file, or file deletion) triggers a full rebuild:
 
     cecil.phar serve --incremental
 

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -196,8 +196,9 @@ Help:
     cecil.phar serve --no-watch
 
   To speed up local development you can enable incremental builds with the --incremental option.
-  When only content pages change, Cecil rebuilds just those pages instead of the whole website;
-  any other change (layout, data, config, theme, static or asset file) triggers a full rebuild:
+  When content pages change, Cecil rebuilds just those pages.
+  When templates change, Cecil rebuilds only pages using those templates (including Twig dependencies such as extends/include).
+  Any other change (data, config, static or asset file, or file deletion) triggers a full rebuild:
 
     cecil.phar serve --incremental
 

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -1,7 +1,7 @@
 <!--
 description: "List of available commands."
 date: 2020-12-19
-updated: 2026-06-15
+updated: 2026-06-18
 -->
 # Commands
 
@@ -168,6 +168,7 @@ Options:
       --host=HOST                  Server host [default: "localhost"]
       --port=PORT                  Server port [default: "8000"]
   -w, --watch|--no-watch           Enable (or disable --no-watch) changes watcher (enabled by default)
+    -i, --incremental                Enable incremental builds (rebuild only changed pages)
   -d, --drafts                     Include drafts
       --optimize|--no-optimize     Enable (or disable --no-optimize) optimization of generated files
   -c, --config=CONFIG              Set the path to extra config files (comma-separated)
@@ -193,6 +194,12 @@ Help:
     cecil.phar serve --open
     cecil.phar serve --drafts
     cecil.phar serve --no-watch
+
+  To speed up local development you can enable incremental builds with the --incremental option.
+  When only content pages change, Cecil rebuilds just those pages instead of the whole website;
+  any other change (layout, data, config, theme, static or asset file) triggers a full rebuild:
+
+    cecil.phar serve --incremental
 
   You can use a custom host and port by using the --host and --port options:
 

--- a/docs/5-Commands.md
+++ b/docs/5-Commands.md
@@ -168,7 +168,7 @@ Options:
       --host=HOST                  Server host [default: "localhost"]
       --port=PORT                  Server port [default: "8000"]
   -w, --watch|--no-watch           Enable (or disable --no-watch) changes watcher (enabled by default)
-    -i, --incremental                Enable incremental builds (rebuild only changed pages)
+  -i, --incremental                Enable incremental builds (rebuild only changed pages)
   -d, --drafts                     Include drafts
       --optimize|--no-optimize     Enable (or disable --no-optimize) optimization of generated files
   -c, --config=CONFIG              Set the path to extra config files (comma-separated)

--- a/src/Command/IncrementalBuildExecutor.php
+++ b/src/Command/IncrementalBuildExecutor.php
@@ -51,7 +51,6 @@ class IncrementalBuildExecutor
             $flushBuildOutput();
             if ($fullBuildProcess->isSuccessful()) {
                 $onBuildSuccess();
-            } else {
             }
 
             return;

--- a/src/Command/IncrementalBuildExecutor.php
+++ b/src/Command/IncrementalBuildExecutor.php
@@ -72,7 +72,6 @@ class IncrementalBuildExecutor
 
         if ($allSuccessful) {
             $onBuildSuccess();
-        } else {
         }
     }
 }

--- a/src/Command/IncrementalBuildExecutor.php
+++ b/src/Command/IncrementalBuildExecutor.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+use Yosymfony\ResourceWatcher\ResourceWatcherResult;
+
+/**
+ * Executes incremental build strategy and runs the required build subprocesses.
+ */
+class IncrementalBuildExecutor
+{
+    public function __construct(
+        private readonly IncrementalBuildResolver $resolver,
+    ) {
+    }
+
+    /**
+     * @param callable(?string): Process $createBuildProcess
+     * @param callable(string, string): void $processOutputCallback
+     * @param callable(): void $flushBuildOutput
+     * @param callable(): void $onBuildSuccess
+     */
+    public function execute(
+        ResourceWatcherResult $watcher,
+        OutputInterface $output,
+        callable $createBuildProcess,
+        callable $processOutputCallback,
+        callable $flushBuildOutput,
+        callable $onBuildSuccess
+    ): void {
+        $pages = $this->resolver->resolve($watcher);
+
+        // null means a full rebuild is required
+        if ($pages === null) {
+            $output->writeln('<comment>Incremental: full rebuild required</comment>');
+            $fullBuildProcess = $createBuildProcess(null);
+            $fullBuildProcess->run($processOutputCallback);
+            $flushBuildOutput();
+            if ($fullBuildProcess->isSuccessful()) {
+                $onBuildSuccess();
+            } else {
+            }
+
+            return;
+        }
+
+        $allSuccessful = true;
+        if (\count($pages) === 0) {
+            $output->writeln('<comment>Incremental: no impacted pages</comment>');
+        }
+        foreach ($pages as $page) {
+            $output->writeln(\sprintf('<comment>Incremental: building page "%s"</comment>', $page));
+            $process = $createBuildProcess($page);
+            $process->run($processOutputCallback);
+            $flushBuildOutput();
+            if (!$process->isSuccessful()) {
+                $allSuccessful = false;
+            }
+        }
+
+        if ($allSuccessful) {
+            $onBuildSuccess();
+        } else {
+        }
+    }
+}

--- a/src/Command/IncrementalBuildResolver.php
+++ b/src/Command/IncrementalBuildResolver.php
@@ -1,0 +1,360 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Command;
+
+use Cecil\Builder;
+use Cecil\Collection\Page\Page;
+use Cecil\Converter\Converter;
+use Cecil\Renderer\Layout;
+use Cecil\Util;
+use Symfony\Component\Finder\Finder;
+use Yosymfony\ResourceWatcher\ResourceWatcherResult;
+
+/**
+ * Resolves impacted source pages for incremental serve builds.
+ */
+class IncrementalBuildResolver
+{
+    public function __construct(
+        private Builder $builder,
+        private bool $includeDrafts = false,
+    ) {
+    }
+
+    /**
+     * Resolves the list of content pages to rebuild from watcher changes.
+     *
+     * Returns an array of page paths (relative to the pages directory) when an incremental
+     * rebuild is possible, or `null` when a full rebuild is required.
+     *
+     * @return array<int, string>|null
+     */
+    public function resolve(ResourceWatcherResult $watcher): ?array
+    {
+        // A deletion may impact lists, sections, taxonomies, etc.: full rebuild.
+        if (\count($watcher->getDeletedFiles()) > 0) {
+            return null;
+        }
+
+        $changedFiles = \array_merge($watcher->getNewFiles(), $watcher->getUpdatedFiles());
+        if (\count($changedFiles) === 0) {
+            return null;
+        }
+
+        $config = $this->builder->getConfig();
+        $pagesPath = $this->normalizePath($config->getPagesPath());
+        $extensions = \array_map('strtolower', (array) $config->get('pages.ext'));
+
+        $pages = [];
+        $templates = [];
+        foreach ($changedFiles as $file) {
+            $normalized = $this->normalizePath((string) $file);
+            if ($templateRef = $this->resolveTemplateRefFromPath($normalized)) {
+                $templates[] = $templateRef;
+
+                continue;
+            }
+            // File extension must be a valid page extension.
+            $extension = \strtolower((string) \pathinfo($normalized, PATHINFO_EXTENSION));
+            if (!\in_array($extension, $extensions, true)) {
+                return null;
+            }
+            $relative = $this->relativePathFromDirectory($normalized, $pagesPath);
+            $pages[$relative] = $relative;
+        }
+
+        if (\count($templates) > 0) {
+            $pagesFromTemplates = $this->resolvePagesImpactedByTemplates($templates);
+            if ($pagesFromTemplates === null) {
+                return null;
+            }
+            foreach ($pagesFromTemplates as $page) {
+                $pages[$page] = $page;
+            }
+        }
+
+        return \array_values($pages);
+    }
+
+    /**
+     * Resolves source pages impacted by changed templates.
+     *
+     * @param array<int, array{scope: string, file: string}> $changedTemplates
+     * @return array<int, string>|null
+     */
+    private function resolvePagesImpactedByTemplates(array $changedTemplates): ?array
+    {
+        $config = $this->builder->getConfig();
+        $affectedTemplates = $this->resolveAffectedTemplates($changedTemplates);
+
+        if (\count($affectedTemplates) === 0) {
+            return [];
+        }
+
+        $pagesPath = $config->getPagesPath();
+        if (!\is_dir($pagesPath)) {
+            return [];
+        }
+
+        $namePattern = '/\.(' . \implode('|', (array) $config->get('pages.ext')) . ')$/';
+        $finder = Finder::create()
+            ->files()
+            ->in($pagesPath)
+            ->name($namePattern);
+
+        if (\is_array($exclude = $config->get('pages.exclude'))) {
+            $finder->exclude($exclude);
+            $finder->notPath($exclude);
+            $finder->notName($exclude);
+        }
+        if (\file_exists(Util::joinFile($pagesPath, '.gitignore'))) {
+            $finder->ignoreVCSIgnored(true);
+        }
+
+        $converter = new Converter($this->builder);
+        $frontmatterFormat = (string) $config->get('pages.frontmatter');
+        $impactedPages = [];
+
+        foreach ($finder as $file) {
+            $page = new Page($file);
+            $page->parse();
+
+            if ($page->getFrontmatter()) {
+                try {
+                    $variables = $converter->convertFrontmatter((string) $page->getFrontmatter(), $frontmatterFormat);
+                    $page->setFmVariables($variables);
+                    $page->setVariables($variables);
+                } catch (\Throwable) {
+                    // Ignore parse failures here: build subprocess will report them if the page is rebuilt.
+                }
+            }
+
+            if (!$this->includeDrafts && !$page->getVariable('published')) {
+                continue;
+            }
+
+            foreach ($this->getPageOutputFormats($page) as $format) {
+                try {
+                    $layout = Layout::finder($page, $format, $config);
+                } catch (\Throwable) {
+                    continue;
+                }
+                $layoutRef = $layout['scope'] . ':' . $layout['file'];
+                if (isset($affectedTemplates[$layoutRef])) {
+                    $pageFilePath = (string) $page->getVariable('filepath');
+                    $impactedPages[$pageFilePath] = $pageFilePath;
+                    break;
+                }
+            }
+        }
+
+        return \array_values($impactedPages);
+    }
+
+    /**
+     * Returns all templates impacted by changed templates (including reverse dependencies).
+     *
+     * @param array<int, array{scope: string, file: string}> $changedTemplates
+     * @return array<string, bool>
+     */
+    private function resolveAffectedTemplates(array $changedTemplates): array
+    {
+        $reverseDependencies = $this->buildReverseTemplateDependencyGraph();
+        $affected = [];
+        $queue = [];
+
+        foreach ($changedTemplates as $templateRef) {
+            $id = $templateRef['scope'] . ':' . $templateRef['file'];
+            $affected[$id] = true;
+            $queue[] = $id;
+        }
+
+        while (($current = \array_shift($queue)) !== null) {
+            foreach ($reverseDependencies[$current] ?? [] as $dependent) {
+                if (!isset($affected[$dependent])) {
+                    $affected[$dependent] = true;
+                    $queue[] = $dependent;
+                }
+            }
+        }
+
+        return $affected;
+    }
+
+    /**
+     * Builds a reverse dependency graph keyed by template reference (`scope:file`).
+     *
+     * @return array<string, array<int, string>>
+     */
+    private function buildReverseTemplateDependencyGraph(): array
+    {
+        $reverseDependencies = [];
+
+        foreach ($this->getTemplateRoots() as $scope => $rootPath) {
+            if (!\is_dir($rootPath)) {
+                continue;
+            }
+
+            $finder = Finder::create()
+                ->files()
+                ->in($rootPath)
+                ->name('/\\.' . Layout::EXT . '$/');
+
+            foreach ($finder as $file) {
+                $fileRef = $scope . ':' . \str_replace('\\', '/', $file->getRelativePathname());
+                $content = $file->getContents();
+                if (\preg_match_all('/\\{%\\s*(?:extends|include|embed|use|import|from)\\s+["\']([^"\']+)["\']/i', $content, $matches)) {
+                    foreach ($matches[1] as $dependency) {
+                        if (!\is_string($dependency) || $dependency === '') {
+                            continue;
+                        }
+                        if (!\str_ends_with($dependency, '.' . Layout::EXT)) {
+                            continue;
+                        }
+                        $dependencyRef = $scope . ':' . \str_replace('\\', '/', \trim($dependency));
+                        $reverseDependencies[$dependencyRef][$fileRef] = $fileRef;
+                    }
+                }
+            }
+        }
+
+        foreach ($reverseDependencies as $template => $dependents) {
+            $reverseDependencies[$template] = \array_values($dependents);
+        }
+
+        return $reverseDependencies;
+    }
+
+    /**
+     * Resolves a filesystem path to a template reference when it belongs to a template root.
+     *
+     * @return array{scope: string, file: string}|null
+     */
+    private function resolveTemplateRefFromPath(string $path): ?array
+    {
+        if (!\str_ends_with($path, '.' . Layout::EXT)) {
+            return null;
+        }
+
+        foreach ($this->getTemplateRoots() as $scope => $rootPath) {
+            $normalizedRoot = $this->normalizePath($rootPath);
+            if ($path === $normalizedRoot || \strncmp($path, $normalizedRoot . '/', \strlen($normalizedRoot) + 1) !== 0) {
+                continue;
+            }
+
+            return [
+                'scope' => $scope,
+                'file' => \substr($path, \strlen($normalizedRoot) + 1),
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns template roots keyed by their scope name used by Layout::finder.
+     *
+     * @return array<string, string>
+     */
+    private function getTemplateRoots(): array
+    {
+        $config = $this->builder->getConfig();
+        $roots = [
+            'site' => $config->getLayoutsPath(),
+        ];
+
+        if ($config->hasTheme()) {
+            foreach ($config->getTheme() ?? [] as $theme) {
+                $roots[$theme] = $config->getThemeDirPath($theme, 'layouts');
+            }
+        }
+
+        $roots['cecil'] = $config->getLayoutsInternalPath();
+
+        return $roots;
+    }
+
+    /**
+     * Returns output formats for a page using render step rules.
+     *
+     * @return array<int, string>
+     */
+    private function getPageOutputFormats(Page $page): array
+    {
+        $config = $this->builder->getConfig();
+
+        if ($page->getVariable('output')) {
+            $formats = $page->getVariable('output');
+            if (!\is_array($formats)) {
+                $formats = [$formats];
+            }
+
+            return \array_values(\array_unique(\array_map('strval', $formats)));
+        }
+
+        $formats = $config->get('output.pagetypeformats.' . $page->getType());
+        if (empty($formats)) {
+            return [];
+        }
+        if (!\is_array($formats)) {
+            $formats = [$formats];
+        }
+
+        return \array_values(\array_unique(\array_map('strval', $formats)));
+    }
+
+    /**
+     * Normalizes a filesystem path to use forward slashes without a trailing slash.
+     */
+    private function normalizePath(string $path): string
+    {
+        $normalized = \rtrim(\str_replace('\\', '/', $path), '/');
+
+        // Prefer canonical absolute path when possible to avoid false negatives
+        // with relative segments, symlinks/junctions or drive letter variations.
+        $realPath = \realpath($normalized);
+        if ($realPath !== false) {
+            $normalized = \rtrim(\str_replace('\\', '/', $realPath), '/');
+        }
+
+        // Windows filesystems are case-insensitive by default.
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $normalized = \strtolower($normalized);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Checks whether a file path is inside a directory path.
+     */
+    private function isPathInDirectory(string $filePath, string $directoryPath): bool
+    {
+        $filePath = $this->normalizePath($filePath);
+        $directoryPath = $this->normalizePath($directoryPath);
+
+        return \str_starts_with($filePath . '/', $directoryPath . '/');
+    }
+
+    /**
+     * Returns file path relative to a directory path.
+     */
+    private function relativePathFromDirectory(string $filePath, string $directoryPath): string
+    {
+        $filePath = $this->normalizePath($filePath);
+        $directoryPath = $this->normalizePath($directoryPath);
+
+        return \ltrim((string) \substr($filePath, \strlen($directoryPath)), '/');
+    }
+}

--- a/src/Command/IncrementalBuildResolver.php
+++ b/src/Command/IncrementalBuildResolver.php
@@ -337,17 +337,6 @@ class IncrementalBuildResolver
     }
 
     /**
-     * Checks whether a file path is inside a directory path.
-     */
-    private function isPathInDirectory(string $filePath, string $directoryPath): bool
-    {
-        $filePath = $this->normalizePath($filePath);
-        $directoryPath = $this->normalizePath($directoryPath);
-
-        return \str_starts_with($filePath . '/', $directoryPath . '/');
-    }
-
-    /**
      * Returns file path relative to a directory path.
      */
     private function relativePathFromDirectory(string $filePath, string $directoryPath): string

--- a/src/Command/IncrementalBuildResolver.php
+++ b/src/Command/IncrementalBuildResolver.php
@@ -70,9 +70,21 @@ class IncrementalBuildResolver
             if (!\in_array($extension, $extensions, true)) {
                 return null;
             }
+            // The changed file must belong to the pages directory (otherwise treat as "other" change).
+            if (\strncmp($normalized, $pagesPath . '/', \strlen($pagesPath) + 1) !== 0) {
+                return null;
+            }
             $relative = $this->relativePathFromDirectory($normalized, $pagesPath);
+            // If the file is excluded from pages discovery, it is not safe to do a partial build.
+            if (\is_array($exclude = $config->get('pages.exclude'))) {
+                foreach ($exclude as $pattern) {
+                    $pattern = (string) $pattern;
+                    if ($pattern !== '' && \preg_match('#(^|/)' . \preg_quote($pattern, '#') . '(/|$)#', $relative)) {
+                        return null;
+                    }
+                }
+            }
             $pages[$relative] = $relative;
-        }
 
         if (\count($templates) > 0) {
             $pagesFromTemplates = $this->resolvePagesImpactedByTemplates($templates);

--- a/src/Command/IncrementalBuildResolver.php
+++ b/src/Command/IncrementalBuildResolver.php
@@ -47,14 +47,14 @@ class IncrementalBuildResolver
             return null;
         }
 
-        $changedFiles = \array_merge($watcher->getNewFiles(), $watcher->getUpdatedFiles());
+        $changedFiles = array_merge($watcher->getNewFiles(), $watcher->getUpdatedFiles());
         if (\count($changedFiles) === 0) {
             return null;
         }
 
         $config = $this->builder->getConfig();
         $pagesPath = $this->normalizePath($config->getPagesPath());
-        $extensions = \array_map('strtolower', (array) $config->get('pages.ext'));
+        $extensions = array_map('strtolower', (array) $config->get('pages.ext'));
 
         $pages = [];
         $templates = [];
@@ -66,12 +66,12 @@ class IncrementalBuildResolver
                 continue;
             }
             // File extension must be a valid page extension.
-            $extension = \strtolower((string) \pathinfo($normalized, PATHINFO_EXTENSION));
+            $extension = strtolower((string) pathinfo($normalized, PATHINFO_EXTENSION));
             if (!\in_array($extension, $extensions, true)) {
                 return null;
             }
             // The changed file must belong to the pages directory (otherwise treat as "other" change).
-            if (\strncmp($normalized, $pagesPath . '/', \strlen($pagesPath) + 1) !== 0) {
+            if (strncmp($normalized, $pagesPath . '/', \strlen($pagesPath) + 1) !== 0) {
                 return null;
             }
             $relative = $this->relativePathFromDirectory($normalized, $pagesPath);
@@ -79,12 +79,13 @@ class IncrementalBuildResolver
             if (\is_array($exclude = $config->get('pages.exclude'))) {
                 foreach ($exclude as $pattern) {
                     $pattern = (string) $pattern;
-                    if ($pattern !== '' && \preg_match('#(^|/)' . \preg_quote($pattern, '#') . '(/|$)#', $relative)) {
+                    if ($pattern !== '' && preg_match('#(^|/)' . preg_quote($pattern, '#') . '(/|$)#', $relative)) {
                         return null;
                     }
                 }
             }
             $pages[$relative] = $relative;
+        }
 
         if (\count($templates) > 0) {
             $pagesFromTemplates = $this->resolvePagesImpactedByTemplates($templates);
@@ -96,7 +97,7 @@ class IncrementalBuildResolver
             }
         }
 
-        return \array_values($pages);
+        return array_values($pages);
     }
 
     /**
@@ -115,11 +116,11 @@ class IncrementalBuildResolver
         }
 
         $pagesPath = $config->getPagesPath();
-        if (!\is_dir($pagesPath)) {
+        if (!is_dir($pagesPath)) {
             return [];
         }
 
-        $namePattern = '/\.(' . \implode('|', (array) $config->get('pages.ext')) . ')$/';
+        $namePattern = '/\.(' . implode('|', (array) $config->get('pages.ext')) . ')$/';
         $finder = Finder::create()
             ->files()
             ->in($pagesPath)
@@ -130,7 +131,7 @@ class IncrementalBuildResolver
             $finder->notPath($exclude);
             $finder->notName($exclude);
         }
-        if (\file_exists(Util::joinFile($pagesPath, '.gitignore'))) {
+        if (file_exists(Util::joinFile($pagesPath, '.gitignore'))) {
             $finder->ignoreVCSIgnored(true);
         }
 
@@ -171,7 +172,7 @@ class IncrementalBuildResolver
             }
         }
 
-        return \array_values($impactedPages);
+        return array_values($impactedPages);
     }
 
     /**
@@ -192,7 +193,7 @@ class IncrementalBuildResolver
             $queue[] = $id;
         }
 
-        while (($current = \array_shift($queue)) !== null) {
+        while (($current = array_shift($queue)) !== null) {
             foreach ($reverseDependencies[$current] ?? [] as $dependent) {
                 if (!isset($affected[$dependent])) {
                     $affected[$dependent] = true;
@@ -214,7 +215,7 @@ class IncrementalBuildResolver
         $reverseDependencies = [];
 
         foreach ($this->getTemplateRoots() as $scope => $rootPath) {
-            if (!\is_dir($rootPath)) {
+            if (!is_dir($rootPath)) {
                 continue;
             }
 
@@ -224,17 +225,17 @@ class IncrementalBuildResolver
                 ->name('/\\.' . Layout::EXT . '$/');
 
             foreach ($finder as $file) {
-                $fileRef = $scope . ':' . \str_replace('\\', '/', $file->getRelativePathname());
+                $fileRef = $scope . ':' . str_replace('\\', '/', $file->getRelativePathname());
                 $content = $file->getContents();
-                if (\preg_match_all('/\\{%\\s*(?:extends|include|embed|use|import|from)\\s+["\']([^"\']+)["\']/i', $content, $matches)) {
+                if (preg_match_all('/\\{%\\s*(?:extends|include|embed|use|import|from)\\s+["\']([^"\']+)["\']/i', $content, $matches)) {
                     foreach ($matches[1] as $dependency) {
                         if (!\is_string($dependency) || $dependency === '') {
                             continue;
                         }
-                        if (!\str_ends_with($dependency, '.' . Layout::EXT)) {
+                        if (!str_ends_with($dependency, '.' . Layout::EXT)) {
                             continue;
                         }
-                        $dependencyRef = $scope . ':' . \str_replace('\\', '/', \trim($dependency));
+                        $dependencyRef = $scope . ':' . str_replace('\\', '/', trim($dependency));
                         $reverseDependencies[$dependencyRef][$fileRef] = $fileRef;
                     }
                 }
@@ -242,7 +243,7 @@ class IncrementalBuildResolver
         }
 
         foreach ($reverseDependencies as $template => $dependents) {
-            $reverseDependencies[$template] = \array_values($dependents);
+            $reverseDependencies[$template] = array_values($dependents);
         }
 
         return $reverseDependencies;
@@ -255,19 +256,19 @@ class IncrementalBuildResolver
      */
     private function resolveTemplateRefFromPath(string $path): ?array
     {
-        if (!\str_ends_with($path, '.' . Layout::EXT)) {
+        if (!str_ends_with($path, '.' . Layout::EXT)) {
             return null;
         }
 
         foreach ($this->getTemplateRoots() as $scope => $rootPath) {
             $normalizedRoot = $this->normalizePath($rootPath);
-            if ($path === $normalizedRoot || \strncmp($path, $normalizedRoot . '/', \strlen($normalizedRoot) + 1) !== 0) {
+            if ($path === $normalizedRoot || strncmp($path, $normalizedRoot . '/', \strlen($normalizedRoot) + 1) !== 0) {
                 continue;
             }
 
             return [
                 'scope' => $scope,
-                'file' => \substr($path, \strlen($normalizedRoot) + 1),
+                'file' => substr($path, \strlen($normalizedRoot) + 1),
             ];
         }
 
@@ -312,7 +313,7 @@ class IncrementalBuildResolver
                 $formats = [$formats];
             }
 
-            return \array_values(\array_unique(\array_map('strval', $formats)));
+            return array_values(array_unique(array_map('strval', $formats)));
         }
 
         $formats = $config->get('output.pagetypeformats.' . $page->getType());
@@ -323,7 +324,7 @@ class IncrementalBuildResolver
             $formats = [$formats];
         }
 
-        return \array_values(\array_unique(\array_map('strval', $formats)));
+        return array_values(array_unique(array_map('strval', $formats)));
     }
 
     /**
@@ -331,18 +332,18 @@ class IncrementalBuildResolver
      */
     private function normalizePath(string $path): string
     {
-        $normalized = \rtrim(\str_replace('\\', '/', $path), '/');
+        $normalized = rtrim(str_replace('\\', '/', $path), '/');
 
         // Prefer canonical absolute path when possible to avoid false negatives
         // with relative segments, symlinks/junctions or drive letter variations.
-        $realPath = \realpath($normalized);
+        $realPath = realpath($normalized);
         if ($realPath !== false) {
-            $normalized = \rtrim(\str_replace('\\', '/', $realPath), '/');
+            $normalized = rtrim(str_replace('\\', '/', $realPath), '/');
         }
 
         // Windows filesystems are case-insensitive by default.
         if (DIRECTORY_SEPARATOR === '\\') {
-            $normalized = \strtolower($normalized);
+            $normalized = strtolower($normalized);
         }
 
         return $normalized;
@@ -356,6 +357,6 @@ class IncrementalBuildResolver
         $filePath = $this->normalizePath($filePath);
         $directoryPath = $this->normalizePath($directoryPath);
 
-        return \ltrim((string) \substr($filePath, \strlen($directoryPath)), '/');
+        return ltrim((string) substr($filePath, \strlen($directoryPath)), '/');
     }
 }

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -29,6 +29,7 @@ use Symfony\Component\Process\Process;
 use Yosymfony\ResourceWatcher\Crc32ContentHash;
 use Yosymfony\ResourceWatcher\ResourceCacheMemory;
 use Yosymfony\ResourceWatcher\ResourceWatcher;
+use Yosymfony\ResourceWatcher\ResourceWatcherResult;
 
 /**
  * Serve command.
@@ -41,6 +42,21 @@ class Serve extends AbstractCommand
 {
     /** @var boolean */
     protected $watcherEnabled;
+
+    /** @var boolean */
+    protected $incrementalEnabled = false;
+
+    /** @var string PHP executable path used to spawn build processes. */
+    protected $php;
+
+    /** @var float Build process timeout, in seconds. */
+    protected $processTimeout;
+
+    /**
+     * Base options used to build the `build` process arguments.
+     * @var array<string, mixed>
+     */
+    protected $buildProcessBaseOptions = [];
 
     /**
      * {@inheritdoc}
@@ -56,6 +72,7 @@ class Serve extends AbstractCommand
                 new InputOption('host', null, InputOption::VALUE_REQUIRED, 'Server host', 'localhost'),
                 new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Server port', '8000'),
                 new InputOption('watch', 'w', InputOption::VALUE_NEGATABLE, 'Enable (or disable --no-watch) changes watcher (enabled by default)', true),
+                new InputOption('incremental', 'i', InputOption::VALUE_NONE, 'Enable incremental builds (rebuild only changed pages)'),
                 new InputOption('drafts', 'd', InputOption::VALUE_NONE, 'Include drafts'),
                 new InputOption('optimize', null, InputOption::VALUE_NEGATABLE, 'Enable (or disable --no-optimize) optimization of generated files'),
                 new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set the path to extra config files (comma-separated)'),
@@ -76,6 +93,12 @@ The <info>%command.name%</> command starts the live-reloading-built-in web serve
   <info>%command.full_name% --open</>
   <info>%command.full_name% --drafts</>
   <info>%command.full_name% --no-watch</>
+
+To speed up local development you can enable <comment>incremental builds</comment> with the <info>--incremental</info> option.
+When only content pages change, Cecil rebuilds <comment>just those pages</comment> instead of the whole website;
+any other change (layout, data, config, theme, static or asset file) triggers a full rebuild:
+
+  <info>%command.full_name% --incremental</>
 
 You can use a custom host and port by using the <info>--host</info> and <info>--port</info> options:
 
@@ -131,8 +154,11 @@ EOF
         $notify = $input->getOption('notify');
         $noansi = $input->getOption('no-ansi');
         $background = $input->getOption('background');
+        $incremental = $input->getOption('incremental');
 
         $this->watcherEnabled = $background ? false : $input->getOption('watch');
+        // incremental builds require the changes watcher to be active
+        $this->incrementalEnabled = $this->watcherEnabled ? (bool) $incremental : false;
 
         // checks if PHP executable is available
         $phpFinder = new PhpExecutableFinder();
@@ -154,7 +180,9 @@ EOF
         $process = new Process($cmd);
 
         // setup build process
-        $buildProcessArguments = $this->createBuildProcessArguments($php, [
+        $this->php = $php;
+        $this->processTimeout = (float) $timeout;
+        $this->buildProcessBaseOptions = [
             'drafts' => $drafts,
             'optimize' => $optimize,
             'clearcache' => $clearcache,
@@ -164,15 +192,9 @@ EOF
             'noansi' => $noansi,
             'host' => $host,
             'port' => $port,
-        ]);
-        $buildProcess = new Process(
-            $buildProcessArguments,
-            null,
-            ['BOX_REQUIREMENT_CHECKER' => '0'] // prevents double check (build then serve)
-        );
-        $buildProcess->setTty(Process::isTtySupported());
-        $buildProcess->setPty(Process::isPtySupported());
-        $buildProcess->setTimeout((float) $timeout);
+        ];
+        $buildProcessArguments = $this->createBuildProcessArguments($php, $this->buildProcessBaseOptions);
+        $buildProcess = $this->createBuildProcess();
         $buildOutputEndsWithLineFeed = true;
         $processOutputCallback = function ($type, $buffer) use ($output, &$buildOutputEndsWithLineFeed) {
             $buildOutputEndsWithLineFeed = str_ends_with($buffer, "\n");
@@ -216,6 +238,29 @@ EOF
             $processOutputCallback,
             $flushBuildOutput
         );
+    }
+
+    /**
+     * Creates a configured `build` process, optionally restricted to a single page.
+     */
+    private function createBuildProcess(?string $page = null): Process
+    {
+        $options = $this->buildProcessBaseOptions;
+        if ($page !== null) {
+            $options['page'] = $page;
+        }
+        $process = new Process(
+            $this->createBuildProcessArguments($this->php, $options),
+            null,
+            ['BOX_REQUIREMENT_CHECKER' => '0'] // prevents double check (build then serve)
+        );
+        $process->setTty(Process::isTtySupported());
+        $process->setPty(Process::isPtySupported());
+        if ($this->processTimeout !== null) {
+            $process->setTimeout($this->processTimeout);
+        }
+
+        return $process;
     }
 
     /**
@@ -441,10 +486,14 @@ EOF
                         }
                         $output->writeln('');
 
-                        $buildProcess->run($processOutputCallback);
-                        $flushBuildOutput();
-                        if ($buildProcess->isSuccessful()) {
-                            $this->buildSuccessActions($output);
+                        if ($this->incrementalEnabled) {
+                            $this->runIncrementalBuild($watcher, $output, $processOutputCallback, $flushBuildOutput, $buildProcess);
+                        } else {
+                            $buildProcess->run($processOutputCallback);
+                            $flushBuildOutput();
+                            if ($buildProcess->isSuccessful()) {
+                                $this->buildSuccessActions($output);
+                            }
                         }
                         $output->writeln('<info>Server is running...</info>');
                         if ($notify) {
@@ -464,6 +513,100 @@ EOF
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Runs an incremental build based on the watcher result.
+     *
+     * If every change is an isolated content page (created or updated), Cecil rebuilds
+     * only those pages. Any other change (deletion, layout, data, config, theme, static
+     * or asset file) triggers a full rebuild.
+     */
+    private function runIncrementalBuild(
+        ResourceWatcherResult $watcher,
+        OutputInterface $output,
+        callable $processOutputCallback,
+        callable $flushBuildOutput,
+        Process $fullBuildProcess
+    ): void {
+        $pages = $this->resolveIncrementalPages($watcher);
+
+        // null means a full rebuild is required
+        if ($pages === null) {
+            $output->writeln('<comment>Incremental: full rebuild required</comment>');
+            $fullBuildProcess->run($processOutputCallback);
+            $flushBuildOutput();
+            if ($fullBuildProcess->isSuccessful()) {
+                $this->buildSuccessActions($output);
+            }
+
+            return;
+        }
+
+        $allSuccessful = true;
+        foreach ($pages as $page) {
+            $output->writeln(\sprintf('<comment>Incremental: building page "%s"</comment>', $page));
+            $process = $this->createBuildProcess($page);
+            $process->run($processOutputCallback);
+            $flushBuildOutput();
+            if (!$process->isSuccessful()) {
+                $allSuccessful = false;
+            }
+        }
+        if ($allSuccessful) {
+            $this->buildSuccessActions($output);
+        }
+    }
+
+    /**
+     * Resolves the list of content pages to rebuild from the watcher result.
+     *
+     * Returns an array of page paths (relative to the pages directory) when an incremental
+     * rebuild is possible, or `null` when a full rebuild is required.
+     *
+     * @return array<int, string>|null
+     */
+    private function resolveIncrementalPages(ResourceWatcherResult $watcher): ?array
+    {
+        // a deletion may impact lists, sections, taxonomies, etc.: full rebuild
+        if (\count($watcher->getDeletedFiles()) > 0) {
+            return null;
+        }
+
+        $changedFiles = array_merge($watcher->getNewFiles(), $watcher->getUpdatedFiles());
+        if (\count($changedFiles) === 0) {
+            return null;
+        }
+
+        $config = $this->getBuilder()->getConfig();
+        $pagesPath = $this->normalizePath($config->getPagesPath());
+        $extensions = array_map('strtolower', (array) $config->get('pages.ext'));
+
+        $pages = [];
+        foreach ($changedFiles as $file) {
+            $normalized = $this->normalizePath($file);
+            // file must live inside the pages directory
+            if (strncmp($normalized, $pagesPath . '/', \strlen($pagesPath) + 1) !== 0) {
+                return null;
+            }
+            // file extension must be a valid page extension
+            $extension = strtolower(pathinfo($normalized, PATHINFO_EXTENSION));
+            if (!\in_array($extension, $extensions, true)) {
+                return null;
+            }
+            $relative = substr($normalized, \strlen($pagesPath) + 1);
+            $pages[$relative] = $relative;
+        }
+
+        return array_values($pages);
+    }
+
+    /**
+     * Normalizes a filesystem path to use forward slashes without a trailing slash.
+     */
+    private function normalizePath(string $path): string
+    {
+        return rtrim(str_replace('\\', '/', $path), '/');
     }
 
     /**

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -29,7 +29,6 @@ use Symfony\Component\Process\Process;
 use Yosymfony\ResourceWatcher\Crc32ContentHash;
 use Yosymfony\ResourceWatcher\ResourceCacheMemory;
 use Yosymfony\ResourceWatcher\ResourceWatcher;
-use Yosymfony\ResourceWatcher\ResourceWatcherResult;
 
 /**
  * Serve command.
@@ -95,8 +94,9 @@ The <info>%command.name%</> command starts the live-reloading-built-in web serve
   <info>%command.full_name% --no-watch</>
 
 To speed up local development you can enable <comment>incremental builds</comment> with the <info>--incremental</info> option.
-When only content pages change, Cecil rebuilds <comment>just those pages</comment> instead of the whole website;
-any other change (layout, data, config, theme, static or asset file) triggers a full rebuild:
+When content pages change, Cecil rebuilds <comment>just those pages</comment>.
+When templates change, Cecil rebuilds <comment>only pages using those templates</comment> (including Twig dependencies such as extends/include).
+Any other change (data, config, static or asset file, or file deletion) triggers a full rebuild:
 
   <info>%command.full_name% --incremental</>
 
@@ -487,7 +487,21 @@ EOF
                         $output->writeln('');
 
                         if ($this->incrementalEnabled) {
-                            $this->runIncrementalBuild($watcher, $output, $processOutputCallback, $flushBuildOutput, $buildProcess);
+                            (new IncrementalBuildExecutor(
+                                new IncrementalBuildResolver(
+                                    $this->getBuilder(),
+                                    !empty($this->buildProcessBaseOptions['drafts'])
+                                )
+                            ))->execute(
+                                $watcher,
+                                $output,
+                                fn (?string $page): Process => $this->createBuildProcess($page),
+                                $processOutputCallback,
+                                $flushBuildOutput,
+                                function () use ($output): void {
+                                    $this->buildSuccessActions($output);
+                                }
+                            );
                         } else {
                             $buildProcess->run($processOutputCallback);
                             $flushBuildOutput();
@@ -513,100 +527,6 @@ EOF
         }
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * Runs an incremental build based on the watcher result.
-     *
-     * If every change is an isolated content page (created or updated), Cecil rebuilds
-     * only those pages. Any other change (deletion, layout, data, config, theme, static
-     * or asset file) triggers a full rebuild.
-     */
-    private function runIncrementalBuild(
-        ResourceWatcherResult $watcher,
-        OutputInterface $output,
-        callable $processOutputCallback,
-        callable $flushBuildOutput,
-        Process $fullBuildProcess
-    ): void {
-        $pages = $this->resolveIncrementalPages($watcher);
-
-        // null means a full rebuild is required
-        if ($pages === null) {
-            $output->writeln('<comment>Incremental: full rebuild required</comment>');
-            $fullBuildProcess->run($processOutputCallback);
-            $flushBuildOutput();
-            if ($fullBuildProcess->isSuccessful()) {
-                $this->buildSuccessActions($output);
-            }
-
-            return;
-        }
-
-        $allSuccessful = true;
-        foreach ($pages as $page) {
-            $output->writeln(\sprintf('<comment>Incremental: building page "%s"</comment>', $page));
-            $process = $this->createBuildProcess($page);
-            $process->run($processOutputCallback);
-            $flushBuildOutput();
-            if (!$process->isSuccessful()) {
-                $allSuccessful = false;
-            }
-        }
-        if ($allSuccessful) {
-            $this->buildSuccessActions($output);
-        }
-    }
-
-    /**
-     * Resolves the list of content pages to rebuild from the watcher result.
-     *
-     * Returns an array of page paths (relative to the pages directory) when an incremental
-     * rebuild is possible, or `null` when a full rebuild is required.
-     *
-     * @return array<int, string>|null
-     */
-    private function resolveIncrementalPages(ResourceWatcherResult $watcher): ?array
-    {
-        // a deletion may impact lists, sections, taxonomies, etc.: full rebuild
-        if (\count($watcher->getDeletedFiles()) > 0) {
-            return null;
-        }
-
-        $changedFiles = array_merge($watcher->getNewFiles(), $watcher->getUpdatedFiles());
-        if (\count($changedFiles) === 0) {
-            return null;
-        }
-
-        $config = $this->getBuilder()->getConfig();
-        $pagesPath = $this->normalizePath($config->getPagesPath());
-        $extensions = array_map('strtolower', (array) $config->get('pages.ext'));
-
-        $pages = [];
-        foreach ($changedFiles as $file) {
-            $normalized = $this->normalizePath($file);
-            // file must live inside the pages directory
-            if (strncmp($normalized, $pagesPath . '/', \strlen($pagesPath) + 1) !== 0) {
-                return null;
-            }
-            // file extension must be a valid page extension
-            $extension = strtolower(pathinfo($normalized, PATHINFO_EXTENSION));
-            if (!\in_array($extension, $extensions, true)) {
-                return null;
-            }
-            $relative = substr($normalized, \strlen($pagesPath) + 1);
-            $pages[$relative] = $relative;
-        }
-
-        return array_values($pages);
-    }
-
-    /**
-     * Normalizes a filesystem path to use forward slashes without a trailing slash.
-     */
-    private function normalizePath(string $path): string
-    {
-        return rtrim(str_replace('\\', '/', $path), '/');
     }
 
     /**
@@ -637,10 +557,18 @@ EOF
      */
     private function setupWatcher(bool $noignorevcs = false): ResourceWatcher
     {
+        $watcherExcludes = [
+            (string) $this->getBuilder()->getConfig()->get('output.dir'),
+            self::SERVE_OUTPUT,
+            Builder::TMP_DIR,
+            (string) $this->getBuilder()->getConfig()->get('cache.dir'),
+        ];
+        $watcherExcludes = array_values(array_unique(array_filter($watcherExcludes)));
+
         $finder = new Finder();
         $finder->files()
             ->in($this->getPath())
-            ->exclude((string) $this->getBuilder()->getConfig()->get('output.dir'));
+            ->exclude($watcherExcludes);
         if (file_exists(Util::joinFile($this->getPath(), '.gitignore')) && $noignorevcs === false) {
             $finder->ignoreVCSIgnored(true);
         }

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -48,8 +48,8 @@ class Serve extends AbstractCommand
     /** @var string PHP executable path used to spawn build processes. */
     protected $php;
 
-    /** @var float Build process timeout, in seconds. */
-    protected $processTimeout;
+    /** @var float|null Build process timeout, in seconds. */
+    protected $processTimeout = null;
 
     /**
      * Base options used to build the `build` process arguments.


### PR DESCRIPTION
This pull request introduces incremental build support to the serve command, allowing Cecil to rebuild only changed pages or those affected by template changes during local development. The implementation adds two new core classes to determine which pages require rebuilding and to execute targeted builds, and updates the CLI, documentation, and help messages to reflect the new `--incremental` option.

**Incremental build support:**

* Added the `--incremental` (`-i`) option to the `serve` command, enabling incremental builds that only rebuild changed pages or those affected by template changes. [[1]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R74) [[2]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R157-R161) [[3]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R96-R102) [[4]](diffhunk://#diff-1638e6e2e8f4b5d62b381c99b8d35aaf69ed4944f4bdab06c0cce3e50a53d190R173) [[5]](diffhunk://#diff-bd7c60a0fa61e1cf76dcbf196248b4ec468d0a0a3608c57722f21875fab757bfR171)
* Introduced the `IncrementalBuildResolver` class to determine which content pages are impacted by file changes, supporting both content and template dependency analysis.
* Added the `IncrementalBuildExecutor` class to coordinate and run incremental or full builds as needed, integrating with the serve command’s watcher.
* Updated `Serve` command logic to use the new incremental build system, including process management and option handling. [[1]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62R45-R59) [[2]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62L157-R185) [[3]](diffhunk://#diff-ca508d8b0db4c9bf218c5fd1f2846baabcb64a7e8d07241c8d01d86e06d01a62L167-R197)

**Documentation updates:**

* Updated both English and French documentation and help messages to describe the incremental build feature, including usage examples and detailed behavior. [[1]](diffhunk://#diff-bd7c60a0fa61e1cf76dcbf196248b4ec468d0a0a3608c57722f21875fab757bfL4-R4) [[2]](diffhunk://#diff-bd7c60a0fa61e1cf76dcbf196248b4ec468d0a0a3608c57722f21875fab757bfR198-R204) [[3]](diffhunk://#diff-1638e6e2e8f4b5d62b381c99b8d35aaf69ed4944f4bdab06c0cce3e50a53d190L5-R5) [[4]](diffhunk://#diff-1638e6e2e8f4b5d62b381c99b8d35aaf69ed4944f4bdab06c0cce3e50a53d190R200-R206)

These changes significantly improve development workflow speed by avoiding unnecessary full site rebuilds when only a subset of pages or templates change.