### PR TITLE
Optimize page parser by reusing file contents

### DIFF
--- a/src/Collection/Page/Parser.php
+++ b/src/Collection/Page/Parser.php
@@ -59,14 +59,15 @@ class Parser
             if (!$this->file->isReadable()) {
                 throw new RuntimeException('Cannot read file.');
             }
+            $content = $this->file->getContents();
             preg_match(
                 '/' . self::PATTERN . '/s',
-                $this->file->getContents(),
+                $content,
                 $matches
             );
             // if there is not front matter, set body only
             if (empty($matches)) {
-                $this->body = $this->file->getContents();
+                $this->body = $content;
 
                 return $this;
             }


### PR DESCRIPTION
## Summary
- read the page file contents once in `Cecil\Collection\Page\Parser::parse()`
- reuse the same `$content` for front matter regex matching and the no-frontmatter body fallback
- remove duplicate `SplFileInfo::getContents()` calls in the common parse path

## Why
This is a low-risk performance win: parsing every page currently performs redundant file reads when front matter is absent and always re-fetches contents for matching. Reusing one in-memory string reduces I/O overhead across builds.

## Validation
- `composer code`
- `composer test`
- `composer test:cli`