### PR TITLE
Optimize page loader sorting path comparisons

### DIFF
--- a/src/Step/Pages/Load.php
+++ b/src/Step/Pages/Load.php
@@ -74,7 +74,7 @@ class Load extends AbstractStep
                     return 1;
                 }
                 // sort by name
-                return \strnatcasecmp($a->getRelativePathname(), $b->getRelativePathname());
+                return strnatcasecmp($a->getRelativePathname(), $b->getRelativePathname());
             });
         // load only one page?
         if ($this->page) {

--- a/src/Step/Pages/Load.php
+++ b/src/Step/Pages/Load.php
@@ -67,14 +67,14 @@ class Load extends AbstractStep
             ->in($this->config->getPagesPath())
             ->sort(function (SplFileInfo $a, SplFileInfo $b): int {
                 // section's index first
-                if ($a->getRelativePath() == $b->getRelativePath() && $a->getBasename('.' . $a->getExtension()) == 'index') {
+                if ($a->getRelativePath() === $b->getRelativePath() && $a->getBasename('.' . $a->getExtension()) === 'index') {
                     return -1;
                 }
-                if ($b->getRelativePath() == $a->getRelativePath() && $b->getBasename('.' . $b->getExtension()) == 'index') {
+                if ($b->getRelativePath() === $a->getRelativePath() && $b->getBasename('.' . $b->getExtension()) === 'index') {
                     return 1;
                 }
                 // sort by name
-                return strnatcasecmp($a->getRealPath(), $b->getRealPath());
+                return \strnatcasecmp($a->getRelativePathname(), $b->getRelativePathname());
             });
         // load only one page?
         if ($this->page) {


### PR DESCRIPTION
## Summary
- replace page-load sort comparator path fallback from getRealPath() to getRelativePathname()
- keep index-first ordering within each section
- switch equality checks in comparator to strict comparisons

## Why
The pages load step sorts every discovered page before parsing. Using getRealPath() inside the comparator triggers repeated path resolution during sort comparisons, which adds avoidable filesystem overhead on larger sites. Sorting on relative pathnames keeps behavior while reducing comparator cost.

## Validation
- composer code:analyse
- composer code:style
- composer test
- composer test:cli