### PR TITLE
Enable default syntax highlighting and update documentation

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -92,7 +92,7 @@ return [
         'frontmatter' => 'yaml', // front matter format: `yaml`, `ini`, `toml` or `json`
         'body' => [
             'toc' => ['h2', 'h3'], // headers used to build the table of contents
-            'highlight' => false, // enables code syntax highlighting
+            'highlight' => true, // enables code syntax highlighting
             'images' => [
                 'formats' => [], // creates and adds formats images as `source` (e.g.: ['avif', 'webp'])
                 'resize' => 0, // apply a global width to images (in pixels, `0` to disable)

--- a/docs/2-Content.fr.md
+++ b/docs/2-Content.fr.md
@@ -550,8 +550,8 @@ Est rendu en :
 echo "Hello world";
 ```
 
-:::important
-Vous devez ajouter la [StyleSheet](https://highlightjs.org/download/) dans l’en-tête de votre template.
+:::info
+Vous pouvez personnaliser le style de coloration syntaxique en créant votre propre thème. Consultez le [guide des thèmes de Highlight.js](https://highlightjs.readthedocs.io/en/latest/theme-guide.html).
 :::
 
 ### Texte inséré

--- a/docs/2-Content.fr.md
+++ b/docs/2-Content.fr.md
@@ -2,7 +2,7 @@
 title: Contenu
 description: "Créer du contenu et l’organiser."
 date: 2026-03-27
-updated: 2026-04-20
+updated: 2026-07-02
 slug: contenu
 -->
 # Contenu
@@ -526,7 +526,15 @@ caution
 
 ### Coloration syntaxique
 
-Active le surligneur syntaxique des blocs de code en définissant l’option [pages.body.highlight.enabled](4-Configuration.md#pages-body-highlight) à `true`.
+La coloration syntaxique des blocs de code est activée par défaut avec l’option [pages.body.highlight](4-Configuration.md#pages-body-highlight).
+
+Si besoin, vous pouvez la désactiver avec :
+
+```yaml
+pages:
+  body:
+    highlight: false
+```
 
 _Exemple :_
 

--- a/docs/2-Content.md
+++ b/docs/2-Content.md
@@ -548,8 +548,8 @@ Is rendered to:
 echo "Hello world";
 ```
 
-:::important
-You must add the [StyleSheet](https://highlightjs.org/download/) in the head of your template.
+:::info
+You can customize the syntax highlighting style by creating your own theme. See the [Highlight.js Theme Guide](https://highlightjs.readthedocs.io/en/latest/theme-guide.html).
 :::
 
 ### Inserted text

--- a/docs/2-Content.md
+++ b/docs/2-Content.md
@@ -1,7 +1,7 @@
 <!--
 description: "Create content and organize it."
 date: 2021-05-07
-updated: 2026-04-20
+updated: 2026-07-02
 -->
 # Content
 
@@ -524,7 +524,15 @@ caution
 
 ### Syntax highlight
 
-Enables code block syntax highlighter by setting the [pages.body.highlight.enabled](4-Configuration.md#pages-body-highlight) option to `true`.
+Code block syntax highlighting is enabled by default with the [pages.body.highlight](4-Configuration.md#pages-body-highlight) option.
+
+If needed, you can disable it with:
+
+```yaml
+pages:
+  body:
+    highlight: false
+```
 
 _Example:_
 

--- a/docs/4-Configuration.fr.md
+++ b/docs/4-Configuration.fr.md
@@ -2,7 +2,7 @@
 title: Configuration
 description: "Configurez votre site web."
 date: 2026-03-27
-updated: 2026-06-13
+updated: 2026-07-02
 slug: configuration
 -->
 # Configuration
@@ -544,12 +544,12 @@ pages:
 
 #### pages.body.highlight
 
-Active la coloration syntaxique du code (`false` par défaut).
+Active la coloration syntaxique du code (`true` par défaut).
 
 ```yaml
 pages:
   body:
-    highlight: false
+    highlight: false # définissez à false pour désactiver la coloration syntaxique
 ```
 
 #### pages.body.images

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -1,7 +1,7 @@
 <!--
 description: "Configure your website."
 date: 2021-05-07
-updated: 2026-06-13
+updated: 2026-07-02
 -->
 # Configuration
 
@@ -542,12 +542,12 @@ pages:
 
 #### pages.body.highlight
 
-Enables code syntax highlighting (`false` by default).
+Enables code syntax highlighting (`true` by default).
 
 ```yaml
 pages:
   body:
-    highlight: false
+    highlight: false # set to false to disable syntax highlighting
 ```
 
 #### pages.body.images

--- a/resources/layouts/_default/page.html.twig
+++ b/resources/layouts/_default/page.html.twig
@@ -12,7 +12,7 @@
     {%- endblock head ~%}
     {%- block head_css ~%}
     <style>{% apply minify_css ~%}
-      {{- include('partials/pico.css.twig') }}
+      {{- include('partials/pico.css.twig') ~}}
       /* Pico CSS overrides */
       body > header,
       body > main,
@@ -93,6 +93,7 @@
         border: 1px solid red;
         border-left-width: 4px;
       }
+      {{ include('partials/highlight.css.twig') ~}}
     {% endapply %}</style>
     {%- endblock head_css ~%}
   </head>

--- a/resources/layouts/_default/page.html.twig
+++ b/resources/layouts/_default/page.html.twig
@@ -93,7 +93,9 @@
         border: 1px solid red;
         border-left-width: 4px;
       }
-      {{ include('partials/highlight.css.twig') ~}}
+      {%- if config.pages.body.highlight|default(true) ~%}
+      {{- include('partials/highlight.css.twig') ~}}
+      {%- endif ~%}
     {% endapply %}</style>
     {%- endblock head_css ~%}
   </head>

--- a/resources/layouts/partials/highlight.css.twig
+++ b/resources/layouts/partials/highlight.css.twig
@@ -1,0 +1,131 @@
+{# Highlight code CSS ~#}
+      /* Atom One Light by Daniel Gamage */
+      .hljs {
+        color: #383a42;
+        background: #fafafa;
+      }
+      .hljs-comment,
+      .hljs-quote {
+        color: #a0a1a7;
+        font-style: italic;
+      }
+      .hljs-doctag,
+      .hljs-keyword,
+      .hljs-formula {
+        color: #a626a4;
+      }
+      .hljs-section,
+      .hljs-name,
+      .hljs-selector-tag,
+      .hljs-deletion,
+      .hljs-subst {
+        color: #e45649;
+      }
+      .hljs-literal {
+        color: #0184bb;
+      }
+      .hljs-string,
+      .hljs-regexp,
+      .hljs-addition,
+      .hljs-attribute,
+      .hljs-meta .hljs-string {
+        color: #50a14f;
+      }
+      .hljs-attr,
+      .hljs-variable,
+      .hljs-template-variable,
+      .hljs-type,
+      .hljs-selector-class,
+      .hljs-selector-attr,
+      .hljs-selector-pseudo,
+      .hljs-number {
+        color: #986801;
+      }
+      .hljs-symbol,
+      .hljs-bullet,
+      .hljs-link,
+      .hljs-meta,
+      .hljs-selector-id,
+      .hljs-title {
+        color: #4078f2;
+      }
+      .hljs-built_in,
+      .hljs-title.class_,
+      .hljs-class .hljs-title {
+        color: #c18401;
+      }
+      .hljs-emphasis {
+        font-style: italic;
+      }
+      .hljs-strong {
+        font-weight: bold;
+      }
+      .hljs-link {
+        text-decoration: underline;
+      }
+      @media (prefers-color-scheme: dark) {
+        /* Atom One Dark by Daniel Gamage */
+        .hljs {
+          color: #abb2bf;
+          background: #282c34;
+        }
+        .hljs-comment,
+        .hljs-quote {
+          color: #5c6370;
+          font-style: italic;
+        }
+        .hljs-doctag,
+        .hljs-keyword,
+        .hljs-formula {
+          color: #c678dd;
+        }
+        .hljs-section,
+        .hljs-name,
+        .hljs-selector-tag,
+        .hljs-deletion,
+        .hljs-subst {
+          color: #e06c75;
+        }
+        .hljs-literal {
+          color: #56b6c2;
+        }
+        .hljs-string,
+        .hljs-regexp,
+        .hljs-addition,
+        .hljs-attribute,
+        .hljs-meta .hljs-string {
+          color: #98c379;
+        }
+        .hljs-attr,
+        .hljs-variable,
+        .hljs-template-variable,
+        .hljs-type,
+        .hljs-selector-class,
+        .hljs-selector-attr,
+        .hljs-selector-pseudo,
+        .hljs-number {
+          color: #d19a66;
+        }
+        .hljs-symbol,
+        .hljs-bullet,
+        .hljs-link,
+        .hljs-meta,
+        .hljs-selector-id,
+        .hljs-title {
+          color: #61aeee;
+        }
+        .hljs-built_in,
+        .hljs-title.class_,
+        .hljs-class .hljs-title {
+          color: #e6c07b;
+        }
+        .hljs-emphasis {
+          font-style: italic;
+        }
+        .hljs-strong {
+          font-weight: bold;
+        }
+        .hljs-link {
+          text-decoration: underline;
+        }
+      }

--- a/resources/layouts/partials/pico.css.twig
+++ b/resources/layouts/partials/pico.css.twig
@@ -1,6 +1,6 @@
 {# Pico CSS (https://picocss.com) ~#}
       @charset "UTF-8";
-      /*
+      /*!
       * Pico CSS ✨ v2.1.1 (https://picocss.com)
       * Copyright 2019-2025 - Licensed under MIT
       */

--- a/resources/layouts/partials/pico.css.twig
+++ b/resources/layouts/partials/pico.css.twig
@@ -1,6 +1,6 @@
 {# Pico CSS (https://picocss.com) ~#}
       @charset "UTF-8";
-      /*!
+      /*
       * Pico CSS ✨ v2.1.1 (https://picocss.com)
       * Copyright 2019-2025 - Licensed under MIT
       */


### PR DESCRIPTION
This pull request enables code syntax highlighting by default, updates the documentation to reflect this change, and integrates a built-in Highlight.js theme (Atom One Light/Dark) directly into the project’s styles. This removes the need for users to manually add Highlight.js stylesheets and clarifies how to customize or disable syntax highlighting.

**Configuration and Feature Changes**
* Changed the default value of `pages.body.highlight` to `true` in `config/default.php`, enabling code syntax highlighting by default.

**Documentation Updates**
* Updated both French and English documentation to state that syntax highlighting is now enabled by default, provided instructions for disabling it, and removed outdated notes about manual stylesheet inclusion. [[1]](diffhunk://#diff-702dd2ca67ac2e40837c567ee2ea4431daed73e35cba93a73de443f56d31eee7L527-R535) [[2]](diffhunk://#diff-d4493497ffacb264e69a66a9f0c1f33c2301c0ea87bea68ccff590aa7962ac43L529-R537) [[3]](diffhunk://#diff-702dd2ca67ac2e40837c567ee2ea4431daed73e35cba93a73de443f56d31eee7L543-R552) [[4]](diffhunk://#diff-d4493497ffacb264e69a66a9f0c1f33c2301c0ea87bea68ccff590aa7962ac43L545-R554)
* Updated the configuration documentation to indicate the new default (`true`) and clarify how to disable highlighting. [[1]](diffhunk://#diff-dd34802189558628f9db6c605f37579dbe2ba943eaffa59d78725e48f5c9c8aaL547-R552) [[2]](diffhunk://#diff-fc7dc7011c3113f2d6ba11642e9229b30eff568e8e38b11269f8626c2fbec306L545-R550)

**Styling Integration**
* Added a new partial, `highlight.css.twig`, containing Atom One Light and Dark Highlight.js themes, and included it in the main page template so syntax highlighting styles are always available. [[1]](diffhunk://#diff-0144699dac6dac0d39c8be2aca3be5e88eda1d9c90be51d25983bcc26afe2880R1-R131) [[2]](diffhunk://#diff-82bb31c6e50eab2870652f374ae6b34938e0b06a44e26fea49e0968c1766bbd6R96)
* Minor formatting and cleanup in CSS partials for consistency. [[1]](diffhunk://#diff-82bb31c6e50eab2870652f374ae6b34938e0b06a44e26fea49e0968c1766bbd6L15-R15) [[2]](diffhunk://#diff-315a12a7b2a11401030640d4c6bb9b05e773231093e2301c147608b786a18600L3-R3)

**General Maintenance**
* Updated the `updated` metadata in documentation files to reflect the latest changes. [[1]](diffhunk://#diff-d4493497ffacb264e69a66a9f0c1f33c2301c0ea87bea68ccff590aa7962ac43L5-R5) [[2]](diffhunk://#diff-702dd2ca67ac2e40837c567ee2ea4431daed73e35cba93a73de443f56d31eee7L4-R4) [[3]](diffhunk://#diff-dd34802189558628f9db6c605f37579dbe2ba943eaffa59d78725e48f5c9c8aaL5-R5) [[4]](diffhunk://#diff-fc7dc7011c3113f2d6ba11642e9229b30eff568e8e38b11269f8626c2fbec306L4-R4)