### PR TITLE
feat: support custom translation loaders

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -187,7 +187,16 @@ return [
         ],
         'translations' => [ // i18n
             'dir' => 'translations', // translations files directory
-            'formats' => ['yaml', 'mo'], // translations supported formats
+            'formats' => [ // translations supported formats
+                'yaml' => [
+                    'loader' => 'Symfony\Component\Translation\Loader\YamlFileLoader',
+                    'ext' => ['yml', 'yaml'],
+                ],
+                'mo' => [
+                    'loader' => 'Symfony\Component\Translation\Loader\MoFileLoader',
+                    'ext' => ['mo'],
+                ],
+            ],
         ],
         'extensions' => [ // list of Twig extensions class
             //'<name>' => 'Cecil\Renderer\Extension\<class>',

--- a/docs/3-Templates.fr.md
+++ b/docs/3-Templates.fr.md
@@ -2,6 +2,7 @@
 title: Templates
 description: "Travailler avec les layouts, les templates et les composants."
 date: 2026-05-26
+updated: 2026-07-10
 slug: templates
 -->
 # Templates
@@ -1434,8 +1435,8 @@ Pluraliser :
 
 ### Fichiers de traduction
 
-Les fichiers de traduction doivent être nommés `messages.<locale>.<format>` et stockés dans le répertoire [`translations`](4-Configuration.md#layouts).
-Cecil prend en charge les fichiers `yaml` et `mo` (Gettext) [formats par défaut](4-Configuration.md#layouts).
+Les fichiers de traduction doivent être nommés `messages.<locale>.<extension>` et stockés dans le répertoire [`translations`](4-Configuration.md#layouts).
+Les extensions prises en charge sont définies pour chaque format de traduction dans [`layouts.translations.formats`](4-Configuration.md#layoutstranslations).
 
 Le code locale (ex. : `fr_FR`) d'une langue est défini dans les entrées [`languages`](4-Configuration.md#languages) de la configuration.
 

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -1,7 +1,7 @@
 <!--
 description: "Working with layouts, templates and components."
 date: 2021-05-07
-updated: 2026-05-26
+updated: 2026-07-10
 alias: documentation/layouts
 -->
 # Templates
@@ -1434,8 +1434,8 @@ Pluralize:
 
 ### Translation files
 
-Translation files must be named `messages.<locale>.<format>` and stored in the [`translations`](4-Configuration.md#layouts) directory.  
-Cecil supports `yaml` and `mo` (Gettext) file [formats by default](4-Configuration.md#layouts).
+Translation files must be named `messages.<locale>.<extension>` and stored in the [`translations`](4-Configuration.md#layouts) directory.  
+Supported file extensions are defined by each translation format in [`layouts.translations.formats`](4-Configuration.md#layoutstranslations).
 
 The locale code (e.g.: `fr_FR`) of a language is defined in the [`languages`](4-Configuration.md#languages) entries of the configuration.
 

--- a/docs/4-Configuration.fr.md
+++ b/docs/4-Configuration.fr.md
@@ -2,7 +2,7 @@
 title: Configuration
 description: "Configurez votre site web."
 date: 2026-03-27
-updated: 2026-07-02
+updated: 2026-07-10
 slug: configuration
 -->
 # Configuration
@@ -1041,9 +1041,20 @@ Options de gestion des traductions.
 ```yaml
 layouts:
   translations:
-    dir: translations       # répertoire source des traductions (`translations` par défaut)
-    formats: ['yaml', 'mo'] # format des fichiers de traduction (`yaml` et `mo` par défaut)
+    dir: translations # répertoire source des traductions (`translations` par défaut)
+    formats:          # formats de traduction pris en charge
+      yaml:
+        loader: Symfony\Component\Translation\Loader\YamlFileLoader
+        ext: [yml, yaml]
+      mo:
+        loader: Symfony\Component\Translation\Loader\MoFileLoader
+        ext: [mo]
 ```
+
+Chaque format de traduction définit :
+
+- `loader` : classe du chargeur de traduction Symfony
+- `ext` : une ou plusieurs extensions de fichier associées à ce format
 
 ### layouts.components
 

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -1,7 +1,7 @@
 <!--
 description: "Configure your website."
 date: 2021-05-07
-updated: 2026-07-02
+updated: 2026-07-10
 -->
 # Configuration
 
@@ -1039,9 +1039,20 @@ Translations handling options.
 ```yaml
 layouts:
   translations:
-    dir: translations       # translations source directory (`translations` by default)
-    formats: ['yaml', 'mo'] # translations files format (`yaml` and `mo` by default)
+    dir: translations # translations source directory (`translations` by default)
+    formats:          # translations supported formats
+      yaml:
+        loader: Symfony\Component\Translation\Loader\YamlFileLoader
+        ext: [yml, yaml]
+      mo:
+        loader: Symfony\Component\Translation\Loader\MoFileLoader
+        ext: [mo]
 ```
+
+Each translation format defines:
+
+- `loader`: Symfony translation loader class
+- `ext`: one or more file extensions associated with this format
 
 ### layouts.components
 

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -44,5 +44,5 @@ interface RendererInterface
     /**
      * Adds a translation file.
      */
-    public function addTransResource(string $translationsDir, string $locale): void;
+    public function addTransResource(string $translationsDir, string $locale, ?array $formatsConfig = null): void;
 }

--- a/src/Renderer/Twig.php
+++ b/src/Renderer/Twig.php
@@ -127,25 +127,25 @@ class Twig implements RendererInterface
             $this->builder->getConfig()->isEnabled('cache.translations') ? $this->builder->getConfig()->getCacheTranslationsPath() : null,
             $this->builder->isDebug()
         );
+        $translationsFormats = $this->getTranslationsFormatsConfig();
         if (\count($this->builder->getConfig()->getLanguages()) > 0) {
-            foreach ((array) $this->builder->getConfig()->get('layouts.translations.formats') as $format) {
-                $loader = \sprintf('Symfony\Component\Translation\Loader\%sFileLoader', ucfirst($format));
-                if (class_exists($loader)) {
-                    $this->translator->addLoader($format, new $loader());
+            foreach ($translationsFormats as $format => $config) {
+                if (class_exists($config['loader'])) {
+                    $this->translator->addLoader($format, new $config['loader']());
                     $this->builder->getLogger()->debug(\sprintf('Translation loader for format "%s" found', $format));
                 }
             }
             foreach ($this->builder->getConfig()->getLanguages() as $lang) {
                 // internal
-                $this->addTransResource($this->builder->getConfig()->getTranslationsInternalPath(), $lang['locale']);
+                $this->addTransResource($this->builder->getConfig()->getTranslationsInternalPath(), $lang['locale'], $translationsFormats);
                 // themes
                 if ($themes = $this->builder->getConfig()->getTheme()) {
                     foreach ($themes as $theme) {
-                        $this->addTransResource($this->builder->getConfig()->getThemeDirPath($theme, 'translations'), $lang['locale']);
+                        $this->addTransResource($this->builder->getConfig()->getThemeDirPath($theme, 'translations'), $lang['locale'], $translationsFormats);
                     }
                 }
                 // site
-                $this->addTransResource($this->builder->getConfig()->getTranslationsPath(), $lang['locale']);
+                $this->addTransResource($this->builder->getConfig()->getTranslationsPath(), $lang['locale'], $translationsFormats);
             }
         }
         $this->twig->addExtension(new TranslationExtension($this->translator));
@@ -225,22 +225,68 @@ class Twig implements RendererInterface
     /**
      * {@inheritdoc}
      */
-    public function addTransResource(string $translationsDir, string $locale): void
+    public function addTransResource(string $translationsDir, string $locale, ?array $formatsConfig = null): void
     {
+        $formatsConfig ??= $this->getTranslationsFormatsConfig();
         $locales = [$locale];
         // if locale is 'fr_FR', trying to load ['fr', 'fr_FR']
         if (\strlen($locale) > 2) {
             array_unshift($locales, substr($locale, 0, 2));
         }
         foreach ($locales as $locale) {
-            foreach ((array) $this->builder->getConfig()->get('layouts.translations.formats') as $format) {
-                $translationFile = Util::joinPath($translationsDir, \sprintf('messages.%s.%s', $locale, $format));
-                if (Util\File::getFS()->exists($translationFile)) {
-                    $this->translator->addResource($format, $translationFile, $locale);
-                    $this->builder->getLogger()->debug(\sprintf('Translation file "%s" added', $translationFile));
+            foreach ($formatsConfig as $format => $config) {
+                foreach ($config['ext'] as $ext) {
+                    $translationFile = Util::joinPath($translationsDir, \sprintf('messages.%s.%s', $locale, $ext));
+                    if (Util\File::getFS()->exists($translationFile)) {
+                        $this->translator->addResource($format, $translationFile, $locale);
+                        $this->builder->getLogger()->debug(\sprintf('Translation file "%s" added', $translationFile));
+                    }
                 }
             }
         }
+    }
+
+    /**
+     * @return array<string, array{loader: string, ext: array<string>}>
+     */
+    private function getTranslationsFormatsConfig(): array
+    {
+        $formatsConfig = [];
+        foreach ((array) $this->builder->getConfig()->get('layouts.translations.formats') as $format => $config) {
+            if (\is_string($config)) {
+                $formatsConfig[$config] = [
+                    'loader' => \sprintf('Symfony\\Component\\Translation\\Loader\\%sFileLoader', ucfirst($config)),
+                    'ext' => [$config],
+                ];
+
+                continue;
+            }
+            if (!\is_array($config)) {
+                continue;
+            }
+
+            $format = \is_string($format) ? $format : ($config['name'] ?? null);
+            if (!\is_string($format) || $format === '') {
+                continue;
+            }
+
+            $extensions = [];
+            foreach ((array) ($config['ext'] ?? [$format]) as $ext) {
+                if (!\is_string($ext) || $ext === '') {
+                    continue;
+                }
+                $extensions[] = $ext;
+            }
+
+            $formatsConfig[$format] = [
+                'loader' => \is_string($config['loader'] ?? null)
+                    ? $config['loader']
+                    : \sprintf('Symfony\\Component\\Translation\\Loader\\%sFileLoader', ucfirst($format)),
+                'ext' => $extensions,
+            ];
+        }
+
+        return $formatsConfig;
     }
 
     /**


### PR DESCRIPTION
This pull request refactors and improves the translation formats configuration and loading mechanism in the application. The main changes include switching from a simple list of formats to a more flexible configuration array, updating method signatures and usages to support the new structure, and introducing a helper method to handle formats configuration parsing. This makes it easier to support new translation formats and file extensions in the future.

**Translation formats configuration improvements:**

* Changed the `layouts.translations.formats` config in `config/default.php` from a simple list (e.g., `['yaml', 'mo']`) to a keyed array with loader and extension details for each format, allowing for greater flexibility and extensibility.
* Updated the `addTransResource` method signature in `RendererInterface.php` and its implementation in `Twig.php` to accept an optional formats configuration array, supporting the new config structure. [[1]](diffhunk://#diff-7386255975c61643876d7d6122b0c8e34da76d9c4ac3750b5d642903de786ef2L47-R47) [[2]](diffhunk://#diff-58ec00302bdc4393aabfd90ab92764fd8f908af56fe748a52301ebb50209be54L228-R290)

**Translation loading logic updates:**

* Refactored the translation loader registration and resource addition in `Twig.php` to use the new formats configuration, supporting multiple file extensions per format and custom loaders. [[1]](diffhunk://#diff-58ec00302bdc4393aabfd90ab92764fd8f908af56fe748a52301ebb50209be54R130-R148) [[2]](diffhunk://#diff-58ec00302bdc4393aabfd90ab92764fd8f908af56fe748a52301ebb50209be54L228-R290)
* Added a private `getTranslationsFormatsConfig` helper method in `Twig.php` to parse and normalize the formats configuration, ensuring backward compatibility and robust handling of various config shapes.