### PR TITLE
feat: optional Dublin Core metatags support

### DIFF
--- a/docs/4-Configuration.fr.md
+++ b/docs/4-Configuration.fr.md
@@ -2,7 +2,7 @@
 title: Configuration
 description: "Configurez votre site web."
 date: 2026-03-27
-updated: 2026-07-10
+updated: 2026-08-17
 slug: configuration
 -->
 # Configuration
@@ -320,6 +320,7 @@ Ce template ajoute les balises meta suivantes :
 - Identifiant de profil Facebook
 - [Twitter/X Card](https://developer.x.com/docs/x-for-websites/cards/guides/getting-started)
 - [Fediverse tag](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/)
+- [Dublin Core](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/)
 - [Structured data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data) (JSON-LD)
 
 #### options metatags
@@ -386,6 +387,7 @@ metatags:
   articles: "blog"         # articles' section (`blog` by default)
   twitter: true            # includes Twitter/X Card meta tags (`true` by default)
   mastodon: true           # includes Mastodon meta tags (`true` by default)
+  dc: false                # includes Dublin Core meta tags (`false` by default)
   data: false              # includes JSON-LD structured data (`false` by default)
 ```
 

--- a/docs/4-Configuration.md
+++ b/docs/4-Configuration.md
@@ -1,7 +1,7 @@
 <!--
 description: "Configure your website."
 date: 2021-05-07
-updated: 2026-07-10
+updated: 2026-08-17
 -->
 # Configuration
 
@@ -318,6 +318,7 @@ This template adds the following meta tags:
 - Facebook profile ID
 - [Twitter/X Card](https://developer.x.com/docs/x-for-websites/cards/guides/getting-started)
 - [Fediverse tag](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/)
+- [Dublin Core](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/)
 - [Structured data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data) (JSON-LD)
 
 #### metatags options
@@ -384,6 +385,7 @@ metatags:
   articles: "blog"         # articles' section (`blog` by default)
   twitter: true            # includes Twitter/X Card meta tags (`true` by default)
   mastodon: true           # includes Mastodon meta tags (`true` by default)
+  dc: false                # includes Dublin Core meta tags (`false` by default)
   data: false              # includes JSON-LD structured data (`false` by default)
 ```
 

--- a/resources/layouts/partials/metatags.html.twig
+++ b/resources/layouts/partials/metatags.html.twig
@@ -301,6 +301,28 @@
   {%- if mastodon.creator and (page.metatags.mastodon ?? site.metatags.mastodon ?? true) ~%}
     <meta name="fediverse:creator" content="@{{ mastodon.creator|trim('@', side: 'left') }}">
   {%- endif ~%}
+  {#- template: Dublin Core ~#}
+  {%- block metatags_dc ~%}
+  {%- if page.metatags.dc ?? site.metatags.dc ?? false ~%}
+    <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/">
+    <meta name="DC.title" content="{{ opengraph.title }}">
+    <meta name="DC.description" content="{{ description }}">
+    {%- if keywords is not empty ~%}
+    <meta name="DC.subject" content="{{ keywords|join(', ') }}">
+    {%- endif ~%}
+    {%- if page.date is defined ~%}
+    <meta name="DC.date" content="{{ page.date|date('Y-m-d') }}">
+    {%- endif ~%}
+    {%- if author.name|default ~%}
+    <meta name="DC.creator" content="{{ author.name|e }}">
+    {%- endif ~%}
+    <meta name="DC.publisher" content="{{ site.title|e }}">
+    <meta name="DC.type" content="Text">
+    <meta name="DC.format" content="text/html">
+    <meta name="DC.identifier" content="{{ opengraph.url }}">
+    <meta name="DC.language" content="{{ site.language.locale }}">
+  {%- endif ~%}
+  {%- endblock metatags_dc ~%}
   {#- template: structured data ~#}
   {%- block metatags_structured_data ~%}
   {%- if page.metatags.data ?? config.metatags.data ?? config.metatags.jsonld ?? false ~%}

--- a/resources/layouts/partials/metatags.html.twig
+++ b/resources/layouts/partials/metatags.html.twig
@@ -304,7 +304,7 @@
   {#- template: Dublin Core ~#}
   {%- block metatags_dc ~%}
   {%- if page.metatags.dc ?? site.metatags.dc ?? false ~%}
-    <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/">
+    <link rel="schema.DC" href="https://purl.org/dc/elements/1.1/">
     <meta name="DC.title" content="{{ opengraph.title }}">
     <meta name="DC.description" content="{{ description }}">
     {%- if keywords is not empty ~%}

--- a/resources/layouts/partials/metatags.html.twig
+++ b/resources/layouts/partials/metatags.html.twig
@@ -310,7 +310,7 @@
     {%- if keywords is not empty ~%}
     <meta name="DC.subject" content="{{ keywords|join(', ') }}">
     {%- endif ~%}
-    {%- if page.date is defined ~%}
+    {%- if page.date|default ~%}
     <meta name="DC.date" content="{{ page.date|date('Y-m-d') }}">
     {%- endif ~%}
     {%- if author.name|default ~%}


### PR DESCRIPTION
Adds a new `metatags.dc` option (default `false`) and extends the `metatags.html.twig` partial to emit Dublin Core tags when enabled. The configuration docs were updated in both English and French, including the metatag feature list and option examples.
