### PR TITLE
feat: add theme toggle to site navigation

### DIFF
--- a/resources/layouts/_default/page.html.twig
+++ b/resources/layouts/_default/page.html.twig
@@ -2,13 +2,12 @@
 <html lang="{{ site.language }}">
   <head>
     {%- block head ~%}
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {%- block head_metatags ~%}
     {{- include('partials/metatags.html.twig', {page, site}, with_context = false) ~}}
     {%- endblock head_metatags ~%}
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black">
+    <meta name="color-scheme" content="light dark">
     {%- endblock head ~%}
     {%- block head_css ~%}
     <style>{% apply minify_css ~%}
@@ -92,6 +91,20 @@
       main .note-caution {
         border: 1px solid red;
         border-left-width: 4px;
+      }
+      /* Theme selector */
+      #theme-toggle {
+        --pico-background-color: transparent;
+        --pico-border-color: transparent;
+        --pico-color: var(--pico-muted-color);
+        padding: 0;
+        border: none;
+        outline:none;
+        transform: translateY(0.4rem);
+      }
+      #theme-toggle:focus {
+        outline-style: none;
+        box-shadow: none;
       }
       {%- if config.pages.body.highlight|default(true) ~%}
       {{- include('partials/highlight.css.twig') ~}}

--- a/resources/layouts/_default/page.html.twig
+++ b/resources/layouts/_default/page.html.twig
@@ -94,13 +94,14 @@
       }
       /* Theme selector */
       #theme-toggle {
+        position: absolute;
+        top: 0;
+        right: 0;
         --pico-background-color: transparent;
         --pico-border-color: transparent;
         --pico-color: var(--pico-muted-color);
-        padding: 0;
         border: none;
         outline:none;
-        transform: translateY(0.4rem);
       }
       #theme-toggle:focus {
         outline-style: none;
@@ -122,6 +123,7 @@
         <div class="site-title">{{ site.title }}</div>
         {%- endif ~%}
         <p>{{ site.baseline }}</p>
+        {{- include('partials/theme-selector.html.twig', {}, with_context = false) ~}}
       </hgroup>
       {{- include('partials/navigation.html.twig', {menu: site.menus.main}, with_context = false) ~}}
       {%- endblock header ~%}

--- a/resources/layouts/partials/navigation.html.twig
+++ b/resources/layouts/partials/navigation.html.twig
@@ -5,6 +5,5 @@
           <li><a href="{{ url(item.url) }}" data-weight="{{ item.weight }}">{{ item.name }}</a></li>
         {%- endfor ~%}
         </ul>
-        {{- include('partials/theme-selector.html.twig', {}, with_context = false) ~}}
       </nav>
       {%- endif ~%}

--- a/resources/layouts/partials/navigation.html.twig
+++ b/resources/layouts/partials/navigation.html.twig
@@ -5,5 +5,6 @@
           <li><a href="{{ url(item.url) }}" data-weight="{{ item.weight }}">{{ item.name }}</a></li>
         {%- endfor ~%}
         </ul>
+        {{- include('partials/theme-selector.html.twig', {}, with_context = false) ~}}
       </nav>
       {%- endif ~%}

--- a/resources/layouts/partials/theme-selector.html.twig
+++ b/resources/layouts/partials/theme-selector.html.twig
@@ -1,6 +1,6 @@
 {#- theme switcher ~#}
 <button id="theme-toggle" type="button" style="cursor: pointer;" title="{% trans %}Change theme color{% endtrans %}">
-  <svg id="theme-toggle-dark-icon" style="width: auto; height: 1.5rem;" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
+  <svg id="theme-toggle-dark-icon" style="width: auto; height: 1.4rem;" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
   <svg id="theme-toggle-light-icon" style="width: auto; height: 1.5rem; display: none;" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path></svg>
 </button>
 <script>{% apply minify_js ~%}

--- a/resources/layouts/partials/theme-selector.html.twig
+++ b/resources/layouts/partials/theme-selector.html.twig
@@ -1,0 +1,62 @@
+{#- theme switcher ~#}
+<button id="theme-toggle" type="button" style="cursor: pointer;" title="{% trans %}Change theme color{% endtrans %}">
+  <svg id="theme-toggle-dark-icon" style="width: auto; height: 1.5rem;" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
+  <svg id="theme-toggle-light-icon" style="width: auto; height: 1.5rem; display: none;" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path></svg>
+</button>
+<script>{% apply minify_js ~%}
+  var themeToggleDarkIcon = document.getElementById('theme-toggle-dark-icon');
+  var themeToggleLightIcon = document.getElementById('theme-toggle-light-icon');
+  var themeToggleBtn = document.getElementById('theme-toggle');
+  function getSystemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  function saveThemePreference(theme) {
+    if (theme === getSystemTheme()) {
+      localStorage.removeItem('theme');
+    } else {
+      localStorage.setItem('theme', theme);
+    }
+  }
+  function updateTheme() {
+    if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.dataset.theme = 'dark';
+      themeToggleDarkIcon.style.display = 'none';
+      themeToggleLightIcon.style.display = '';
+    } else {
+      document.documentElement.dataset.theme = 'light';
+      themeToggleLightIcon.style.display = 'none';
+      themeToggleDarkIcon.style.display = '';
+    }
+  }
+  updateTheme();
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', ({matches:isDark}) => {
+      var storedTheme = localStorage.getItem('theme');
+      if (storedTheme === (isDark ? 'dark' : 'light')) {
+        localStorage.removeItem('theme');
+      }
+      updateTheme();
+    })
+  themeToggleBtn.addEventListener('click', function() {
+    themeToggleDarkIcon.style.display = themeToggleDarkIcon.style.display === 'none' ? '' : 'none';
+    themeToggleLightIcon.style.display = themeToggleLightIcon.style.display === 'none' ? '' : 'none';
+    if (localStorage.getItem('theme')) {
+      if (localStorage.getItem('theme') === 'light') {
+        saveThemePreference('dark');
+        updateTheme();
+      } else {
+        saveThemePreference('light');
+        updateTheme();
+      }
+    } else {
+      if (document.documentElement.dataset.theme === 'dark') {
+        saveThemePreference('light');
+        updateTheme();
+      } else {
+        saveThemePreference('dark');
+        updateTheme();
+      }
+    }
+  });
+{% endapply %}</script>


### PR DESCRIPTION
Introduces a new `theme-selector` partial with a light/dark toggle button and inline script to switch themes, persist user preference in `localStorage`, and react to system color-scheme changes. The navigation now includes this selector, and page layout metadata/CSS were updated to support it (`color-scheme` meta tag, toggle-specific styles, and normalized UTF-8 charset casing).