### PR TITLE
test: adds comprehensive unit tests for several core classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,10 @@
     "code:md": "phpmd ./src text ./.phpmd-rules.xml --cache",
     "code:md:gh": "phpmd ./src github ./.phpmd-rules.xml",
     "code:style": "phpcs",
-    "test": "@test:integration",
+    "test": [
+      "@test:unit",
+      "@test:integration"
+    ],
     "test:bin": "cd bin && php cecil --version && rm -rf demo && mkdir demo && php cecil new:site demo --demo -f -n && php cecil new:page demo -f -n && php cecil build demo -v && rm -rf demo",
     "test:cli": "phpunit -c ./ --testsuite=IntegrationCliTests",
     "test:coverage": "XDEBUG_MODE=coverage phpunit -c ./ --testsuite=IntegrationTests --coverage-text --coverage-clover=coverage/clover.xml",

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -247,7 +247,7 @@ class Cache implements CacheInterface
     {
         try {
             if (!Util\File::getFS()->exists($this->cacheDir)) {
-                throw new RuntimeException(\sprintf('The cache directory "%s" does not exists.', $this->cacheDir));
+                throw new RuntimeException(\sprintf('The cache directory "%s" does not exist.', $this->cacheDir));
             }
             $fileCount = 0;
             $iterator = new \RecursiveIteratorIterator(

--- a/src/Util.php
+++ b/src/Util.php
@@ -26,6 +26,8 @@ class Util
 {
     /**
      * Formats a class name.
+     * @param array $options Options for formatting. Supported options:
+     *  - 'lowercase' (bool): Whether to convert the class name to lowercase. Default is false.
      *
      * ie: "Cecil\Step\OptimizeHtml" become "OptimizeHtml"
      *

--- a/src/Util.php
+++ b/src/Util.php
@@ -36,7 +36,10 @@ class Util
         $lowercase = false;
         extract($options, EXTR_IF_EXISTS);
 
-        $className = substr(strrchr(\get_class($class), '\\'), 1);
+        $className = \get_class($class);
+        if (($position = strrpos($className, '\\')) !== false) {
+            $className = substr($className, $position + 1);
+        }
         if ($lowercase) {
             $className = strtolower($className);
         }

--- a/tests/Unit/Asset/AssetTest.php
+++ b/tests/Unit/Asset/AssetTest.php
@@ -16,6 +16,7 @@ namespace Cecil\Test\Unit\Asset;
 use Cecil\Asset;
 use Cecil\Builder;
 use Cecil\Cache;
+use Cecil\Collection\Page\Collection as PagesCollection;
 use Cecil\Config;
 use Cecil\Exception\RuntimeException;
 use Cecil\Logger\PrintLogger;
@@ -144,6 +145,66 @@ class AssetTest extends TestCase
         self::assertStringStartsWith('sha256-', $asset->integrity('sha256'));
     }
 
+    public function testToStringReturnsAssetPathByDefault(): void
+    {
+        ['asset' => $asset, 'cache' => $cache] = $this->createTestAsset([
+            'path' => '/css/site.css',
+            'content' => 'body{color:black;}',
+        ]);
+        $this->filesystem->dumpFile($cache->getContentFile('/css/site.css'), 'body{color:black;}');
+
+        self::assertSame('/css/site.css', (string) $asset);
+    }
+
+    public function testToStringReturnsCanonicalUrlWhenEnabled(): void
+    {
+        ['asset' => $asset, 'cache' => $cache] = $this->createTestAsset([
+            'path' => '/css/site.css',
+            'content' => 'body{color:black;}',
+        ], [
+            'canonicalurl' => true,
+            'baseurl' => 'https://example.test/base/',
+        ]);
+        $this->filesystem->dumpFile($cache->getContentFile('/css/site.css'), 'body{color:black;}');
+
+        self::assertSame('https://example.test/base/css/site.css', (string) $asset);
+    }
+
+    public function testToStringReturnsImageCdnUrlWhenEnabledForSvg(): void
+    {
+        ['asset' => $asset, 'cache' => $cache] = $this->createTestAsset([
+            'path' => '/img/logo.svg',
+            'type' => 'image',
+            'ext' => 'svg',
+            'subtype' => 'image/svg+xml',
+            'width' => 120,
+            'height' => 60,
+            'content' => '<svg width="120" height="60" xmlns="http://www.w3.org/2000/svg"/>',
+        ], [
+            'assets' => [
+                'images' => [
+                    'quality' => 80,
+                    'cdn' => [
+                        'enabled' => true,
+                        'svg' => true,
+                        'remote' => false,
+                        'account' => 'demo-account',
+                        'canonical' => true,
+                        'url' => 'https://cdn.example/%account%/%image_url%?w=%width%&q=%quality%&f=%format%',
+                    ],
+                ],
+            ],
+        ]);
+        $this->filesystem->dumpFile($cache->getContentFile('/img/logo.svg'), $asset['content']);
+
+        $url = (string) $asset;
+
+        self::assertStringStartsWith('https://cdn.example/demo-account/', $url);
+        self::assertStringContainsString('w=120', $url);
+        self::assertStringContainsString('q=80', $url);
+        self::assertStringContainsString('f=svg', $url);
+    }
+
     public function testConvertAndFormatsThrowForNonImageAsset(): void
     {
         ['asset' => $asset] = $this->createTestAsset([
@@ -156,6 +217,34 @@ class AssetTest extends TestCase
         $this->expectExceptionMessage('not an image');
 
         $asset->convert('webp');
+    }
+
+    public function testConvertReturnsUpdatedCloneWhenImageHandledByCdn(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/img/photo.png',
+            'type' => 'image',
+            'ext' => 'png',
+            'subtype' => 'image/png',
+            'url' => 'https://example.com/photo.png',
+        ], [
+            'assets' => [
+                'images' => [
+                    'cdn' => [
+                        'enabled' => false,
+                        'remote' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $converted = $asset->convert('webp', 42);
+
+        self::assertNotSame($asset, $converted);
+        self::assertSame('webp', $converted['ext']);
+        self::assertSame('image/webp', $converted['subtype']);
+        self::assertSame('/img/photo.png', $converted['path']);
+        self::assertSame('/img/photo.png', $asset['path']);
     }
 
     public function testWebpAndAvifDelegateToConvertAndThrowForNonImage(): void
@@ -189,6 +278,52 @@ class AssetTest extends TestCase
         self::assertNull($asset->getHeight());
     }
 
+    public function testGetWidthThrowsOnInvalidImageContent(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/img/invalid.png',
+            'type' => 'image',
+            'ext' => 'png',
+            'subtype' => 'image/png',
+            'content' => 'invalid-image-content',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to get width');
+
+        $asset->getWidth();
+    }
+
+    public function testGetHeightThrowsOnInvalidImageContent(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/img/invalid.png',
+            'type' => 'image',
+            'ext' => 'png',
+            'subtype' => 'image/png',
+            'content' => 'invalid-image-content',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to get height');
+
+        $asset->getHeight();
+    }
+
+    public function testGetWidthAndHeightFromSvgAttributes(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/img/vector.svg',
+            'type' => 'image',
+            'ext' => 'svg',
+            'subtype' => 'image/svg+xml',
+            'content' => '<svg width="321" height="123" xmlns="http://www.w3.org/2000/svg"></svg>',
+        ]);
+
+        self::assertSame(321, $asset->getWidth());
+        self::assertSame(123, $asset->getHeight());
+    }
+
     public function testGetVideoThrowsForNonVideoAsset(): void
     {
         ['asset' => $asset] = $this->createTestAsset([
@@ -200,6 +335,19 @@ class AssetTest extends TestCase
         $this->expectExceptionMessage('Unable to get video infos');
 
         $asset->getVideo();
+    }
+
+    public function testGetAudioThrowsWhenFileIsInvalid(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/audio/test.mp3',
+            'type' => 'audio',
+            'file' => $this->root . DIRECTORY_SEPARATOR . 'missing.mp3',
+        ]);
+
+        $this->expectException(\Throwable::class);
+
+        $asset->getAudio();
     }
 
     public function testIsImageInCdnForSvgAndRemoteCases(): void
@@ -258,6 +406,123 @@ class AssetTest extends TestCase
         self::assertFalse($localPng->isImageInCdn());
     }
 
+    public function testResizeReturnsSameAssetForShortCircuitConditions(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/img/photo.png',
+            'type' => 'image',
+            'ext' => 'png',
+            'subtype' => 'image/png',
+            'width' => 400,
+            'height' => 200,
+        ]);
+
+        self::assertSame($asset, $asset->resize());
+        self::assertSame($asset, $asset->resize(400, 200));
+        self::assertSame($asset, $asset->resize(450, null));
+        self::assertSame($asset, $asset->resize(null, 250));
+    }
+
+    public function testResizeReturnsComputedDimensionsWhenHandledByCdn(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/img/photo.png',
+            'type' => 'image',
+            'ext' => 'png',
+            'subtype' => 'image/png',
+            'url' => 'https://example.com/photo.png',
+            'width' => 400,
+            'height' => 200,
+        ], [
+            'assets' => [
+                'images' => [
+                    'cdn' => [
+                        'enabled' => false,
+                        'remote' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $resizedByWidth = $asset->resize(100, null);
+        self::assertSame(100, $resizedByWidth['width']);
+        self::assertEquals(50, $resizedByWidth['height']);
+
+        $resizedByHeight = $asset->resize(null, 50);
+        self::assertEquals(100, $resizedByHeight['width']);
+        self::assertSame(50, $resizedByHeight['height']);
+    }
+
+    public function testFingerprintUpdatesPathWithContentHash(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/css/site.css',
+            'ext' => 'css',
+            'content' => 'body { color: red; }',
+        ]);
+
+        $result = $asset->fingerprint();
+
+        self::assertSame($asset, $result);
+        self::assertMatchesRegularExpression('#^/css/site\.[a-f0-9]+\.css$#', $asset['path']);
+    }
+
+    public function testCompileTransformsScssToCss(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/css/site.scss',
+            'file' => $this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'site.scss',
+            'ext' => 'scss',
+            'type' => 'text',
+            'subtype' => 'text/x-scss',
+            'content' => '$color: red; body { color: $color; }',
+        ]);
+
+        $asset->compile();
+
+        self::assertSame('/css/site.css', $asset['path']);
+        self::assertSame('css', $asset['ext']);
+        self::assertSame('text/css', $asset['subtype']);
+        self::assertStringContainsString('body', $asset['content']);
+    }
+
+    public function testMinifyTransformsCssContent(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/css/site.css',
+            'ext' => 'css',
+            'type' => 'text',
+            'subtype' => 'text/css',
+            'content' => "body {\n    color: red;\n}\n",
+            'size' => 0,
+        ]);
+
+        $asset->minify();
+
+        self::assertSame('body{color:red}', trim((string) $asset['content']));
+        self::assertGreaterThan(0, $asset['size']);
+    }
+
+    public function testMinifyCompilesScssBeforeMinifying(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/css/site.scss',
+            'file' => $this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'site.scss',
+            'ext' => 'scss',
+            'type' => 'text',
+            'subtype' => 'text/x-scss',
+            'content' => '$color: red; body { color: $color; }',
+            'size' => 0,
+        ]);
+
+        $asset->minify();
+
+        self::assertSame('/css/site.css', $asset['path']);
+        self::assertSame('css', $asset['ext']);
+        self::assertSame('text/css', $asset['subtype']);
+        self::assertSame('body{color:red}', trim((string) $asset['content']));
+    }
+
     public function testStaticHelpersDelegateToLocator(): void
     {
         self::assertSame(
@@ -283,6 +548,7 @@ class AssetTest extends TestCase
         ], $config), new PrintLogger(Builder::VERBOSITY_VERBOSE));
         $builder->setSourceDir($this->sourceDir);
         $builder->setDestinationDir($this->destinationDir);
+        $builder->setPages(new PagesCollection('pages'));
         $cache = new Cache($builder, 'assets');
 
         $asset = new class () extends Asset {

--- a/tests/Unit/Asset/AssetTest.php
+++ b/tests/Unit/Asset/AssetTest.php
@@ -1,0 +1,328 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Asset;
+
+use Cecil\Asset;
+use Cecil\Builder;
+use Cecil\Cache;
+use Cecil\Config;
+use Cecil\Exception\RuntimeException;
+use Cecil\Logger\PrintLogger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class AssetTest extends TestCase
+{
+    private string $root;
+
+    private string $sourceDir;
+
+    private string $destinationDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-asset-test-' . uniqid('', true);
+        $this->sourceDir = $this->root . DIRECTORY_SEPARATOR . 'source';
+        $this->destinationDir = $this->root . DIRECTORY_SEPARATOR . 'destination';
+        $this->filesystem->mkdir([$this->sourceDir, $this->destinationDir]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->root);
+    }
+
+    public function testArrayAccessMethodsManipulateData(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset();
+
+        $asset['foo'] = 'bar';
+        self::assertTrue(isset($asset['foo']));
+        self::assertSame('bar', $asset['foo']);
+
+        unset($asset['foo']);
+        self::assertFalse(isset($asset['foo']));
+        self::assertNull($asset['foo']);
+    }
+
+    public function testSaveReturnsEarlyWhenAssetIsMissing(): void
+    {
+        ['asset' => $asset, 'builder' => $builder] = $this->createTestAsset([
+            'missing' => true,
+            'path' => '/styles/missing.css',
+        ]);
+
+        $asset->save();
+
+        self::assertSame([], $builder->getAssetsList());
+    }
+
+    public function testSaveThrowsWhenPathIsMissing(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'missing' => false,
+            'path' => '',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing path');
+
+        $asset->save();
+    }
+
+    public function testSaveAddsAssetWhenContentFileAlreadyExists(): void
+    {
+        ['asset' => $asset, 'builder' => $builder, 'cache' => $cache] = $this->createTestAsset([
+            'path' => '/styles/app.css',
+            'content' => 'body{}',
+        ]);
+
+        $contentFile = $cache->getContentFile('/styles/app.css');
+        $this->filesystem->dumpFile($contentFile, 'body{}');
+
+        $asset->save();
+
+        self::assertSame(['/styles/app.css'], $builder->getAssetsList());
+    }
+
+    public function testSaveRebuildsMissingContentCacheFileWhenContentIsAvailable(): void
+    {
+        ['asset' => $asset, 'builder' => $builder, 'cache' => $cache] = $this->createTestAsset([
+            'path' => '/styles/rebuild.css',
+            'content' => 'a{b:c;}',
+        ]);
+
+        $contentFile = $cache->getContentFile('/styles/rebuild.css');
+        $this->filesystem->remove($contentFile);
+
+        $asset->save();
+
+        self::assertFileExists($contentFile);
+        self::assertSame(['/styles/rebuild.css'], $builder->getAssetsList());
+    }
+
+    public function testSaveSkipsAssetWhenContentCacheFileCannotBeRebuilt(): void
+    {
+        ['asset' => $asset, 'builder' => $builder, 'cache' => $cache] = $this->createTestAsset([
+            'path' => '/styles/skip.css',
+            'content' => '',
+        ]);
+
+        $contentFile = $cache->getContentFile('/styles/skip.css');
+        $this->filesystem->remove($contentFile);
+
+        $asset->save();
+
+        self::assertFileDoesNotExist($contentFile);
+        self::assertSame([], $builder->getAssetsList());
+    }
+
+    public function testDataurlAndIntegrityHelpers(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'type' => 'text',
+            'subtype' => 'text/plain',
+            'content' => 'hello',
+        ]);
+
+        self::assertSame('data:text/plain;base64,aGVsbG8=', $asset->dataurl());
+        self::assertStringStartsWith('sha384-', $asset->integrity());
+        self::assertStringStartsWith('sha256-', $asset->integrity('sha256'));
+    }
+
+    public function testConvertAndFormatsThrowForNonImageAsset(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/scripts/app.js',
+            'type' => 'text',
+            'ext' => 'js',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not an image');
+
+        $asset->convert('webp');
+    }
+
+    public function testWebpAndAvifDelegateToConvertAndThrowForNonImage(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/scripts/app.js',
+            'type' => 'text',
+            'ext' => 'js',
+        ]);
+
+        try {
+            $asset->webp();
+            self::fail('Expected exception for webp conversion.');
+        } catch (RuntimeException $e) {
+            self::assertStringContainsString('not an image', $e->getMessage());
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not an image');
+
+        $asset->avif();
+    }
+
+    public function testGetWidthAndHeightReturnNullForUnsupportedType(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'type' => 'text',
+        ]);
+
+        self::assertNull($asset->getWidth());
+        self::assertNull($asset->getHeight());
+    }
+
+    public function testGetVideoThrowsForNonVideoAsset(): void
+    {
+        ['asset' => $asset] = $this->createTestAsset([
+            'path' => '/img/logo.svg',
+            'type' => 'image',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to get video infos');
+
+        $asset->getVideo();
+    }
+
+    public function testIsImageInCdnForSvgAndRemoteCases(): void
+    {
+        ['asset' => $svgAsset] = $this->createTestAsset([
+            'type' => 'image',
+            'ext' => 'svg',
+            'subtype' => 'image/svg+xml',
+            'url' => null,
+        ], [
+            'assets' => [
+                'images' => [
+                    'cdn' => [
+                        'enabled' => true,
+                        'svg' => true,
+                        'remote' => false,
+                    ],
+                ],
+            ],
+        ]);
+        self::assertTrue($svgAsset->isImageInCdn());
+
+        ['asset' => $remoteAsset] = $this->createTestAsset([
+            'type' => 'image',
+            'ext' => 'png',
+            'subtype' => 'image/png',
+            'url' => 'https://example.com/a.png',
+        ], [
+            'assets' => [
+                'images' => [
+                    'cdn' => [
+                        'enabled' => false,
+                        'remote' => true,
+                    ],
+                ],
+            ],
+        ]);
+        self::assertTrue($remoteAsset->isImageInCdn());
+
+        ['asset' => $localPng] = $this->createTestAsset([
+            'type' => 'image',
+            'ext' => 'png',
+            'subtype' => 'image/png',
+            'url' => null,
+        ], [
+            'assets' => [
+                'images' => [
+                    'cdn' => [
+                        'enabled' => true,
+                        'svg' => false,
+                        'remote' => false,
+                    ],
+                ],
+            ],
+        ]);
+        self::assertFalse($localPng->isImageInCdn());
+    }
+
+    public function testStaticHelpersDelegateToLocator(): void
+    {
+        self::assertSame(
+            \Cecil\Asset\Locator::buildPathFromUrl('https://example.com/style.css'),
+            Asset::buildPathFromUrl('https://example.com/style.css')
+        );
+        self::assertSame(
+            \Cecil\Asset\Locator::sanitize('a<b>c'),
+            Asset::sanitize('a<b>c')
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $config
+     *
+     * @return array{asset: Asset, builder: Builder, cache: Cache}
+     */
+    private function createTestAsset(array $data = [], array $config = []): array
+    {
+        $builder = new Builder(array_merge([
+            'baseurl' => 'https://example.com/',
+        ], $config), new PrintLogger(Builder::VERBOSITY_VERBOSE));
+        $builder->setSourceDir($this->sourceDir);
+        $builder->setDestinationDir($this->destinationDir);
+        $cache = new Cache($builder, 'assets');
+
+        $asset = new class () extends Asset {
+            public function __construct()
+            {
+            }
+
+            public function seed(Builder $builder, Config $config, Cache $cache, array $data): void
+            {
+                $this->builder = $builder;
+                $this->config = $config;
+                $this->cache = $cache;
+                $this->data = $data;
+                $this->cacheTags = [];
+            }
+        };
+
+        $asset->seed($builder, $builder->getConfig(), $cache, array_merge([
+            'file' => '',
+            'files' => [],
+            'missing' => false,
+            '_path' => '/asset',
+            'path' => '/asset',
+            'url' => null,
+            'ext' => 'txt',
+            'type' => 'text',
+            'subtype' => 'text/plain',
+            'size' => 0,
+            'width' => null,
+            'height' => null,
+            'exif' => [],
+            'duration' => null,
+            'content' => 'content',
+            'hash' => 'hash',
+        ], $data));
+
+        return [
+            'asset' => $asset,
+            'builder' => $builder,
+            'cache' => $cache,
+        ];
+    }
+}

--- a/tests/Unit/Asset/LocatorTest.php
+++ b/tests/Unit/Asset/LocatorTest.php
@@ -185,24 +185,42 @@ class LocatorTest extends TestCase
 
     public function testLocateRemoteWithFallbackUsesFallbackPath(): void
     {
-        $this->filesystem->mkdir($this->sourceDir . DIRECTORY_SEPARATOR . 'assets');
-        file_put_contents($this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'local.css', 'body{}');
+        $previousTimeout = ini_get('default_socket_timeout');
+        ini_set('default_socket_timeout', '1');
 
-        $locator = new Locator($this->createBuilder());
-        $result = $locator->locate('https://invalid.invalid/style.css', 'local.css');
+        try {
+            $this->filesystem->mkdir($this->sourceDir . DIRECTORY_SEPARATOR . 'assets');
+            file_put_contents($this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'local.css', 'body{}');
 
-        self::assertSame('local.css', $result['path']);
-        self::assertFileExists($result['file']);
+            $locator = new Locator($this->createBuilder());
+            $result = $locator->locate('http://127.0.0.1:9/style.css', 'local.css');
+
+            self::assertSame('local.css', $result['path']);
+            self::assertFileExists($result['file']);
+        } finally {
+            if ($previousTimeout !== false) {
+                ini_set('default_socket_timeout', (string) $previousTimeout);
+            }
+        }
     }
 
     public function testLocateRemoteWithoutFallbackThrowsRuntimeException(): void
     {
-        $locator = new Locator($this->createBuilder());
+        $previousTimeout = ini_get('default_socket_timeout');
+        ini_set('default_socket_timeout', '1');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to get remote file');
+        try {
+            $locator = new Locator($this->createBuilder());
 
-        $locator->locate('https://invalid.invalid/style.css');
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('Unable to get remote file');
+
+            $locator->locate('http://127.0.0.1:9/style.css');
+        } finally {
+            if ($previousTimeout !== false) {
+                ini_set('default_socket_timeout', (string) $previousTimeout);
+            }
+        }
     }
 
     private function createBuilder(array $config = []): Builder

--- a/tests/Unit/Asset/LocatorTest.php
+++ b/tests/Unit/Asset/LocatorTest.php
@@ -13,11 +13,41 @@ declare(strict_types=1);
 
 namespace Cecil\Test\Unit\Asset;
 
+use Cecil\Builder;
 use Cecil\Asset\Locator;
+use Cecil\Exception\RuntimeException;
+use Cecil\Logger\PrintLogger;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 class LocatorTest extends TestCase
 {
+    private string $root;
+
+    private string $sourceDir;
+
+    private string $destinationDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-locator-test-' . uniqid('', true);
+        $this->sourceDir = $this->root . DIRECTORY_SEPARATOR . 'source';
+        $this->destinationDir = $this->root . DIRECTORY_SEPARATOR . 'destination';
+
+        $this->filesystem->mkdir([
+            $this->sourceDir,
+            $this->destinationDir,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->root);
+    }
+
     // --- buildPathFromUrl ---
 
     public function testBuildPathFromUrlBasic(): void
@@ -88,5 +118,101 @@ class LocatorTest extends TestCase
         self::assertStringNotContainsString('<', $result);
         self::assertStringNotContainsString('>', $result);
         self::assertStringNotContainsString(':', $result);
+    }
+
+    public function testLocateFindsLocalizedFileInAssetsDirectory(): void
+    {
+        $this->filesystem->mkdir($this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'css');
+        file_put_contents($this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'css' . DIRECTORY_SEPARATOR . 'app.fr.css', 'body{}');
+
+        $locator = new Locator($this->createBuilder());
+        $result = $locator->locate('css/app.css', language: 'fr');
+
+        self::assertSame('css/app.fr.css', $result['path']);
+        self::assertFileExists($result['file']);
+    }
+
+    public function testLocateFallsBackToThemeAssetsThenStatic(): void
+    {
+        $themeName = 'my-theme';
+        $themeAssetsDir = $this->sourceDir . DIRECTORY_SEPARATOR . 'themes' . DIRECTORY_SEPARATOR . $themeName . DIRECTORY_SEPARATOR . 'assets';
+        $staticDir = $this->sourceDir . DIRECTORY_SEPARATOR . 'static';
+        $this->filesystem->mkdir([$themeAssetsDir, $staticDir]);
+
+        file_put_contents($themeAssetsDir . DIRECTORY_SEPARATOR . 'theme.css', 'theme');
+        file_put_contents($staticDir . DIRECTORY_SEPARATOR . 'fallback.css', 'static');
+
+        $locator = new Locator($this->createBuilder([
+            'theme' => $themeName,
+        ]));
+
+        $fromTheme = $locator->locate('theme.css');
+        self::assertSame('theme.css', $fromTheme['path']);
+        self::assertStringContainsString('themes', $fromTheme['file']);
+
+        $fromStatic = $locator->locate('fallback.css');
+        self::assertSame('fallback.css', $fromStatic['path']);
+        self::assertStringContainsString('static', $fromStatic['file']);
+    }
+
+    public function testLocateFallsBackToThemeStaticDirectory(): void
+    {
+        $themeName = 'my-theme';
+        $themeStaticDir = $this->sourceDir . DIRECTORY_SEPARATOR . 'themes' . DIRECTORY_SEPARATOR . $themeName . DIRECTORY_SEPARATOR . 'static';
+        $this->filesystem->mkdir($themeStaticDir);
+        file_put_contents($themeStaticDir . DIRECTORY_SEPARATOR . 'theme-static.css', 'theme-static');
+
+        $locator = new Locator($this->createBuilder([
+            'theme' => $themeName,
+        ]));
+
+        $result = $locator->locate('theme-static.css');
+
+        self::assertSame('theme-static.css', $result['path']);
+        self::assertStringContainsString('themes', $result['file']);
+        self::assertStringContainsString('static', $result['file']);
+    }
+
+    public function testLocateThrowsWhenFileCannotBeFound(): void
+    {
+        $locator = new Locator($this->createBuilder());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to locate file');
+
+        $locator->locate('missing.css');
+    }
+
+    public function testLocateRemoteWithFallbackUsesFallbackPath(): void
+    {
+        $this->filesystem->mkdir($this->sourceDir . DIRECTORY_SEPARATOR . 'assets');
+        file_put_contents($this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'local.css', 'body{}');
+
+        $locator = new Locator($this->createBuilder());
+        $result = $locator->locate('https://invalid.invalid/style.css', 'local.css');
+
+        self::assertSame('local.css', $result['path']);
+        self::assertFileExists($result['file']);
+    }
+
+    public function testLocateRemoteWithoutFallbackThrowsRuntimeException(): void
+    {
+        $locator = new Locator($this->createBuilder());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to get remote file');
+
+        $locator->locate('https://invalid.invalid/style.css');
+    }
+
+    private function createBuilder(array $config = []): Builder
+    {
+        $builder = new Builder(array_merge([
+            'baseurl' => 'https://example.com/',
+        ], $config), new PrintLogger(Builder::VERBOSITY_VERBOSE));
+        $builder->setSourceDir($this->sourceDir);
+        $builder->setDestinationDir($this->destinationDir);
+
+        return $builder;
     }
 }

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit;
+
+use Cecil\Asset;
+use Cecil\Builder;
+use Cecil\Collection\Menu\Collection as MenuCollection;
+use Cecil\Collection\Page\Collection as PagesCollection;
+use Cecil\Collection\Taxonomy\Collection as TaxonomyCollection;
+use Cecil\Collection\Taxonomy\Vocabulary;
+use Cecil\Exception\RuntimeException;
+use Cecil\Logger\PrintLogger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+class BuilderTest extends TestCase
+{
+    public function testCreateReturnsBuilderInstance(): void
+    {
+        $builder = Builder::create(['baseurl' => 'https://example.com/']);
+
+        self::assertInstanceOf(Builder::class, $builder);
+    }
+
+    public function testDataAccessorsAndLanguageFallback(): void
+    {
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+        $builder->setData([
+            'en' => ['k' => 'en-value'],
+            'fr' => ['k' => 'fr-value'],
+        ]);
+
+        self::assertSame(['k' => 'fr-value'], $builder->getData('fr'));
+        self::assertSame(['k' => 'en-value'], $builder->getData('de'));
+        self::assertIsArray($builder->getData());
+    }
+
+    public function testStaticAndPagesFilesAndPagesCollectionAccessors(): void
+    {
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+
+        $builder->setStatic(['a.css', 'b.js']);
+        self::assertSame(['a.css', 'b.js'], $builder->getStatic());
+
+        $finder = new Finder();
+        $builder->setPagesFiles($finder);
+        self::assertSame($finder, $builder->getPagesFiles());
+
+        $pages = new PagesCollection('pages');
+        $builder->setPages($pages);
+        self::assertSame($pages, $builder->getPages());
+    }
+
+    public function testAssetsListDeduplicatesEntries(): void
+    {
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+
+        $builder->addToAssetsList('/css/app.css');
+        $builder->addToAssetsList('/css/app.css');
+        $builder->addToAssetsList('/js/app.js');
+
+        self::assertSame(['/css/app.css', '/js/app.js'], $builder->getAssetsList());
+    }
+
+    public function testRememberAssetTracksHitsAndMisses(): void
+    {
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+        $asset = $this->createMock(Asset::class);
+
+        $first = $builder->rememberAsset('k1', static fn (): Asset => $asset);
+        $second = $builder->rememberAsset('k1', static fn (): Asset => $asset);
+
+        self::assertSame($asset, $first);
+        self::assertSame($asset, $second);
+
+        $stats = $builder->getAssetRegistryStats();
+        self::assertSame(1, $stats['hits']);
+        self::assertSame(1, $stats['misses']);
+        self::assertSame(2, $stats['total']);
+        self::assertSame(50.0, $stats['deduplication_ratio']);
+    }
+
+    public function testRememberAssetFactoryMustReturnAsset(): void
+    {
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('factory must return an Asset');
+
+        $builder->rememberAsset('bad', static fn () => new \stdClass());
+    }
+
+    public function testLayoutCacheStatsAreTracked(): void
+    {
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+
+        $builder->recordLayoutCacheAccess(true);
+        $builder->recordLayoutCacheAccess(false);
+        $builder->recordLayoutCacheAccess(true);
+
+        $stats = $builder->getLayoutCacheStats();
+        self::assertSame(2, $stats['hits']);
+        self::assertSame(1, $stats['misses']);
+        self::assertSame(3, $stats['total']);
+        self::assertSame(66.67, $stats['hit_rate']);
+    }
+
+    public function testMenusAndTaxonomiesAccessors(): void
+    {
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+
+        $menus = new MenuCollection('main');
+        $builder->setMenus(['en' => $menus]);
+        self::assertSame($menus, $builder->getMenus('en'));
+
+        $taxonomies = new TaxonomyCollection('tax');
+        $taxonomies->add(new Vocabulary('tags'));
+        $builder->setTaxonomies(['en' => $taxonomies]);
+        self::assertSame($taxonomies, $builder->getTaxonomies('en'));
+    }
+
+    public function testLoggerDebugAndVersionHelpers(): void
+    {
+        $logger = new PrintLogger(Builder::VERBOSITY_DEBUG);
+        $builder = new Builder(['baseurl' => 'https://example.com/'], $logger);
+
+        self::assertSame($logger, $builder->getLogger());
+        self::assertFalse($builder->isDebug());
+        self::assertNotSame('', Builder::getVersion());
+        self::assertIsArray($builder->getMetrics());
+        self::assertSame([], $builder->getBuildOptions());
+    }
+
+    public function testGetBuildIdThrowsTypeErrorBeforeBuildInitialization(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Builder::getBuildId();
+    }
+}

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace Cecil\Test\Unit;
 
+use Cecil\Asset;
 use Cecil\Builder;
 use Cecil\Cache;
 use Cecil\Logger\PrintLogger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo;
 
 class CacheTest extends TestCase
 {
@@ -90,6 +92,251 @@ class CacheTest extends TestCase
         self::assertFileExists($cache->getContentFile($keptContentPath));
     }
 
+    public function testGetReturnsDefaultWhenEntryDoesNotExist(): void
+    {
+        $cache = $this->createCache();
+
+        self::assertSame('fallback', $cache->get('missing-key', 'fallback'));
+    }
+
+    public function testExpiredEntryReturnsDefaultAndIsDeleted(): void
+    {
+        $cache = $this->createCache();
+        $key = $cache->createKey('expirable', name: 'ttl-test');
+
+        self::assertTrue($cache->set($key, ['value' => 'x'], 0));
+
+        self::assertSame('fallback', $cache->get($key, 'fallback'));
+        self::assertFalse($cache->has($key));
+    }
+
+    public function testCreateKeyRejectsUnsupportedValueType(): void
+    {
+        $cache = $this->createCache();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid value type');
+
+        $cache->createKey(new \stdClass());
+    }
+
+    public function testCreateKeyIncludesTruthyTagsAndSkipsFalsyOnes(): void
+    {
+        $cache = $this->createCache();
+        $key = $cache->createKey('stylesheet', name: 'asset', tags: [
+            'minify' => true,
+            'lang' => 'fr',
+            'weight' => 0,
+            'debug' => false,
+        ]);
+
+        self::assertStringContainsString('asset-', $key);
+        self::assertStringContainsString('_minify_lfr__', $key);
+        self::assertStringNotContainsString('weight', $key);
+        self::assertStringNotContainsString('debug', $key);
+    }
+
+    public function testClearByPatternReturnsZeroWhenCacheDirectoryDoesNotExist(): void
+    {
+        $cache = $this->createCache();
+        $cache->clear();
+
+        self::assertSame(0, $cache->clearByPattern('anything'));
+    }
+
+    public function testGetContentFileStripsProtocolFromPath(): void
+    {
+        $cache = $this->createCache();
+
+        $path = $cache->getContentFile('https://example.com/assets/style.css');
+
+        self::assertStringNotContainsString('https://', $path);
+        self::assertStringContainsString('example.com', $path);
+    }
+
+    public function testSetAndGetWithDateIntervalTtl(): void
+    {
+        $cache = $this->createCache();
+        $key = $cache->createKey('interval', name: 'interval');
+
+        self::assertTrue($cache->set($key, 'value', new \DateInterval('PT10S')));
+        self::assertSame('value', $cache->get($key));
+    }
+
+    public function testSetPrunesPreviousEntriesWithSamePrefix(): void
+    {
+        $cache = $this->createCache();
+        $first = 'shared__hash-1__v1';
+        $second = 'shared__hash-2__v1';
+
+        self::assertTrue($cache->set($first, 'first'));
+        self::assertTrue($cache->set($second, 'second'));
+
+        self::assertSame('fallback', $cache->get($first, 'fallback'));
+        self::assertSame('second', $cache->get($second));
+    }
+
+    public function testCreateKeyCreatesShardedCacheFilePath(): void
+    {
+        $cache = $this->createCache();
+        $key = $cache->createKey('content', name: 'assets-image');
+
+        self::assertTrue($cache->set($key, 'value'));
+        self::assertTrue($cache->has($key));
+        self::assertSame('value', $cache->get($key));
+    }
+
+    public function testCreateKeyFromAssetUsesPathExtensionAndHash(): void
+    {
+        $cache = $this->createCache();
+
+        $asset = new class () extends Asset {
+            public function __construct()
+            {
+            }
+
+            public function seed(array $data): self
+            {
+                $this->data = $data;
+
+                return $this;
+            }
+        };
+
+        $asset->seed([
+            '_path' => '/css/app.css',
+            'ext' => 'css',
+            'hash' => 'abc123',
+        ]);
+
+        $key = $cache->createKey($asset);
+
+        self::assertStringContainsString('css-app.css_css__abc123__', $key);
+    }
+
+    public function testCreateKeyFromSplFileInfoUsesRelativePathAndFileHash(): void
+    {
+        $cache = $this->createCache();
+
+        $fileDir = $this->sourceDir . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'css';
+        $this->filesystem->mkdir($fileDir);
+        $filePath = $fileDir . DIRECTORY_SEPARATOR . 'app.css';
+        file_put_contents($filePath, 'body{color:black;}');
+
+        $file = new SplFileInfo($filePath, 'assets/css', 'assets/css/app.css');
+        $key = $cache->createKey($file);
+
+        self::assertStringContainsString('assets-css-app.css__', $key);
+        self::assertStringContainsString('__' . Builder::getVersion(), $key);
+    }
+
+    public function testGetMultipleIsNotImplemented(): void
+    {
+        $cache = $this->createCache();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cache::getMultiple not yet implemented.');
+
+        $cache->getMultiple(['a', 'b']);
+    }
+
+    public function testSetMultipleIsNotImplemented(): void
+    {
+        $cache = $this->createCache();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cache::setMultiple not yet implemented.');
+
+        $cache->setMultiple(['a' => 1]);
+    }
+
+    public function testDeleteMultipleIsNotImplemented(): void
+    {
+        $cache = $this->createCache();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cache::deleteMultiple not yet implemented.');
+
+        $cache->deleteMultiple(['a']);
+    }
+
+    public function testDeleteAndClearAreSafeOnMissingEntries(): void
+    {
+        $cache = $this->createCache();
+
+        self::assertTrue($cache->delete('missing-key'));
+        self::assertTrue($cache->clear());
+    }
+
+    public function testGetReturnsPayloadWithoutContentWhenContentFileIsMissing(): void
+    {
+        $cache = $this->createCache();
+        $key = $cache->createKey('stylesheet', name: 'missing-content');
+        $contentPath = 'styles/missing.css';
+
+        self::assertTrue($cache->set($key, [
+            'content' => 'body { color: green; }',
+            'path'    => $contentPath,
+        ]));
+
+        $this->filesystem->remove($cache->getContentFile($contentPath));
+        $value = $cache->get($key);
+
+        self::assertIsArray($value);
+        self::assertSame($contentPath, $value['path']);
+        self::assertArrayNotHasKey('content', $value);
+    }
+
+    public function testHasReflectsEntryLifecycle(): void
+    {
+        $cache = $this->createCache();
+        $key = $cache->createKey('lifecycle', name: 'lifecycle');
+
+        self::assertFalse($cache->has($key));
+        self::assertTrue($cache->set($key, 'value'));
+        self::assertTrue($cache->has($key));
+        self::assertTrue($cache->delete($key));
+        self::assertFalse($cache->has($key));
+    }
+
+    public function testGetRestoresContentFromDedicatedContentFile(): void
+    {
+        $cache = $this->createCache();
+        $key = $cache->createKey('stylesheet', name: 'content-restore');
+
+        self::assertTrue($cache->set($key, [
+            'content' => 'body { color: purple; }',
+            'path' => 'styles/restore.css',
+        ]));
+
+        $value = $cache->get($key);
+
+        self::assertIsArray($value);
+        self::assertSame('styles/restore.css', $value['path']);
+        self::assertSame('body { color: purple; }', $value['content']);
+    }
+
+    public function testDurationHelperSupportsIntAndDateInterval(): void
+    {
+        $cache = $this->createTestableCache();
+
+        self::assertSame(42, $cache->durationPublic(42));
+        self::assertSame(3661, $cache->durationPublic(new \DateInterval('PT1H1M1S')));
+    }
+
+    public function testDeleteContentFileRemovesExistingFileAndIsIdempotent(): void
+    {
+        $cache = $this->createTestableCache();
+        $path = 'styles/delete-me.css';
+        $file = $cache->getContentFile($path);
+        $this->filesystem->dumpFile($file, 'body{}');
+
+        self::assertFileExists($file);
+        self::assertTrue($cache->deleteContentFilePublic($path));
+        self::assertFileDoesNotExist($file);
+        self::assertTrue($cache->deleteContentFilePublic($path));
+    }
+
     private function createCache(): Cache
     {
         $builder = new Builder([
@@ -99,5 +346,26 @@ class CacheTest extends TestCase
         $builder->setDestinationDir($this->destinationDir);
 
         return new Cache($builder, 'assets');
+    }
+
+    private function createTestableCache(): Cache
+    {
+        $builder = new Builder([
+            'baseurl' => 'https://example.com/',
+        ], new PrintLogger(Builder::VERBOSITY_VERBOSE));
+        $builder->setSourceDir($this->sourceDir);
+        $builder->setDestinationDir($this->destinationDir);
+
+        return new class ($builder, 'assets') extends Cache {
+            public function durationPublic(int|\DateInterval $ttl): int
+            {
+                return $this->duration($ttl);
+            }
+
+            public function deleteContentFilePublic(string $path): bool
+            {
+                return $this->deleteContentFile($path);
+            }
+        };
     }
 }

--- a/tests/Unit/Collection/CollectionTest.php
+++ b/tests/Unit/Collection/CollectionTest.php
@@ -65,4 +65,85 @@ class CollectionTest extends TestCase
         self::assertTrue($filtered->has('b'));
         self::assertSame(1, $filtered->getPosition('b'));
     }
+
+    public function testAddDuplicateItemThrowsDomainException(): void
+    {
+        $collection = new Collection('test');
+        $item = new Item('duplicate');
+        $collection->add($item);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('item already exists');
+
+        $collection->add(new Item('duplicate'));
+    }
+
+    public function testGetReplaceAndRemoveMissingItemThrowDomainException(): void
+    {
+        $collection = new Collection('test');
+
+        try {
+            $collection->get('missing');
+            self::fail('Expected exception was not thrown.');
+        } catch (\DomainException $e) {
+            self::assertStringContainsString('Failed getting "missing"', $e->getMessage());
+        }
+
+        try {
+            $collection->replace('missing', new Item('other'));
+            self::fail('Expected exception was not thrown.');
+        } catch (\DomainException $e) {
+            self::assertStringContainsString('Failed replacing "missing"', $e->getMessage());
+        }
+
+        try {
+            $collection->remove('missing');
+            self::fail('Expected exception was not thrown.');
+        } catch (\DomainException $e) {
+            self::assertStringContainsString('Failed removing "missing"', $e->getMessage());
+        }
+    }
+
+    public function testFirstAndLastReturnNullOnEmptyCollection(): void
+    {
+        $collection = new Collection('empty');
+
+        self::assertNull($collection->first());
+        self::assertNull($collection->last());
+    }
+
+    public function testArrayAccessAndHelpersBehaveAsExpected(): void
+    {
+        $collection = new Collection('helpers');
+        $first = new Item('first');
+        $second = new Item('second');
+
+        $collection[] = $first;
+        $collection[] = $second;
+
+        self::assertTrue(isset($collection['first']));
+        self::assertSame($first, $collection['first']);
+        self::assertSame([0, 1], $collection->keys());
+        self::assertSame('helpers', (string) $collection);
+        self::assertStringEndsWith("\n", $collection->toJson());
+
+        unset($collection['first']);
+        self::assertFalse($collection->has('first'));
+    }
+
+    public function testReverseAndMapReturnDerivedCollections(): void
+    {
+        $collection = new Collection('test', [
+            new Item('a'),
+            new Item('b'),
+        ]);
+
+        $reversed = $collection->reverse();
+        $mapped = $collection->map(function (Item $item): Item {
+            return new Item($item->getId() . '-mapped');
+        });
+
+        self::assertSame('b', $reversed->first()?->getId());
+        self::assertSame('a-mapped', $mapped->first()?->getId());
+    }
 }

--- a/tests/Unit/Collection/Menu/MenuCollectionTest.php
+++ b/tests/Unit/Collection/Menu/MenuCollectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Collection\Menu;
+
+use Cecil\Collection\Menu\Collection;
+use Cecil\Collection\Menu\Entry;
+use Cecil\Collection\Menu\Menu;
+use PHPUnit\Framework\TestCase;
+
+class MenuCollectionTest extends TestCase
+{
+    public function testEntryGettersAndSetters(): void
+    {
+        $entry = new Entry('home');
+        $entry->setName('Home')->setUrl('/')->setWeight(10);
+
+        self::assertSame('Home', $entry->getName());
+        self::assertSame('/', $entry->getUrl());
+        self::assertSame(10, $entry->getWeight());
+    }
+
+    public function testMenuAddReplacesExistingEntryWithSameId(): void
+    {
+        $menu = new Menu('main');
+        $menu->add((new Entry('home'))->setName('Old')->setWeight(1));
+        $menu->add((new Entry('home'))->setName('New')->setWeight(2));
+
+        self::assertCount(1, $menu);
+        self::assertSame('New', $menu->get('home')->getName());
+        self::assertSame(2, $menu->get('home')->getWeight());
+    }
+
+    public function testCollectionGetAndIsset(): void
+    {
+        $menus = new Collection('menus');
+        $main = new Menu('main');
+        $menus->add($main);
+
+        self::assertTrue(isset($menus->main));
+        self::assertFalse(isset($menus->footer));
+        self::assertSame($main, $menus->get('main'));
+    }
+}

--- a/tests/Unit/Collection/Page/PageTest.php
+++ b/tests/Unit/Collection/Page/PageTest.php
@@ -13,12 +13,34 @@ declare(strict_types=1);
 
 namespace Cecil\Test\Unit\Collection\Page;
 
+use Cecil\Collection\Page\Collection;
 use Cecil\Collection\Page\Page;
+use Cecil\Collection\Taxonomy\Term;
+use Cecil\Collection\Taxonomy\Vocabulary;
+use Cecil\Exception\RuntimeException;
 use Cecil\Util;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo;
 
 class PageTest extends TestCase
 {
+    private string $tmpDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-page-test-' . uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
     public function testPageCreationWithStringId(): void
     {
         $page = new Page('test-page');
@@ -66,5 +88,229 @@ class PageTest extends TestCase
         $page = new Page('test');
         $page->setPath('section/test');
         self::assertSame('section/test', $page->getPath());
+    }
+
+    public function testGetIdWithoutLangStripsLanguagePrefixWhenPresent(): void
+    {
+        $page = new Page('fr/section/page');
+        $page->setVariable('language', 'fr');
+
+        self::assertSame('section/page', $page->getIdWithoutLang());
+    }
+
+    public function testGetIdWithoutLangKeepsOriginalWhenLanguageIsNotSet(): void
+    {
+        $page = new Page('section/page');
+
+        self::assertSame('section/page', $page->getIdWithoutLang());
+    }
+
+    public function testSetPathHandlesHomepageAndSectionIndex(): void
+    {
+        $homepage = new Page('home');
+        $homepage->setPath('index');
+        self::assertSame('', $homepage->getPath());
+
+        $section = new Page('section-index');
+        $section->setPath('blog/index');
+        self::assertSame('blog', $section->getPath());
+    }
+
+    public function testSetVariableDraftTrueSetsPublishedFalse(): void
+    {
+        $page = new Page('draft');
+        $page->setVariable('draft', true);
+
+        self::assertFalse($page->getVariable('published'));
+    }
+
+    public function testSetVariableScheduleCanPublishPage(): void
+    {
+        $page = new Page('scheduled');
+        $page->setVariable('schedule', [
+            'publish' => '2000-01-01',
+        ]);
+        self::assertTrue($page->getVariable('published'));
+
+        $page->setVariable('schedule', [
+            'expiry' => '2999-01-01',
+        ]);
+        self::assertTrue($page->getVariable('published'));
+    }
+
+    public function testSetVariablePathRejectsNonSlugifiedValue(): void
+    {
+        $page = new Page('invalid-slug');
+
+        $this->expectException(\Cecil\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('variable should be');
+
+        $page->setVariable('path', 'Bad Path');
+    }
+
+    public function testRenderedAndPaginatorHelpers(): void
+    {
+        $page = new Page('helpers');
+        $page->setBodyHtml('<p>Hello</p>');
+        $page->addRendered(['html' => '<p>Hello</p>']);
+        $page->setPaginator(['page' => 1]);
+
+        self::assertSame('<p>Hello</p>', $page->getBodyHtml());
+        self::assertSame('<p>Hello</p>', $page->getContent());
+        self::assertSame(['html' => '<p>Hello</p>'], $page->getRendered());
+        self::assertSame(['page' => 1], $page->getPaginator());
+        self::assertSame(['page' => 1], $page->getPagination());
+    }
+
+    public function testFrontmatterVariablesCanBeSetAndUnset(): void
+    {
+        $page = new Page('frontmatter');
+        $page->setVariable('custom', 'value');
+        self::assertTrue($page->hasVariable('custom'));
+
+        $page->unVariable('custom');
+        self::assertFalse($page->hasVariable('custom'));
+
+        $page->setFmVariables(['title' => 'Front']);
+        self::assertSame(['title' => 'Front'], $page->getFmVariables());
+    }
+
+    public function testPageCreationWithInvalidIdThrowsRuntimeException(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Create a page with a string ID or a SplFileInfo.');
+
+        new Page(123);
+    }
+
+    public function testPageCreationFromSplFileInfoSetsExpectedMetadata(): void
+    {
+        $file = $this->createFileInfo('blog', '01-hello.fr.md', "---\ntitle: Hello\n---\nBody");
+        $page = new Page($file);
+
+        self::assertFalse($page->isVirtual());
+        self::assertSame('fr/blog/hello', $page->getId());
+        self::assertSame('blog/hello', $page->getPath());
+        self::assertSame('hello', $page->getSlug());
+        self::assertSame('blog', $page->getFolder());
+        self::assertSame(1, $page->getVariable('weight'));
+        self::assertSame('fr', $page->getVariable('language'));
+        self::assertSame('blog/hello', $page->getVariable('langref'));
+        self::assertSame('hello', $page->getVariable('title'));
+        self::assertSame('01-hello.fr.md', $page->getFileName());
+        self::assertIsString($page->getFilePath());
+    }
+
+    public function testReadmeAtRootCreatesHomepageType(): void
+    {
+        $file = $this->createFileInfo('', 'README.md', 'Hello');
+        $page = new Page($file);
+
+        self::assertSame('homepage', $page->getType());
+        self::assertSame('index', $page->getId());
+    }
+
+    public function testGetPathnameIsAliasOfGetPath(): void
+    {
+        $page = new Page('alias');
+        $page->setPath('section/alias');
+
+        self::assertSame($page->getPath(), $page->getPathname());
+    }
+
+    public function testSetSectionAndUnSection(): void
+    {
+        $page = new Page('section');
+
+        $page->setSection('blog');
+        self::assertSame('blog', $page->getSection());
+
+        $page->unSection();
+        self::assertNull($page->getSection());
+    }
+
+    public function testSetAndGetPagesCollection(): void
+    {
+        $page = new Page('parent');
+        $pages = new Collection('pages', [new Page('child')]);
+
+        $page->setPages($pages);
+
+        self::assertSame($pages, $page->getPages());
+    }
+
+    public function testSetAndGetTermsVocabulary(): void
+    {
+        $page = new Page('taxonomy-page');
+        $terms = new Vocabulary('tags');
+        $terms->add((new Term('php'))->setName('PHP'));
+
+        $page->setTerms($terms);
+
+        self::assertSame($terms, $page->getTerms());
+    }
+
+    public function testSetVariableLastmodMapsToUpdated(): void
+    {
+        $page = new Page('dates');
+        $page->setVariable('lastmod', '2025-01-01');
+
+        self::assertInstanceOf(\DateTime::class, $page->getVariable('updated'));
+        self::assertSame('2025-01-01', $page->getVariable('updated')->format('Y-m-d'));
+    }
+
+    public function testSetVariableDateRejectsInvalidValue(): void
+    {
+        $page = new Page('dates');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not a valid date');
+
+        $page->setVariable('date', ['not-a-date']);
+    }
+
+    public function testParseReadsFrontmatterAndBody(): void
+    {
+        $file = $this->createFileInfo('', 'content.md', "---\ntitle: Parsed\n---\nHello body");
+        $page = new Page($file);
+
+        $page->parse();
+
+        self::assertSame('title: Parsed', $page->getFrontmatter());
+        self::assertSame('Hello body', $page->getBody());
+    }
+
+    public function testSetSlugUpdatesPathWhenSlugAlreadySet(): void
+    {
+        $page = new Page('slug');
+        $page->setFolder('blog');
+        $page->setSlug('first');
+        $page->setSlug('second');
+
+        self::assertSame('blog/second', $page->getPath());
+        self::assertSame('second', $page->getSlug());
+    }
+
+    public function testSetPathWithoutSlashUpdatesSlug(): void
+    {
+        $page = new Page('single');
+        $page->setPath('landing');
+
+        self::assertSame('landing', $page->getSlug());
+    }
+
+    private function createFileInfo(string $relativePath, string $filename, string $content): SplFileInfo
+    {
+        $dir = $relativePath === ''
+            ? $this->tmpDir
+            : $this->tmpDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $this->filesystem->mkdir($dir);
+
+        $filePath = $dir . DIRECTORY_SEPARATOR . $filename;
+        file_put_contents($filePath, $content);
+
+        $relativePathname = $relativePath === '' ? $filename : $relativePath . '/' . $filename;
+
+        return new SplFileInfo($filePath, $relativePath, $relativePathname);
     }
 }

--- a/tests/Unit/Collection/Page/ParserTest.php
+++ b/tests/Unit/Collection/Page/ParserTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Collection\Page;
+
+use Cecil\Collection\Page\Parser;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo;
+
+class ParserTest extends TestCase
+{
+    private string $tmpDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-parser-test-' . uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    public function testParseWithFrontmatterAndBody(): void
+    {
+        $file = $this->createFileInfo('with-frontmatter.md', "---\ntitle: Parsed\n---\nBody");
+
+        $parser = (new Parser($file))->parse();
+
+        self::assertSame('title: Parsed', $parser->getFrontmatter());
+        self::assertSame('Body', $parser->getBody());
+    }
+
+    public function testParseWithoutFrontmatterSetsBodyOnly(): void
+    {
+        $file = $this->createFileInfo('without-frontmatter.md', "Plain body");
+
+        $parser = (new Parser($file))->parse();
+
+        self::assertNull($parser->getFrontmatter());
+        self::assertSame('Plain body', $parser->getBody());
+    }
+
+    private function createFileInfo(string $filename, string $content): SplFileInfo
+    {
+        $path = $this->tmpDir . DIRECTORY_SEPARATOR . $filename;
+        file_put_contents($path, $content);
+
+        return new SplFileInfo($path, '', $filename);
+    }
+}

--- a/tests/Unit/Collection/Page/PrefixSuffixTest.php
+++ b/tests/Unit/Collection/Page/PrefixSuffixTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Collection\Page;
+
+use Cecil\Collection\Page\PrefixSuffix;
+use PHPUnit\Framework\TestCase;
+
+class PrefixSuffixTest extends TestCase
+{
+    public function testPrefixAndSuffixDetection(): void
+    {
+        self::assertTrue(PrefixSuffix::hasPrefix('2026-08-20_post'));
+        self::assertTrue(PrefixSuffix::hasPrefix('10_post'));
+        self::assertFalse(PrefixSuffix::hasPrefix('post'));
+
+        self::assertTrue(PrefixSuffix::hasSuffix('post.fr'));
+        self::assertFalse(PrefixSuffix::hasSuffix('post'));
+    }
+
+    public function testPrefixAndSuffixExtraction(): void
+    {
+        self::assertSame('2026-08-20', PrefixSuffix::getPrefix('2026-08-20_post'));
+        self::assertSame('fr', PrefixSuffix::getSuffix('post.fr'));
+        self::assertNull(PrefixSuffix::getPrefix('post'));
+        self::assertNull(PrefixSuffix::getSuffix('post'));
+    }
+
+    public function testSubAndSubPrefixRemoveExpectedParts(): void
+    {
+        self::assertSame('post', PrefixSuffix::sub('2026-08-20_post.fr'));
+        self::assertSame('post.fr', PrefixSuffix::subPrefix('2026-08-20_post.fr'));
+        self::assertSame('post', PrefixSuffix::sub('post'));
+        self::assertSame('post', PrefixSuffix::subPrefix('post'));
+    }
+
+    public function testCustomPrefixSeparatorIsSupported(): void
+    {
+        self::assertTrue(PrefixSuffix::hasPrefix('10|post', ['|']));
+        self::assertSame('10', PrefixSuffix::getPrefix('10|post', ['|']));
+        self::assertSame('post', PrefixSuffix::sub('10|post', ['|']));
+    }
+}

--- a/tests/Unit/Collection/Taxonomy/CollectionTest.php
+++ b/tests/Unit/Collection/Taxonomy/CollectionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Collection\Taxonomy;
+
+use Cecil\Collection\Taxonomy\Collection;
+use Cecil\Collection\Taxonomy\Vocabulary;
+use PHPUnit\Framework\TestCase;
+
+class CollectionTest extends TestCase
+{
+    public function testGetReturnsVocabulary(): void
+    {
+        $taxonomies = new Collection('taxonomies');
+        $tags = new Vocabulary('tags');
+        $taxonomies->add($tags);
+
+        self::assertSame($tags, $taxonomies->get('tags'));
+    }
+}

--- a/tests/Unit/Collection/Taxonomy/VocabularyTest.php
+++ b/tests/Unit/Collection/Taxonomy/VocabularyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Collection\Taxonomy;
+
+use Cecil\Collection\Taxonomy\Term;
+use Cecil\Collection\Taxonomy\Vocabulary;
+use PHPUnit\Framework\TestCase;
+
+class VocabularyTest extends TestCase
+{
+    public function testAddSkipsDuplicateTermsAndGetReturnsTerm(): void
+    {
+        $vocabulary = new Vocabulary('tags');
+        $term = (new Term('php'))->setName('PHP');
+
+        $vocabulary->add($term);
+        $vocabulary->add((new Term('php'))->setName('Duplicate'));
+
+        self::assertCount(1, $vocabulary);
+        self::assertSame($term, $vocabulary->get('php'));
+        self::assertSame('PHP', $vocabulary->get('php')->getName());
+    }
+}

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -16,9 +16,26 @@ namespace Cecil\Test\Unit;
 use Cecil\Config;
 use Cecil\Exception\ConfigException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ConfigTest extends TestCase
 {
+    private string $tmpDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-config-test-' . uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
     public function testEmptyCacheDirectoryIsRejectedWhenCacheIsEnabled(): void
     {
         $this->expectException(ConfigException::class);
@@ -41,5 +58,552 @@ class ConfigTest extends TestCase
                 'formats' => ['html'],
             ],
         ]);
+    }
+
+    public function testLoadFileThrowsWhenFileDoesNotExist(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        Config::loadFile($this->tmpDir . DIRECTORY_SEPARATOR . 'missing.yml');
+    }
+
+    public function testLoadFileReturnsEmptyArrayWhenIgnoredAndMissing(): void
+    {
+        self::assertSame([], Config::loadFile($this->tmpDir . DIRECTORY_SEPARATOR . 'missing.yml', true));
+    }
+
+    public function testLoadFileThrowsOnInvalidYaml(): void
+    {
+        $file = $this->tmpDir . DIRECTORY_SEPARATOR . 'invalid.yml';
+        file_put_contents($file, "title: [unterminated\n");
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('parsing error');
+
+        Config::loadFile($file);
+    }
+
+    public function testGetCachePathThrowsWhenCacheDirectoryIsUndefined(): void
+    {
+        $config = new Config([
+            'cache' => [
+                'enabled' => false,
+                'dir' => '',
+            ],
+        ]);
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('cache directory (`cache.dir`) is not defined');
+
+        $config->getCachePath();
+    }
+
+    public function testGetThemeReturnsArrayWhenConfiguredAsString(): void
+    {
+        $config = new Config();
+        $config->import([
+            'theme' => 'cecil-theme',
+        ]);
+
+        self::assertSame(['cecil-theme'], $config->getTheme());
+    }
+
+    public function testGetAndHasUseLanguageSpecificConfiguration(): void
+    {
+        $config = new Config();
+        $config->import([
+            'language' => 'en',
+            'title' => 'Global title',
+            'languages' => [
+                ['code' => 'en', 'locale' => 'en_US', 'config' => ['title' => 'English title']],
+                ['code' => 'fr', 'locale' => 'fr_FR', 'config' => ['title' => 'Titre francais']],
+            ],
+        ]);
+
+        self::assertTrue($config->has('title', 'fr'));
+        self::assertSame('Titre francais', $config->get('title', 'fr'));
+    }
+
+    public function testGetReturnsDefaultConfigurationValueWhenFallbackIsDisabledAndNoLocalizedValue(): void
+    {
+        $config = new Config();
+        $config->import([
+            'language' => 'en',
+            'title' => 'Global title',
+            'languages' => [
+                ['code' => 'en', 'locale' => 'en_US', 'config' => ['title' => 'English title']],
+                ['code' => 'fr', 'locale' => 'fr_FR', 'config' => []],
+            ],
+        ]);
+
+        self::assertSame('Site title', $config->get('title', 'fr', false));
+    }
+
+    public function testGetOutputFormatPropertyThrowsWhenPropertyIsUnknown(): void
+    {
+        $config = new Config();
+        $config->import([]);
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Property "unknown" is not defined for format "html".');
+
+        $config->getOutputFormatProperty('html', 'unknown');
+    }
+
+    public function testOutputFormatPropertyReturnsMediaType(): void
+    {
+        $config = new Config();
+        $config->import([]);
+
+        self::assertSame('text/html', $config->getOutputFormatProperty('html', 'mediatype'));
+    }
+
+    public function testPathHelpersRespectConfiguredDirectories(): void
+    {
+        $source = $this->tmpDir . DIRECTORY_SEPARATOR . 'source';
+        $destination = $this->tmpDir . DIRECTORY_SEPARATOR . 'destination';
+        $this->filesystem->mkdir([$source, $destination]);
+
+        $config = new Config();
+        $config->setSourceDir($source);
+        $config->setDestinationDir($destination);
+        $config->import([]);
+
+        self::assertStringEndsWith('pages', $config->getPagesPath());
+        self::assertStringEndsWith('_site', $config->getOutputPath());
+        self::assertStringEndsWith('data', $config->getDataPath());
+        self::assertStringEndsWith('layouts', $config->getLayoutsPath());
+        self::assertStringEndsWith('translations', $config->getTranslationsPath());
+        self::assertStringEndsWith('themes', $config->getThemesPath());
+        self::assertStringEndsWith('static', $config->getStaticPath());
+        self::assertStringEndsWith('assets', $config->getAssetsPath());
+        self::assertStringEndsWith('remote', $config->getAssetsRemotePath());
+    }
+
+    public function testAbsoluteCachePathCreatesCecilSubdirectory(): void
+    {
+        $source = $this->tmpDir . DIRECTORY_SEPARATOR . 'source';
+        $destination = $this->tmpDir . DIRECTORY_SEPARATOR . 'destination';
+        $absoluteCacheRoot = $this->tmpDir . DIRECTORY_SEPARATOR . 'cache-root';
+        $this->filesystem->mkdir([$source, $destination, $absoluteCacheRoot]);
+
+        $config = new Config();
+        $config->setSourceDir($source);
+        $config->setDestinationDir($destination);
+        $config->import([
+            'cache' => [
+                'enabled' => true,
+                'dir' => $absoluteCacheRoot,
+            ],
+        ]);
+
+        $cachePath = $config->getCachePath();
+
+        self::assertStringEndsWith('cache-root' . DIRECTORY_SEPARATOR . 'cecil', $cachePath);
+        self::assertDirectoryExists($cachePath);
+    }
+
+    public function testLanguageHelpersReturnExpectedValues(): void
+    {
+        $config = new Config();
+        $config->import([
+            'language' => ['code' => 'en'],
+            'languages' => [
+                ['code' => 'en', 'locale' => 'en_US', 'name' => 'English'],
+                ['code' => 'fr', 'locale' => 'fr_FR', 'name' => 'Francais'],
+            ],
+        ]);
+
+        self::assertSame('en', $config->getLanguageDefault());
+        self::assertSame(1, $config->getLanguageIndex('fr'));
+        self::assertSame('fr_FR', $config->getLanguageProperty('locale', 'fr'));
+        self::assertCount(2, $config->getLanguages());
+    }
+
+    public function testLanguageDefaultMustExistInLanguagesList(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('is not listed in "languages"');
+
+        $config = new Config();
+        $config->import([
+            'language' => 'en',
+            'languages' => [
+                ['code' => 'fr', 'locale' => 'fr_FR'],
+            ],
+        ]);
+        $config->getLanguages();
+    }
+
+    public function testSetSourceDirAndSetDestinationDirValidateDirectories(): void
+    {
+        $config = new Config();
+        $missing = $this->tmpDir . DIRECTORY_SEPARATOR . 'missing-dir';
+
+        try {
+            $config->setSourceDir($missing);
+            self::fail('Expected exception was not thrown for source dir.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('is not a valid source', $e->getMessage());
+        }
+
+        try {
+            $config->setDestinationDir($missing);
+            self::fail('Expected exception was not thrown for destination dir.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('is not a valid destination', $e->getMessage());
+        }
+    }
+
+    public function testIsEnabledSupportsBooleanAndEnabledSubkey(): void
+    {
+        $config = new Config();
+        $config->import([
+            'featureA' => true,
+            'featureB' => ['enabled' => true],
+            'featureC' => ['enabled' => false],
+            'featureD' => 'custom',
+        ]);
+
+        self::assertTrue($config->isEnabled('featureA'));
+        self::assertTrue($config->isEnabled('featureB'));
+        self::assertFalse($config->isEnabled('featureC'));
+        self::assertTrue($config->isEnabled('featureD'));
+        self::assertFalse($config->isEnabled('missingFeature'));
+    }
+
+    public function testThemeHelpersAndMissingThemeValidation(): void
+    {
+        $source = $this->tmpDir . DIRECTORY_SEPARATOR . 'source';
+        $destination = $this->tmpDir . DIRECTORY_SEPARATOR . 'destination';
+        $this->filesystem->mkdir([$source, $destination]);
+
+        $config = new Config();
+        $config->setSourceDir($source);
+        $config->setDestinationDir($destination);
+        $config->import([]);
+
+        self::assertNull($config->getTheme());
+        self::assertFalse($config->hasTheme());
+
+        $config->import(['theme' => 'missing-theme']);
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Theme "missing-theme" not found');
+        $config->hasTheme();
+    }
+
+    public function testCacheAndInternalPathsHelpers(): void
+    {
+        $source = $this->tmpDir . DIRECTORY_SEPARATOR . 'source';
+        $destination = $this->tmpDir . DIRECTORY_SEPARATOR . 'destination';
+        $this->filesystem->mkdir([$source, $destination]);
+
+        $config = new Config();
+        $config->setSourceDir($source);
+        $config->setDestinationDir($destination);
+        $config->import([]);
+
+        self::assertStringEndsWith('templates', $config->getCacheTemplatesPath());
+        self::assertStringEndsWith('translations', $config->getCacheTranslationsPath());
+        self::assertStringEndsWith('assets', $config->getCacheAssetsPath());
+        self::assertStringEndsWith('resources' . DIRECTORY_SEPARATOR . 'layouts', $config->getLayoutsInternalPath());
+        self::assertStringEndsWith('resources' . DIRECTORY_SEPARATOR . 'translations', $config->getTranslationsInternalPath());
+    }
+
+    public function testLayoutSectionAndThemeDirPathHelpers(): void
+    {
+        $config = new Config();
+        $config->import([
+            'layouts' => [
+                'sections' => [
+                    'blog' => 'custom-blog',
+                ],
+            ],
+        ]);
+
+        self::assertSame('custom-blog', $config->getLayoutSection('blog'));
+        self::assertSame('news', $config->getLayoutSection('news'));
+        self::assertStringEndsWith('themes' . DIRECTORY_SEPARATOR . 'my-theme' . DIRECTORY_SEPARATOR . 'assets', $config->getThemeDirPath('my-theme', 'assets'));
+    }
+
+    public function testLanguageValidationErrorsAreRaised(): void
+    {
+        try {
+            new Config([
+                'language' => 'bad_code',
+            ]);
+            self::fail('Expected invalid language code exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('Default language code', $e->getMessage());
+        }
+
+        try {
+            new Config([
+                'languages' => [
+                    ['code' => 'en'],
+                ],
+            ]);
+            self::fail('Expected missing locale exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('locale is not defined', $e->getMessage());
+        }
+
+        try {
+            new Config([
+                'languages' => [
+                    ['code' => 'en', 'locale' => 'invalid-locale'],
+                ],
+            ]);
+            self::fail('Expected invalid locale exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('language locale', $e->getMessage());
+        }
+    }
+
+    public function testDeprecatedOptionsRaiseDetailedErrors(): void
+    {
+        try {
+            new Config([
+                'frontmatter' => 'yaml',
+            ]);
+            self::fail('Expected deprecated move exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('must be moved to', $e->getMessage());
+            self::assertStringContainsString('pages:', $e->getMessage());
+        }
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('deprecated and must be removed');
+
+        new Config([
+            'assets' => [
+                'remote' => [
+                    'dir' => '/tmp',
+                ],
+            ],
+        ]);
+    }
+
+    public function testEnvironmentVariablesOverrideConfigurationAndCastBooleans(): void
+    {
+        putenv('CECIL_TITLE=Env Title');
+        putenv('CECIL_CANONICALURL=true');
+
+        try {
+            $config = new Config();
+            $config->import([]);
+
+            self::assertSame('Env Title', $config->get('title'));
+            self::assertTrue($config->get('canonicalurl'));
+        } finally {
+            putenv('CECIL_TITLE');
+            putenv('CECIL_CANONICALURL');
+        }
+    }
+
+    public function testExportContainsImportedValues(): void
+    {
+        $config = new Config();
+        $config->import(['title' => 'Exported title']);
+
+        $export = $config->export();
+
+        self::assertIsArray($export);
+        self::assertSame('Exported title', $export['title']);
+    }
+
+    public function testSourceAndDestinationFallbacksUseCurrentWorkingDirectory(): void
+    {
+        $config = new Config();
+
+        self::assertSame(getcwd(), $config->getSourceDir());
+        self::assertSame(getcwd(), $config->getDestinationDir());
+    }
+
+    public function testGetOutputFormatPropertyReturnsNullForUnknownFormat(): void
+    {
+        $config = new Config();
+        $config->import([]);
+
+        self::assertNull($config->getOutputFormatProperty('unknown-format', 'mediatype'));
+    }
+
+    public function testAssetsResponsiveHelpersReturnConfiguredValues(): void
+    {
+        $config = new Config();
+        $config->import([]);
+
+        self::assertNotEmpty($config->getAssetsImagesWidths());
+        self::assertArrayHasKey('default', $config->getAssetsImagesSizes());
+        self::assertNotEmpty($config->getAssetsImagesDensities());
+    }
+
+    public function testLanguageHelpersRaiseExceptionsForMissingValues(): void
+    {
+        try {
+            new Config([
+                'language' => [],
+            ]);
+            self::fail('Expected missing language.code exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('There is no default "language" key.', $e->getMessage());
+        }
+
+        $config = new Config();
+        $config->import([]);
+
+        try {
+            $config->getLanguageIndex('zz');
+            self::fail('Expected undefined language code exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('is not defined', $e->getMessage());
+        }
+
+        try {
+            $config->getLanguageProperty('unknown_property');
+            self::fail('Expected missing language property exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('Property "unknown_property" is not defined', $e->getMessage());
+        }
+    }
+
+    public function testGetLanguagesFiltersDisabledEntries(): void
+    {
+        $config = new Config();
+        $config->import([
+            'language' => 'en',
+            'languages' => [
+                ['code' => 'en', 'locale' => 'en_US', 'enabled' => true],
+                ['code' => 'fr', 'locale' => 'fr_FR', 'enabled' => false],
+            ],
+        ]);
+
+        $languages = $config->getLanguages();
+
+        self::assertCount(1, $languages);
+        self::assertSame('en', $languages[0]['code']);
+    }
+
+    public function testHasThemeReturnsTrueWhenThemeConfigExists(): void
+    {
+        $source = $this->tmpDir . DIRECTORY_SEPARATOR . 'source';
+        $destination = $this->tmpDir . DIRECTORY_SEPARATOR . 'destination';
+        $themeDir = $source . DIRECTORY_SEPARATOR . 'themes' . DIRECTORY_SEPARATOR . 'existing-theme';
+        $this->filesystem->mkdir([$source, $destination, $themeDir]);
+        file_put_contents($themeDir . DIRECTORY_SEPARATOR . 'config.yml', "title: Theme\n");
+
+        $config = new Config();
+        $config->setSourceDir($source);
+        $config->setDestinationDir($destination);
+        $config->import(['theme' => 'existing-theme']);
+
+        self::assertTrue($config->hasTheme());
+    }
+
+    public function testHasWithLanguageAndFallbackDisabledUsesDefaultPresence(): void
+    {
+        $config = new Config();
+        $config->import([
+            'language' => 'en',
+            'languages' => [
+                ['code' => 'en', 'locale' => 'en_US', 'config' => []],
+                ['code' => 'fr', 'locale' => 'fr_FR', 'config' => []],
+            ],
+        ]);
+
+        self::assertTrue($config->has('title', 'fr', false));
+    }
+
+    public function testGetLanguagePropertyUsesDefaultLanguageWhenCodeIsNull(): void
+    {
+        $config = new Config();
+        $config->import([]);
+
+        self::assertSame('en_EN', $config->getLanguageProperty('locale'));
+    }
+
+    public function testGetOutputFormatPropertyCanReturnArrayProperty(): void
+    {
+        $config = new Config();
+        $config->import([]);
+
+        $exclude = $config->getOutputFormatProperty('atom', 'exclude');
+
+        self::assertIsArray($exclude);
+        self::assertContains('redirect', $exclude);
+    }
+
+    public function testIsCacheDirIsAbsoluteReturnsFalseForRelativeCacheDir(): void
+    {
+        $config = new Config();
+        $config->import([
+            'cache' => [
+                'dir' => '.cache',
+            ],
+        ]);
+
+        self::assertFalse($config->isCacheDirIsAbsolute());
+    }
+
+    public function testGetCachePathUsesDestinationForRelativeCacheDirectory(): void
+    {
+        $source = $this->tmpDir . DIRECTORY_SEPARATOR . 'source';
+        $destination = $this->tmpDir . DIRECTORY_SEPARATOR . 'destination';
+        $this->filesystem->mkdir([$source, $destination]);
+
+        $config = new Config();
+        $config->setSourceDir($source);
+        $config->setDestinationDir($destination);
+        $config->import([
+            'cache' => [
+                'enabled' => true,
+                'dir' => '.cache',
+            ],
+        ]);
+
+        self::assertSame($destination . DIRECTORY_SEPARATOR . '.cache', $config->getCachePath());
+    }
+
+    public function testOutputFormatValidationRequiresNameAndMediatype(): void
+    {
+        try {
+            new Config([
+                'output' => [
+                    'formats' => [
+                        ['mediatype' => 'text/plain'],
+                    ],
+                ],
+            ]);
+            self::fail('Expected missing name validation exception.');
+        } catch (ConfigException $e) {
+            self::assertStringContainsString('missing "name"', $e->getMessage());
+        }
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('missing "mediatype"');
+
+        new Config([
+            'output' => [
+                'formats' => [
+                    ['name' => 'plain'],
+                ],
+            ],
+        ]);
+    }
+
+    public function testLanguageCanBeOverriddenToEmptyViaEnvironment(): void
+    {
+        putenv('CECIL_LANGUAGE=');
+
+        try {
+            $this->expectException(ConfigException::class);
+            $this->expectExceptionMessage('There is no default "language" key.');
+
+            $config = new Config();
+            $config->import([]);
+        } finally {
+            putenv('CECIL_LANGUAGE');
+        }
     }
 }

--- a/tests/Unit/Logger/PrintLoggerTest.php
+++ b/tests/Unit/Logger/PrintLoggerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Logger;
+
+use Cecil\Builder;
+use Cecil\Logger\PrintLogger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+
+class PrintLoggerTest extends TestCase
+{
+    public function testLogThrowsForUnknownLevel(): void
+    {
+        $logger = new PrintLogger();
+
+        $this->expectException(\Psr\Log\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        $logger->log('unknown', 'hello');
+    }
+
+    public function testInfoAndErrorFormatting(): void
+    {
+        $logger = new PrintLogger();
+
+        ob_start();
+        $logger->log(LogLevel::INFO, 'Hello {name}', ['name' => 'Cecil']);
+        $logger->log(LogLevel::ERROR, 'Boom');
+        $output = ob_get_clean();
+
+        self::assertStringContainsString("Hello Cecil\n", $output);
+        self::assertStringContainsString("[error] Boom\n", $output);
+    }
+
+    public function testProgressContextIsPrinted(): void
+    {
+        $logger = new PrintLogger();
+
+        ob_start();
+        $logger->log(LogLevel::INFO, 'Build', ['progress' => [1, 3]]);
+        $output = ob_get_clean();
+
+        self::assertStringContainsString('Build (1/3)', $output);
+    }
+
+    public function testVerbosityFilterSkipsHigherLevels(): void
+    {
+        $logger = new PrintLogger(Builder::VERBOSITY_NORMAL);
+
+        ob_start();
+        $logger->log(LogLevel::DEBUG, 'hidden');
+        $output = ob_get_clean();
+
+        self::assertSame('', $output);
+    }
+
+    public function testInterpolationSupportsNonScalarValues(): void
+    {
+        $logger = new PrintLogger();
+        $date = new \DateTimeImmutable('2026-01-01T10:00:00+00:00');
+        $object = new class () {
+            public function __toString(): string
+            {
+                return 'obj';
+            }
+        };
+
+        ob_start();
+        $logger->log(LogLevel::INFO, '{date} {object} {array}', [
+            'date' => $date,
+            'object' => $object,
+            'array' => ['x'],
+        ]);
+        $output = ob_get_clean();
+
+        self::assertStringContainsString('2026-01-01T10:00:00+00:00', $output);
+        self::assertStringContainsString('obj', $output);
+        self::assertStringContainsString('[array]', $output);
+    }
+
+    public function testFormatRemovesSpacesAndNewLines(): void
+    {
+        self::assertSame("'foobar'", PrintLogger::format("foo\n bar"));
+    }
+}

--- a/tests/Unit/Util/DateTest.php
+++ b/tests/Unit/Util/DateTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Util;
+
+use Cecil\Util\Date;
+use PHPUnit\Framework\TestCase;
+
+class DateTest extends TestCase
+{
+    public function testIsValidRecognizesExpectedFormat(): void
+    {
+        self::assertTrue(Date::isValid('2026-08-20'));
+        self::assertFalse(Date::isValid('2026-13-99'));
+    }
+
+    public function testToDatetimeRejectsNull(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("can't be null");
+
+        Date::toDatetime(null);
+    }
+
+    public function testToDatetimeSupportsDateTimeAndImmutable(): void
+    {
+        $dateTime = new \DateTime('2024-01-01T00:00:00+00:00');
+        self::assertSame($dateTime, Date::toDatetime($dateTime));
+
+        $immutable = new \DateTimeImmutable('2024-01-01T00:00:00+00:00');
+        $converted = Date::toDatetime($immutable);
+        self::assertInstanceOf(\DateTime::class, $converted);
+        self::assertSame($immutable->getTimestamp(), $converted->getTimestamp());
+    }
+
+    public function testToDatetimeSupportsTimestampAndString(): void
+    {
+        $fromTimestamp = Date::toDatetime(0);
+        self::assertSame(0, $fromTimestamp->getTimestamp());
+
+        $fromString = Date::toDatetime('2024-02-20 12:34:56');
+        self::assertInstanceOf(\DateTime::class, $fromString);
+        self::assertSame('2024-02-20', $fromString->format('Y-m-d'));
+    }
+
+    public function testToDatetimeRejectsWrongType(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('must be a string, an integer timestamp');
+
+        Date::toDatetime([]);
+    }
+
+    public function testDurationToIso8601RoundsAndFormats(): void
+    {
+        self::assertSame('PT00H00M3661S', Date::durationToIso8601(3661));
+        self::assertSame('PT00H00M01S', Date::durationToIso8601(0.6));
+    }
+}

--- a/tests/Unit/Util/FileTest.php
+++ b/tests/Unit/Util/FileTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Util;
+
+use Cecil\Exception\RuntimeException;
+use Cecil\Util\File;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FileTest extends TestCase
+{
+    private string $tmpDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-file-test-' . uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    public function testGetFsReturnsFilesystemInstance(): void
+    {
+        self::assertInstanceOf(Filesystem::class, File::getFS());
+    }
+
+    public function testFileGetContentsHandlesEmptyAndMissingFiles(): void
+    {
+        self::assertFalse(File::fileGetContents(''));
+        self::assertFalse(File::fileGetContents($this->tmpDir . DIRECTORY_SEPARATOR . 'missing.txt'));
+    }
+
+    public function testFileGetContentsReadsLocalFile(): void
+    {
+        $file = $this->tmpDir . DIRECTORY_SEPARATOR . 'sample.txt';
+        file_put_contents($file, 'hello');
+
+        self::assertSame('hello', File::fileGetContents($file));
+    }
+
+    public function testGetMediaTypeReturnsMainAndSubtype(): void
+    {
+        $file = $this->tmpDir . DIRECTORY_SEPARATOR . 'sample.txt';
+        file_put_contents($file, 'hello');
+
+        [$type, $subtype] = File::getMediaType($file);
+
+        self::assertNotSame('', $type);
+        self::assertStringContainsString('/', $subtype);
+        self::assertSame(explode('/', $subtype)[0], $type);
+    }
+
+    public function testGetMediaTypeThrowsForMissingFile(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to get media type');
+
+        File::getMediaType($this->tmpDir . DIRECTORY_SEPARATOR . 'does-not-exist.txt');
+    }
+
+    public function testGetExtensionUsesPathInfoWhenAvailable(): void
+    {
+        self::assertSame('css', File::getExtension('style.min.css'));
+    }
+
+    public function testGetExtensionCanBeGuessedForFileWithoutExtension(): void
+    {
+        $file = $this->tmpDir . DIRECTORY_SEPARATOR . 'README';
+        file_put_contents($file, 'hello');
+
+        self::assertSame('txt', File::getExtension($file));
+    }
+
+    public function testGetExtensionThrowsWhenFileWithoutExtensionCannotBeGuessed(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to get extension');
+
+        File::getExtension($this->tmpDir . DIRECTORY_SEPARATOR . 'missing-no-extension');
+    }
+
+    public function testReadExifReturnsEmptyArrayForInvalidSource(): void
+    {
+        self::assertSame([], File::readExif(''));
+
+        $file = $this->tmpDir . DIRECTORY_SEPARATOR . 'sample.txt';
+        file_put_contents($file, 'hello');
+        self::assertSame([], File::readExif($file));
+    }
+
+    public function testGetRealPathResolvesExistingRelativePath(): void
+    {
+        $path = File::getRealPath('../config/default.php');
+
+        self::assertFileExists($path);
+        self::assertStringEndsWith('config' . DIRECTORY_SEPARATOR . 'default.php', $path);
+    }
+
+    public function testGetRealPathThrowsForUnknownPathOutsidePhar(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to get the real path');
+
+        File::getRealPath('../config/does-not-exist.php');
+    }
+
+    public function testIsRemoteRecognizesHttpLikeSchemes(): void
+    {
+        self::assertTrue(File::isRemote('http://example.com/file.css'));
+        self::assertTrue(File::isRemote('https://example.com/file.css'));
+        self::assertTrue(File::isRemote('ftp://example.com/file.css'));
+        self::assertFalse(File::isRemote('/local/path/file.css'));
+    }
+
+    public function testIsRemoteExistsReturnsFalseForLocalPath(): void
+    {
+        self::assertFalse(File::isRemoteExists($this->tmpDir . DIRECTORY_SEPARATOR . 'local.txt'));
+    }
+}

--- a/tests/Unit/Util/PlatformTest.php
+++ b/tests/Unit/Util/PlatformTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Util;
+
+use Cecil\Util\Platform;
+use PHPUnit\Framework\TestCase;
+
+class PlatformTest extends TestCase
+{
+    public function testIsWindowsMatchesPhpConstant(): void
+    {
+        self::assertSame(\defined('PHP_WINDOWS_VERSION_BUILD'), Platform::isWindows());
+    }
+
+    public function testGetOsReturnsKnownConstant(): void
+    {
+        $os = Platform::getOS();
+
+        self::assertContains($os, [
+            Platform::OS_UNKNOWN,
+            Platform::OS_WIN,
+            Platform::OS_LINUX,
+            Platform::OS_OSX,
+        ]);
+    }
+
+    public function testGetPharPathThrowsWhenNotRunningFromPhar(): void
+    {
+        if (Platform::isPhar()) {
+            self::assertNotSame('', Platform::getPharPath());
+
+            return;
+        }
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to get Phar path.');
+
+        Platform::getPharPath();
+    }
+
+    public function testIsPharReturnsBoolean(): void
+    {
+        self::assertIsBool(Platform::isPhar());
+    }
+
+    public function testGetPharPathReturnsPreconfiguredStaticPath(): void
+    {
+        $getter = static function () {
+            return self::$pharPath ?? null;
+        };
+        $setter = static function ($value): void {
+            self::$pharPath = $value;
+        };
+        $boundGetter = \Closure::bind($getter, null, Platform::class);
+        $boundSetter = \Closure::bind($setter, null, Platform::class);
+        $previousValue = $boundGetter();
+
+        try {
+            $boundSetter('/tmp/fake-cecil.phar');
+            self::assertSame('/tmp/fake-cecil.phar', Platform::getPharPath());
+        } finally {
+            $boundSetter($previousValue);
+        }
+    }
+}

--- a/tests/Unit/Util/StrTest.php
+++ b/tests/Unit/Util/StrTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Util;
+
+use Cecil\Util\Str;
+use PHPUnit\Framework\TestCase;
+
+class StrTest extends TestCase
+{
+    public function testCombineArrayToStringSupportsSeparator(): void
+    {
+        $value = Str::combineArrayToString([
+            ['name' => 'a', 'value' => 1],
+            ['name' => 'b', 'value' => 2],
+        ], 'name', 'value', '=');
+
+        self::assertSame('a=1, b=2', $value);
+    }
+
+    public function testArrayToListFormatsBulletLines(): void
+    {
+        self::assertSame(" - one\n - two", Str::arrayToList(['one', 'two']));
+    }
+
+    public function testStrToBoolConvertsKnownLiteralsOnly(): void
+    {
+        self::assertTrue(Str::strToBool('true'));
+        self::assertFalse(Str::strToBool('off'));
+        self::assertSame('maybe', Str::strToBool('maybe'));
+        self::assertSame(42, Str::strToBool(42));
+    }
+
+    public function testStartsWithAndEndsWith(): void
+    {
+        self::assertTrue(Str::startsWith('cecil-app', 'cecil'));
+        self::assertFalse(Str::startsWith('cecil-app', 'app'));
+
+        self::assertTrue(Str::endsWith('cecil-app', 'app'));
+        self::assertFalse(Str::endsWith('cecil-app', 'cecil'));
+        self::assertTrue(Str::endsWith('cecil-app', ''));
+    }
+}

--- a/tests/Unit/UtilTest.php
+++ b/tests/Unit/UtilTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit;
+
+use Cecil\Builder;
+use Cecil\Util;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class UtilTest extends TestCase
+{
+    private string $tmpDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-util-test-' . uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    public function testFormatClassAndMethodNames(): void
+    {
+        $object = new class () {};
+
+        self::assertNotSame('', Util::formatClassName($object, ['lowercase' => true]));
+        self::assertSame(strtolower(Util::formatClassName($object)), Util::formatClassName($object, ['lowercase' => true]));
+        self::assertSame('method', Util::formatMethodName('A\\B::method'));
+    }
+
+    public function testJoinPathAndJoinFileNormalizeSeparators(): void
+    {
+        self::assertSame('a/b/c', Util::joinPath('a/', '/b', 'c'));
+
+        $joinedFile = Util::joinFile('a/', '/b', 'c');
+        self::assertStringContainsString('a', $joinedFile);
+        self::assertStringContainsString('b', $joinedFile);
+        self::assertStringContainsString('c', $joinedFile);
+    }
+
+    public function testMemoryAndDurationConverters(): void
+    {
+        self::assertSame('0', Util::convertMemory(0));
+        self::assertStringContainsString('kb', Util::convertMemory(2048));
+
+        self::assertStringEndsWith('ms', Util::convertDuration(0.25));
+        self::assertStringEndsWith('s', Util::convertDuration(1.5));
+        self::assertStringContainsString('ms', Util::convertMicrotime(microtime(true)));
+    }
+
+    public function testGetPhpRequirementsParsesComposerRequire(): void
+    {
+        $requirements = Util::getPhpRequirements();
+
+        self::assertSame('8.2.0', $requirements['minimumVersion']);
+        self::assertContains('fileinfo', $requirements['requiredExtensions']);
+        self::assertContains('gd', $requirements['requiredExtensions']);
+        self::assertContains('mbstring', $requirements['requiredExtensions']);
+    }
+
+    public function testMatchesUrlPatternForKnownServices(): void
+    {
+        $youtube = Util::matchesUrlPattern('https://youtu.be/dQw4w9WgXcQ');
+        self::assertIsArray($youtube);
+        self::assertSame('video', $youtube['type']);
+        self::assertStringContainsString('youtube-nocookie.com/embed/dQw4w9WgXcQ', $youtube['url']);
+
+        $vimeo = Util::matchesUrlPattern('https://vimeo.com/123456');
+        self::assertIsArray($vimeo);
+        self::assertStringContainsString('player.vimeo.com/video/123456', $vimeo['url']);
+
+        $dailymotion = Util::matchesUrlPattern('https://www.dailymotion.com/video/x7tgcz');
+        self::assertIsArray($dailymotion);
+        self::assertStringContainsString('dailymotion.com/player.html?video=x7tgcz', $dailymotion['url']);
+
+        $gist = Util::matchesUrlPattern('https://gist.github.com/user/abcdef');
+        self::assertIsArray($gist);
+        self::assertSame('script', $gist['type']);
+        self::assertSame('https://gist.github.com/user/abcdef', $gist['url']);
+
+        self::assertFalse(Util::matchesUrlPattern('https://example.com/nope'));
+    }
+
+    public function testAutoloadLoadsClassFromSourceExtensionsDirectory(): void
+    {
+        $extensionsDir = $this->tmpDir . DIRECTORY_SEPARATOR . 'extensions';
+        $this->filesystem->mkdir($extensionsDir);
+
+        $className = 'CecilTmpAutoloadClass';
+        $classFile = $extensionsDir . DIRECTORY_SEPARATOR . $className . '.php';
+        file_put_contents($classFile, "<?php\nclass $className {}\n");
+
+        $builder = new Builder(['baseurl' => 'https://example.com/']);
+        $builder->setSourceDir($this->tmpDir);
+
+        Util::autoload($builder, 'extensions');
+
+        self::assertTrue(class_exists($className));
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several core classes, improving test coverage and ensuring robust behavior for edge cases and error handling. The updates include new tests for the `Builder`, `Cache`, `Collection`, and `Locator` classes, as well as enhancements to test setup and minor code corrections.

**New and Improved Unit Tests**

* Added a new `BuilderTest` class to cover a wide range of `Builder` behaviors, including data accessors, asset registry, layout cache stats, and error handling.
* Significantly expanded `CacheTest` with tests for cache key creation, expiration, content file management, unimplemented methods, and more, including utility methods for better testability. [[1]](diffhunk://#diff-bffcd3aa7531a88c863a3f21b8dcef360a49dccde3c540efdc84f176e2e943b9R95-R339) [[2]](diffhunk://#diff-bffcd3aa7531a88c863a3f21b8dcef360a49dccde3c540efdc84f176e2e943b9R350-R370)
* Improved `LocatorTest` by adding setup/teardown logic and new tests for asset location logic, including localization, theme/static fallbacks, remote files, and error cases. [[1]](diffhunk://#diff-c0b80eabe4aa7f73f4dc4c3d5c8a5c4d37ea30f684bc51f5d531dd5ef6503570R16-R50) [[2]](diffhunk://#diff-c0b80eabe4aa7f73f4dc4c3d5c8a5c4d37ea30f684bc51f5d531dd5ef6503570R122-R217)
* Enhanced `CollectionTest` with tests for duplicate handling, missing item errors, array access, and helper methods, ensuring collection operations are robust.

**Bugfixes and Minor Improvements**

* Fixed a typo in an exception message in `Cache.php` ("does not exist" instead of "does not exists").
* Updated `composer.json` to run both unit and integration tests when invoking the `test` script.