### PR TITLE
chore: remove experimental PHP 8.5 CI matrix entry

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           composer run-script code:style
       - name: Run tests
-        if: ${{ contains(matrix.type, '') }}
+        if: ${{ matrix.type == '' }}
         run: |
           echo "::group::Integration tests"
           composer run-script test:integration
@@ -167,6 +167,6 @@ jobs:
           APP_DEBUG: 0
         run: blackfire run php vendor/bin/phpunit -c ./ --testsuite=IntegrationTests
       - name: Build a skeleton site from `cecil.phar` binary
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.php >= 8.2 && contains(matrix.type, '') }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.php >= 8.2 && matrix.type == '' }}
         run: |
           composer run-script test:phar

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,6 @@ jobs:
   test:
     name: PHP ${{ join(matrix.*, ' ') }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ join(matrix.type) == 'experimental' }}
     env:
       extensions: :psr, mbstring, intl, gettext, fileinfo, gd, sodium, exif, :redis, :relay
       ext-cache-key: cache-ext-v1
@@ -43,9 +42,6 @@ jobs:
           - php: '8.2'
             os: 'ubuntu-latest'
             type: 'profiling'
-          - php: '8.5'
-            os: 'ubuntu-latest'
-            type: 'experimental'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v7
@@ -113,15 +109,6 @@ jobs:
           BLACKFIRE_SERVER_TOKEN: ${{ secrets.BLACKFIRE_SERVER_TOKEN }}
           BLACKFIRE_CLIENT_ID: ${{ secrets.BLACKFIRE_CLIENT_ID }}
           BLACKFIRE_CLIENT_TOKEN: ${{ secrets.BLACKFIRE_CLIENT_TOKEN }}
-      - name: Install experimental PHP
-        if: ${{ join(matrix.type) == 'experimental' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
-          ini-values: opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=64M
-          coverage: none
-          tools: composer:${{ env.COMPOSER_VERSION }}, box
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v6
@@ -145,7 +132,7 @@ jobs:
         run: |
           composer run-script code:style
       - name: Run tests
-        if: ${{ contains(matrix.type, '') || contains(matrix.type, 'experimental') }}
+        if: ${{ contains(matrix.type, '') }}
         run: |
           echo "::group::Integration tests"
           composer run-script test:integration
@@ -180,6 +167,6 @@ jobs:
           APP_DEBUG: 0
         run: blackfire run php vendor/bin/phpunit -c ./ --testsuite=IntegrationTests
       - name: Build a skeleton site from `cecil.phar` binary
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.php >= 8.2 && (contains(matrix.type, '') || contains(matrix.type, 'experimental')) }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.php >= 8.2 && contains(matrix.type, '') }}
         run: |
           composer run-script test:phar


### PR DESCRIPTION
Drops the PHP 8.5 experimental job from the CI matrix along with its associated continue-on-error flag, setup step, and conditional checks.

