### PR TITLE
fix: stop double-escaping title in auto JSON-LD blocks

### DIFF
--- a/resources/layouts/partials/metatags.html.twig
+++ b/resources/layouts/partials/metatags.html.twig
@@ -8,6 +8,7 @@
   {%- set title_pagination_shownumber = page.metatags.title.pagination.shownumber|default(site.metatags.title.pagination.shownumber ?? true) %}
   {%- set title_pagination_label = page.metatags.title.pagination.label|default(site.metatags.title.pagination.label|default('Page %s')) %}
   {%- set title = page.title|trans|e %}
+  {%- set title_raw = page.title|trans %}
   {%- set title_html = title ~ title_divider ~ site.title|e %}
   {%- if title_only %}
     {%- set title_html = title %}
@@ -15,6 +16,7 @@
   {#- homepage title #}
   {%- if page.type == 'homepage' %}
     {%- set title = site.title|e %}
+    {%- set title_raw = site.title %}
     {%- set title_html = title ~ title_divider ~ site.baseline|default|e %}
     {%- if title_only or site.baseline|default is empty %}
       {%- set title_html = title %}
@@ -24,6 +26,7 @@
   {%- if page.paginator.current|default(0) > 1 %}
     {%- if title_pagination_shownumber %}
       {%- set title = page.title|e ~ ' (' ~ title_pagination_label|format(page.paginator.current) ~ ')' %}
+      {%- set title_raw = page.title ~ ' (' ~ title_pagination_label|format(page.paginator.current) ~ ')' %}
       {%- set title_html = page.title|e ~ title_divider ~ title_pagination_label|format(page.paginator.current) ~ title_divider ~ site.title|e %}
       {%- if title_only %}
         {%- set title_html = page.title|e ~ title_divider ~ title_pagination_label|format(page.paginator.current) %}
@@ -31,6 +34,8 @@
     {%- endif %}
   {%- endif %}
 {% endif %}
+{#- raw (unescaped) title, for contexts with their own escaping strategy (e.g. jsonld.js.twig) #}
+{%- set title_raw = title_raw|default(title) %}
 {# description #}
 {% set description = page.description|default(site.description)|e %}
 {# keywords / tags #}
@@ -304,7 +309,9 @@
   {#- template: structured data ~#}
   {%- block metatags_structured_data ~%}
   {%- if page.metatags.data ?? config.metatags.data ?? config.metatags.jsonld ?? false ~%}
-  {{- include('partials/jsonld.js.twig', {author}) ~}}
+  {#- with_context = false: jsonld.js.twig has its own (JS) escaping strategy,
+      it must not inherit `title` already HTML-escaped for this template ~#}
+  {{- include('partials/jsonld.js.twig', {author, page, title: title_raw}, with_context = false) ~}}
   {%- endif ~%}
   {%- endblock metatags_structured_data ~%}
 {%- endblock content -%}


### PR DESCRIPTION
## Bug

`partials/metatags.html.twig` computes `title` HTML-escaped (`page.title|trans|e`) for use in `<title>`, OpenGraph and Twitter meta tags. Its include of `partials/jsonld.js.twig` was the only one in the file missing `with_context = false`, so this already-escaped `title` leaked into `jsonld.js.twig` via inherited context — which then applies its own `|e('js')` on top of it.

The `&` from the HTML entity gets re-escaped, so the auto `WebPage` / `BreadcrumbList` / `NewsArticle` / `VideoObject` JSON-LD blocks end up with garbage instead of an apostrophe. For example, a title containing `d'utiliser` renders as the literal string `d&#039;utiliser` in the JSON-LD output (garbled through JS-escaping into `d&#039;utiliser`), instead of `d'utiliser`. This gets flagged as invalid/dirty structured data by tools like the Rich Results Test.

Only the JSON-LD partial is affected — `<title>`, OG and Twitter tags render correctly since they consume the pre-escaped `title` directly without a second escaping pass.

## Fix

- Track an unescaped `title_raw` alongside `title`, mirroring the same fallback logic (page title / homepage → `site.title` / paginated title suffix).
- Pass `with_context = false` to the `jsonld.js.twig` include, explicitly passing `{author, page, title: title_raw}` — matching the pattern already used by the other 3 includes in this file.

`jsonld.js.twig` itself is unchanged: its existing `title|default(page.title)|e('js')` now receives raw data and escapes it exactly once.

## Testing

- Built a minimal site locally with a page title containing an apostrophe: `WebPage.name`, `BreadcrumbList` item name, and `NewsArticle.headline` now render the correct apostrophe instead of double-escaped garbage.
- Built the homepage with no `title` in front matter to confirm the `site.title` fallback still works (no regression on the empty-title edge case).
- Full test suite passes: `vendor/bin/phpunit` — 56 tests, 214 assertions, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)