### PR TITLE
feat: add nested section hierarchy and breadcrumbs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -332,24 +332,24 @@
         },
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.1.4",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
+                "reference": "adccca3324eece92ca35463648c12b9e6293c05b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
-                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/adccca3324eece92ca35463648c12b9e6293c05b",
+                "reference": "adccca3324eece92ca35463648c12b9e6293c05b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.5"
+                "phpoption/phpoption": "^1.10"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34 || ^10.5.63 || ^11.5.55 || ^12.5.14"
             },
             "type": "library",
             "autoload": {
@@ -378,7 +378,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.2.0"
             },
             "funding": [
                 {
@@ -390,7 +390,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:43:20+00:00"
+            "time": "2026-08-24T09:06:52+00:00"
         },
         {
             "name": "intervention/gif",
@@ -462,16 +462,16 @@
         },
         {
             "name": "intervention/image",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "5598b9e39751c34afc5cdee84abef77f92c26f68"
+                "reference": "3fd8ac3da6410d4de873be7be665f8ce8e6aeec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/5598b9e39751c34afc5cdee84abef77f92c26f68",
-                "reference": "5598b9e39751c34afc5cdee84abef77f92c26f68",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/3fd8ac3da6410d4de873be7be665f8ce8e6aeec5",
+                "reference": "3fd8ac3da6410d4de873be7be665f8ce8e6aeec5",
                 "shasum": ""
             },
             "require": {
@@ -518,7 +518,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Intervention/image/issues",
-                "source": "https://github.com/Intervention/image/tree/4.3.0"
+                "source": "https://github.com/Intervention/image/tree/4.3.1"
             },
             "funding": [
                 {
@@ -534,7 +534,7 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2026-08-21T12:18:16+00:00"
+            "time": "2026-08-24T13:23:45+00:00"
         },
         {
             "name": "james-heinrich/getid3",
@@ -1215,16 +1215,16 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.5",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
+                "reference": "67b192b6a42ec03944b972d6e633ddec78ad2c6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
-                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/67b192b6a42ec03944b972d6e633ddec78ad2c6d",
+                "reference": "67b192b6a42ec03944b972d6e633ddec78ad2c6d",
                 "shasum": ""
             },
             "require": {
@@ -1232,7 +1232,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
+                "phpunit/phpunit": "^8.5.54 || ^9.6.36 || ^10.5.64 || ^11.5.56 || ^12.5.33"
             },
             "type": "library",
             "extra": {
@@ -1274,7 +1274,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.10.0"
             },
             "funding": [
                 {
@@ -1286,7 +1286,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:41:33+00:00"
+            "time": "2026-08-24T00:54:40+00:00"
         },
         {
             "name": "psr/cache",
@@ -3012,16 +3012,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.38.1",
+            "version": "v1.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+                "reference": "51b5ff5ba85452b31ec6f55490b08148612339d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
-                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/51b5ff5ba85452b31ec6f55490b08148612339d9",
+                "reference": "51b5ff5ba85452b31ec6f55490b08148612339d9",
                 "shasum": ""
             },
             "require": {
@@ -3075,7 +3075,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.42.0"
             },
             "funding": [
                 {
@@ -3095,20 +3095,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T15:22:23+00:00"
+            "time": "2026-08-24T10:51:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.38.0",
+            "version": "v1.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+                "reference": "aa20edea75bd9c48cfecc8360922e5a6e5c44502"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/aa20edea75bd9c48cfecc8360922e5a6e5c44502",
+                "reference": "aa20edea75bd9c48cfecc8360922e5a6e5c44502",
                 "shasum": ""
             },
             "require": {
@@ -3160,7 +3160,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.42.0"
             },
             "funding": [
                 {
@@ -3180,7 +3180,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T13:48:31+00:00"
+            "time": "2026-08-07T06:33:24+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -5095,23 +5095,23 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.4",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
+                "reference": "301c07936b16d88628b126b01d082ba153cf4c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
-                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/301c07936b16d88628b126b01d082ba153cf4c40",
+                "reference": "301c07936b16d88628b126b01d082ba153cf4c40",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.4",
+                "graham-campbell/result-type": "^1.2",
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.5",
+                "phpoption/phpoption": "^1.10",
                 "symfony/polyfill-ctype": "^1.26",
                 "symfony/polyfill-mbstring": "^1.26",
                 "symfony/polyfill-php80": "^1.26"
@@ -5155,7 +5155,7 @@
                     "homepage": "https://github.com/vlucas"
                 }
             ],
-            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "description": "Loads environment variables from `.env` to `$_ENV` and `$_SERVER` automagically, and optionally to `getenv()`.",
             "keywords": [
                 "dotenv",
                 "env",
@@ -5163,7 +5163,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.7.0"
             },
             "funding": [
                 {
@@ -5175,7 +5175,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-06T19:11:50+00:00"
+            "time": "2026-08-24T18:07:49+00:00"
         },
         {
             "name": "voku/html-min",
@@ -6412,16 +6412,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.21",
+            "version": "v3.95.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "1228a1cd06e867846b5922a09d2ee948d8182e91"
+                "reference": "482722e0783c16325a07a998a0d9eda560f9be99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/1228a1cd06e867846b5922a09d2ee948d8182e91",
-                "reference": "1228a1cd06e867846b5922a09d2ee948d8182e91",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/482722e0783c16325a07a998a0d9eda560f9be99",
+                "reference": "482722e0783c16325a07a998a0d9eda560f9be99",
                 "shasum": ""
             },
             "require": {
@@ -6504,7 +6504,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.21"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.22"
             },
             "funding": [
                 {
@@ -6512,7 +6512,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-21T17:03:47+00:00"
+            "time": "2026-08-24T10:37:43+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/docs/2-Content.fr.md
+++ b/docs/2-Content.fr.md
@@ -2,7 +2,7 @@
 title: Contenu
 description: "Créer du contenu et l’organiser."
 date: 2026-03-27
-updated: 2026-07-23
+updated: 2026-08-23
 slug: contenu
 -->
 # Contenu
@@ -863,6 +863,32 @@ _Exemple :_
 circular: true
 ---
 ```
+
+#### Sous-section
+
+Un dossier imbriqué qui contient explicitement un fichier `index.md` devient une _sous-section_ de sa _Section_ parente.
+
+```plaintext
+<monsiteweb>
+└─ pages
+   └─ blog                 <- Section
+      ├─ index.md
+      ├─ post-1.md         <- Page de la Section « blog »
+      └─ 2024              <- Sous-section (contient un « index.md »)
+         ├─ index.md
+         └─ post-2.md      <- Page de la Section « blog » *et* de la sous-section « blog/2024 »
+```
+
+Une _sous-section_ :
+
+- est une _Section_ (même type, mêmes variables et même résolution de [gabarit](3-Templates.md)) accessible à sa propre URL (ex. : `/blog/2024/`)
+- peut être imbriquée à n'importe quelle profondeur (ex. : `blog/2024/06/`)
+- liste ses propres pages, et ses pages appartiennent aussi à chacune de leurs _Sections_ parentes
+- n'est **pas** listée dans sa _Section_ parente
+
+:::info
+Un dossier imbriqué **sans** fichier `index.md` n'est pas une _sous-section_ : ses pages appartiennent simplement à la _Section_ parente.
+:::
 
 ### Page d'accueil
 

--- a/docs/2-Content.md
+++ b/docs/2-Content.md
@@ -1,7 +1,7 @@
 <!--
 description: "Create content and organize it."
 date: 2021-05-07
-updated: 2026-07-23
+updated: 2026-08-23
 -->
 # Content
 
@@ -862,6 +862,32 @@ _Example:_
 circular: true
 ---
 ```
+
+#### Sub-section
+
+A nested folder that explicitly contains an `index.md` file is turned into a _sub-section_ of its parent _Section_.
+
+```plaintext
+<mywebsite>
+└─ pages
+   └─ blog                 <- Section
+      ├─ index.md
+      ├─ post-1.md         <- Page in Section "blog"
+      └─ 2024              <- Sub-section (contains an "index.md")
+         ├─ index.md
+         └─ post-2.md      <- Page in Section "blog" *and* sub-section "blog/2024"
+```
+
+A _sub-section_:
+
+- is a _Section_ (same type, variables and [layout](3-Templates.md) resolution) available at its own URL (e.g.: `/blog/2024/`)
+- can be nested at any depth (e.g.: `blog/2024/06/`)
+- lists its own pages, and its pages also belong to each of their parent _Sections_
+- is **not** listed in its parent _Section_
+
+:::info
+A nested folder **without** an `index.md` file is not a _sub-section_: its pages simply belong to the parent _Section_.
+:::
 
 ### Home page
 

--- a/docs/3-Templates.fr.md
+++ b/docs/3-Templates.fr.md
@@ -2,7 +2,7 @@
 title: Templates
 description: "Travailler avec les layouts, les templates et les composants."
 date: 2026-05-26
-updated: 2026-07-10
+updated: 2026-08-25
 slug: templates
 -->
 # Templates
@@ -288,20 +288,24 @@ _Exemples :_
 
 La variable `page` contient les variables intégrées d'une page **et** celles définies dans le [avant-plan](2-Content.md#front-matter).
 
-| Variables | Descriptif | Exemple |
-| --------------------- | ------------------------------------------------------ | -------------------------- |
-| `page.id` | Identifiant unique.                                     | `blog/post-1` |
-| `page.title` | Nom du fichier (sans extension).                         | `Post 1` |
-| `page.date` | Date de création du fichier.                                    | _DateHeure_ |
-| `page.body` | Corps du fichier.                                             | _Marquage_ |
-| `page.content` | Corps du fichier converti en HTML.                           | _HTML_ |
-| `page.section` | Dossier racine du fichier (_slugified_).                        | `blog` |
-| `page.path` | Chemin du fichier (_slugified_).                               | `blog/post-1` |
-| `page.slug` | Nom du fichier (_slugified_).                               | `post-1` |
-| `page.filepath` | Chemin du système de fichiers.                                      | `Blog/Post 1.md` |
-| `page.type` | `homepage`, `page`, `section`, `vocabulary` ou `term`. | `page` |
-| `page.pages` | Collection de toutes les sous-pages.                           | _Collection_ |
-| `page.translations` | Collection de pages traduites.                        | _Collection_ |
+| Variables             | Descriptif                                                      | Exemple          |
+| --------------------- | --------------------------------------------------------------- | ---------------- |
+| `page.id`             | Identifiant unique.                                             | `blog/post-1`    |
+| `page.title`          | Nom du fichier (sans extension).                                | `Post 1`         |
+| `page.date`           | Date de création du fichier.                                    | _DateHeure_      |
+| `page.body`           | Corps du fichier.                                               | _Marquage_       |
+| `page.content`        | Corps du fichier converti en HTML.                              | _HTML_           |
+| `page.section`        | Dossier racine du fichier (_slugified_).                        | `blog`           |
+| `page.path`           | Chemin du fichier (_slugified_).                                | `blog/post-1`    |
+| `page.slug`           | Nom du fichier (_slugified_).                                   | `post-1`         |
+| `page.filepath`       | Chemin du système de fichiers.                                  | `Blog/Post 1.md` |
+| `page.type`           | `homepage`, `page`, `section`, `vocabulary` ou `term`.          | `page`           |
+| `page.pages`          | Collection de toutes les sous-pages.                            | _Collection_     |
+| `page.parent`         | Page de la _section_ parente (`null` si aucune).                | _Page_           |
+| `page.ancestors`      | Collection des _sections_ ancêtres (la plus proche en premier). | _Collection_     |
+| `page.sections`       | Collection des _sections_ descendantes immédiates.              | _Collection_     |
+| `page.toplevel`       | `true` si la page est une _section_ de premier niveau.          | _Boolean_        |
+| `page.translations`   | Collection de pages traduites.                                  | _Collection_     |
 
 :::important
 Utilisez la méthode `showable` sur la collection de pages pour renvoyer uniquement les pages publiées et non les pages _virtuelles/redirectes/exclues_.
@@ -315,6 +319,65 @@ _Exemple:_
 ```
 
 :::
+
+#### Sections imbriquées
+
+Dans un contexte de [sections imbriquées](2-Content.md#sub-section), les propriétés `page.parent`, `page.ancestors`, `page.sections` et `page.toplevel` facilitent la construction de la navigation.
+
+_Fil d'Ariane (de la page d'accueil à la page courante) :_
+
+```twig
+<nav aria-label="breadcrumb">
+  <ul>
+    <li><a href="{{ url(site.home) }}">{{ site.title }}</a></li>
+    {% for section in page.ancestors|reverse %}
+    <li><a href="{{ url(section) }}">{{ section.title }}</a></li>
+    {% endfor %}
+    {% if page.id != site.home %}
+    <li><a href="{{ url(page) }}" aria-current="page">{{ page.title }}</a></li>
+    {% endif %}
+  </ul>
+</nav>
+```
+
+:::tip
+Un partial [`breadcrumb.html.twig`](https://github.com/Cecilapp/Cecil/blob/master/resources/layouts/partials/breadcrumb.html.twig) prêt à l'emploi est disponible :
+
+```twig
+{{ include('partials/breadcrumb.html.twig') }}
+```
+
+:::
+
+_Menu des sous-sections (sections descendantes immédiates de la section courante) :_
+
+```twig
+{% if page.sections|length %}
+<ul>
+  {% for section in page.sections|sort_by_title %}
+  <li><a href="{{ url(section) }}">{{ section.title }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+```
+
+_Navigation principale limitée aux sections de premier niveau (depuis n'importe quelle page) :_
+
+```twig
+<nav>
+  {% for section in site.page(site.home).sections|sort_by_title %}
+  <a href="{{ url(section) }}">{{ section.title }}</a>
+  {% endfor %}
+</nav>
+```
+
+_Lien vers la section parente :_
+
+```twig
+{% if page.parent %}
+<a href="{{ url(page.parent) }}">← {{ page.parent.title }}</a>
+{% endif %}
+```
 
 #### page.<prev/next>
 

--- a/docs/3-Templates.md
+++ b/docs/3-Templates.md
@@ -1,7 +1,7 @@
 <!--
 description: "Working with layouts, templates and components."
 date: 2021-05-07
-updated: 2026-07-10
+updated: 2026-08-25
 alias: documentation/layouts
 -->
 # Templates
@@ -287,20 +287,24 @@ _Examples:_
 
 The `page` variable contains built-in variables of a page **and** those set in the [front matter](2-Content.md#front-matter).
 
-| Variable              | Description                                            | Example                    |
-| --------------------- | ------------------------------------------------------ | -------------------------- |
-| `page.id`             | Unique identifier.                                     | `blog/post-1`              |
-| `page.title`          | File name (without extension).                         | `Post 1`                   |
-| `page.date`           | File creation date.                                    | _DateTime_                 |
-| `page.body`           | File body.                                             | _Markdown_                 |
-| `page.content`        | File body converted in HTML.                           | _HTML_                     |
-| `page.section`        | File root folder (_slugified_).                        | `blog`                     |
-| `page.path`           | File path (_slugified_).                               | `blog/post-1`              |
-| `page.slug`           | File name (_slugified_).                               | `post-1`                   |
-| `page.filepath`       | File system path.                                      | `Blog/Post 1.md`           |
-| `page.type`           | `homepage`, `page`, `section`, `vocabulary` or `term`. | `page`                     |
-| `page.pages`          | Collection of all sub pages.                           | _Collection_               |
-| `page.translations`   | Collection of translated pages.                        | _Collection_               |
+| Variable              | Description                                            | Example          |
+| --------------------- | ------------------------------------------------------ | ---------------- |
+| `page.id`             | Unique identifier.                                     | `blog/post-1`    |
+| `page.title`          | File name (without extension).                         | `Post 1`         |
+| `page.date`           | File creation date.                                    | _DateTime_       |
+| `page.body`           | File body.                                             | _Markdown_       |
+| `page.content`        | File body converted in HTML.                           | _HTML_           |
+| `page.section`        | File root folder (_slugified_).                        | `blog`           |
+| `page.path`           | File path (_slugified_).                               | `blog/post-1`    |
+| `page.slug`           | File name (_slugified_).                               | `post-1`         |
+| `page.filepath`       | File system path.                                      | `Blog/Post 1.md` |
+| `page.type`           | `homepage`, `page`, `section`, `vocabulary` or `term`. | `page`           |
+| `page.pages`          | Collection of all sub pages.                           | _Collection_     |
+| `page.parent`         | Parent _section_'s page (`null` if none).              | _Page_           |
+| `page.ancestors`      | Collection of ancestor _sections_ (nearest first).     | _Collection_     |
+| `page.sections`       | Collection of immediate descendant _sections_.         | _Collection_     |
+| `page.toplevel`       | `true` if the page is a top level _section_.           | _Boolean_        |
+| `page.translations`   | Collection of translated pages.                        | _Collection_     |
 
 :::important
 Use `showable` method on pages collection to return only published and not _virtual/redirect/excluded_ pages.
@@ -314,6 +318,65 @@ _Example:_
 ```
 
 :::
+
+#### Nested sections
+
+In a [nested sections](2-Content.md#sub-section) context, `page.parent`, `page.ancestors`, `page.sections` and `page.toplevel` help you build navigation.
+
+_Breadcrumb (from the home page to the current page):_
+
+```twig
+<nav aria-label="breadcrumb">
+  <ul>
+    <li><a href="{{ url(site.home) }}">{{ site.title }}</a></li>
+    {% for section in page.ancestors|reverse %}
+    <li><a href="{{ url(section) }}">{{ section.title }}</a></li>
+    {% endfor %}
+    {% if page.id != site.home %}
+    <li><a href="{{ url(page) }}" aria-current="page">{{ page.title }}</a></li>
+    {% endif %}
+  </ul>
+</nav>
+```
+
+:::tip
+A ready-to-use [`breadcrumb.html.twig`](https://github.com/Cecilapp/Cecil/blob/master/resources/layouts/partials/breadcrumb.html.twig) partial is available:
+
+```twig
+{{ include('partials/breadcrumb.html.twig') }}
+```
+
+:::
+
+_Sub-sections menu (immediate descendant sections of the current section):_
+
+```twig
+{% if page.sections|length %}
+<ul>
+  {% for section in page.sections|sort_by_title %}
+  <li><a href="{{ url(section) }}">{{ section.title }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+```
+
+_Main navigation limited to top level sections (from any page):_
+
+```twig
+<nav>
+  {% for section in site.page(site.home).sections|sort_by_title %}
+  <a href="{{ url(section) }}">{{ section.title }}</a>
+  {% endfor %}
+</nav>
+```
+
+_Link to the parent section:_
+
+```twig
+{% if page.parent %}
+<a href="{{ url(page.parent) }}">← {{ page.parent.title }}</a>
+{% endif %}
+```
 
 #### page.<prev/next>
 

--- a/docs/api/classes/Cecil-Asset-Image.html
+++ b/docs/api/classes/Cecil-Asset-Image.html
@@ -169,7 +169,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">35</span>
+    <span class="phpdocumentor-element-found-in__line">37</span>
 
     </aside>
 
@@ -336,7 +336,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a class="" href="classes/Cecil-Asset-Image.html#method_manager">manager()</a>
     <span>
-                                &nbsp;: <abbr title="\Intervention\Image\ImageManager">ImageManager</abbr>    </span>
+                                &nbsp;: <abbr title="\Intervention\Image\Interfaces\ImageManagerInterface">ImageManagerInterface</abbr>    </span>
 </dt>
 <dd>Create new manager instance with available driver.</dd>
 
@@ -368,7 +368,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">242</span>
+    <span class="phpdocumentor-element-found-in__line">254</span>
 
     </aside>
 
@@ -424,7 +424,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">266</span>
+    <span class="phpdocumentor-element-found-in__line">278</span>
 
     </aside>
 
@@ -501,7 +501,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">383</span>
+    <span class="phpdocumentor-element-found-in__line">394</span>
 
     </aside>
 
@@ -564,7 +564,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">354</span>
+    <span class="phpdocumentor-element-found-in__line">365</span>
 
     </aside>
 
@@ -647,7 +647,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">397</span>
+    <span class="phpdocumentor-element-found-in__line">408</span>
 
     </aside>
 
@@ -730,7 +730,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">153</span>
+    <span class="phpdocumentor-element-found-in__line">159</span>
 
     </aside>
 
@@ -807,7 +807,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">212</span>
+    <span class="phpdocumentor-element-found-in__line">224</span>
 
     </aside>
 
@@ -870,7 +870,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">180</span>
+    <span class="phpdocumentor-element-found-in__line">188</span>
 
     </aside>
 
@@ -940,7 +940,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">196</span>
+    <span class="phpdocumentor-element-found-in__line">206</span>
 
     </aside>
 
@@ -1003,7 +1003,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">426</span>
+    <span class="phpdocumentor-element-found-in__line">437</span>
 
     </aside>
 
@@ -1059,7 +1059,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">228</span>
+    <span class="phpdocumentor-element-found-in__line">240</span>
 
     </aside>
 
@@ -1122,7 +1122,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">489</span>
+    <span class="phpdocumentor-element-found-in__line">500</span>
 
     </aside>
 
@@ -1171,7 +1171,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">445</span>
+    <span class="phpdocumentor-element-found-in__line">456</span>
 
     </aside>
 
@@ -1220,7 +1220,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">467</span>
+    <span class="phpdocumentor-element-found-in__line">478</span>
 
     </aside>
 
@@ -1269,7 +1269,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">475</span>
+    <span class="phpdocumentor-element-found-in__line">486</span>
 
     </aside>
 
@@ -1318,7 +1318,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">459</span>
+    <span class="phpdocumentor-element-found-in__line">470</span>
 
     </aside>
 
@@ -1367,7 +1367,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">119</span>
+    <span class="phpdocumentor-element-found-in__line">123</span>
 
     </aside>
 
@@ -1444,7 +1444,7 @@ It supports GD, Imagick and libvips drivers, depending on available extensions.<
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">78</span>
+    <span class="phpdocumentor-element-found-in__line">80</span>
 
     </aside>
 
@@ -1539,7 +1539,7 @@ The $rmAnimation parameter can be set to true to remove animations from animated
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Image.php"><a href="files/src-asset-image.html"><abbr title="src/Asset/Image.php">Image.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -1547,7 +1547,7 @@ The $rmAnimation parameter can be set to true to remove animations from animated
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">manager</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><abbr title="\Intervention\Image\ImageManager">ImageManager</abbr></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">manager</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><abbr title="\Intervention\Image\Interfaces\ImageManagerInterface">ImageManagerInterface</abbr></span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -1560,7 +1560,7 @@ The $rmAnimation parameter can be set to true to remove animations from animated
     
             <section>
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-        <span class="phpdocumentor-signature__response_type"><abbr title="\Intervention\Image\ImageManager">ImageManager</abbr></span>
+        <span class="phpdocumentor-signature__response_type"><abbr title="\Intervention\Image\Interfaces\ImageManagerInterface">ImageManagerInterface</abbr></span>
             </section>
 
 </article>

--- a/docs/api/classes/Cecil-Asset-Locator.html
+++ b/docs/api/classes/Cecil-Asset-Locator.html
@@ -169,7 +169,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">33</span>
+    <span class="phpdocumentor-element-found-in__line">32</span>
 
     </aside>
 
@@ -308,7 +308,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">36</span>
+    <span class="phpdocumentor-element-found-in__line">35</span>
 
     </aside>
 
@@ -345,7 +345,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">39</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
@@ -387,7 +387,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">41</span>
+    <span class="phpdocumentor-element-found-in__line">40</span>
 
     </aside>
 
@@ -431,7 +431,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">166</span>
+    <span class="phpdocumentor-element-found-in__line">165</span>
 
     </aside>
 
@@ -489,7 +489,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">119</span>
+    <span class="phpdocumentor-element-found-in__line">118</span>
 
     </aside>
 
@@ -540,7 +540,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">55</span>
+    <span class="phpdocumentor-element-found-in__line">54</span>
 
     </aside>
 
@@ -626,7 +626,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">136</span>
+    <span class="phpdocumentor-element-found-in__line">135</span>
 
     </aside>
 
@@ -675,7 +675,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">196</span>
+    <span class="phpdocumentor-element-found-in__line">195</span>
 
     </aside>
 
@@ -747,7 +747,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Asset/Locator.php"><a href="files/src-asset-locator.html"><abbr title="src/Asset/Locator.php">Locator.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">146</span>
+    <span class="phpdocumentor-element-found-in__line">145</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Cache.html
+++ b/docs/api/classes/Cecil-Cache.html
@@ -171,7 +171,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">27</span>
+    <span class="phpdocumentor-element-found-in__line">26</span>
 
     </aside>
 
@@ -412,7 +412,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">30</span>
+    <span class="phpdocumentor-element-found-in__line">29</span>
 
     </aside>
 
@@ -443,7 +443,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -489,7 +489,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -526,7 +526,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">37</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -568,7 +568,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">39</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
@@ -619,7 +619,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">143</span>
+    <span class="phpdocumentor-element-found-in__line">142</span>
 
     </aside>
 
@@ -658,7 +658,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">247</span>
+    <span class="phpdocumentor-element-found-in__line">246</span>
 
     </aside>
 
@@ -707,7 +707,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">191</span>
+    <span class="phpdocumentor-element-found-in__line">190</span>
 
     </aside>
 
@@ -792,7 +792,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">125</span>
+    <span class="phpdocumentor-element-found-in__line">124</span>
 
     </aside>
 
@@ -841,7 +841,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">175</span>
+    <span class="phpdocumentor-element-found-in__line">174</span>
 
     </aside>
 
@@ -890,7 +890,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">89</span>
+    <span class="phpdocumentor-element-found-in__line">88</span>
 
     </aside>
 
@@ -942,7 +942,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">279</span>
+    <span class="phpdocumentor-element-found-in__line">278</span>
 
     </aside>
 
@@ -991,7 +991,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">159</span>
+    <span class="phpdocumentor-element-found-in__line">158</span>
 
     </aside>
 
@@ -1047,7 +1047,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">76</span>
+    <span class="phpdocumentor-element-found-in__line">75</span>
 
     </aside>
 
@@ -1096,7 +1096,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -1159,7 +1159,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">167</span>
+    <span class="phpdocumentor-element-found-in__line">166</span>
 
     </aside>
 
@@ -1215,7 +1215,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">388</span>
 
     </aside>
 
@@ -1264,7 +1264,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">374</span>
+    <span class="phpdocumentor-element-found-in__line">373</span>
 
     </aside>
 
@@ -1313,7 +1313,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">289</span>
+    <span class="phpdocumentor-element-found-in__line">288</span>
 
     </aside>
 
@@ -1362,7 +1362,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">417</span>
+    <span class="phpdocumentor-element-found-in__line">416</span>
 
     </aside>
 
@@ -1407,7 +1407,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">319</span>
+    <span class="phpdocumentor-element-found-in__line">318</span>
 
     </aside>
 
@@ -1456,7 +1456,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">405</span>
+    <span class="phpdocumentor-element-found-in__line">404</span>
 
     </aside>
 
@@ -1501,7 +1501,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">356</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -1550,7 +1550,7 @@ The key is sanitized to remove reserved characters and ensure it is a valid file
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Cache.php"><a href="files/src-cache.html"><abbr title="src/Cache.php">Cache.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">301</span>
+    <span class="phpdocumentor-element-found-in__line">300</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Collection-Page-Page.html
+++ b/docs/api/classes/Cecil-Collection-Page-Page.html
@@ -173,7 +173,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">28</span>
+    <span class="phpdocumentor-element-found-in__line">27</span>
 
     </aside>
 
@@ -302,6 +302,12 @@ Provides methods to manage page properties, variables, and rendering.</p>
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/Cecil-Collection-Page-Page.html#property_sectionIndex">$sectionIndex</a>
+    <span>
+                        &nbsp;: bool            </span>
+</dt>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/Cecil-Collection-Page-Page.html#property_slug">$slug</a>
     <span>
                         &nbsp;: string            </span>
@@ -352,6 +358,13 @@ Provides methods to manage page properties, variables, and rendering.</p>
                                 &nbsp;: self    </span>
 </dt>
 <dd>Add rendered.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a class="" href="classes/Cecil-Collection-Page-Page.html#method_getAncestors">getAncestors()</a>
+    <span>
+                                &nbsp;: <a href="classes/Cecil-Collection-Page-Collection.html"><abbr title="\Cecil\Collection\Page\Collection">Collection</abbr></a>    </span>
+</dt>
+<dd>Returns the collection of the page&#039;s ancestor sections, from the nearest to the farthest.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a class="" href="classes/Cecil-Collection-Page-Page.html#method_getBody">getBody()</a>
@@ -444,6 +457,13 @@ Provides methods to manage page properties, variables, and rendering.</p>
 <dd>Get paginator.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a class="" href="classes/Cecil-Collection-Page-Page.html#method_getParent">getParent()</a>
+    <span>
+                                &nbsp;: self|null    </span>
+</dt>
+<dd>Returns the parent section&#039;s page (`null` if there is none).</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a class="" href="classes/Cecil-Collection-Page-Page.html#method_getPath">getPath()</a>
     <span>
                                 &nbsp;: string|null    </span>
@@ -469,6 +489,13 @@ Provides methods to manage page properties, variables, and rendering.</p>
                                 &nbsp;: string|null    </span>
 </dt>
 <dd>Get section.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a class="" href="classes/Cecil-Collection-Page-Page.html#method_getSections">getSections()</a>
+    <span>
+                                &nbsp;: <a href="classes/Cecil-Collection-Page-Collection.html"><abbr title="\Cecil\Collection\Page\Collection">Collection</abbr></a>    </span>
+</dt>
+<dd>Returns the collection of the page&#039;s immediate descendant sections.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a class="" href="classes/Cecil-Collection-Page-Page.html#method_getSlug">getSlug()</a>
@@ -511,6 +538,13 @@ Provides methods to manage page properties, variables, and rendering.</p>
                                 &nbsp;: bool    </span>
 </dt>
 <dd>Is variable exists?</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a class="" href="classes/Cecil-Collection-Page-Page.html#method_isSectionIndex">isSectionIndex()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Is the page a folder&#039;s index (created from an &quot;index.md&quot; file)?</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a class="" href="classes/Cecil-Collection-Page-Page.html#method_isVirtual">isVirtual()</a>
@@ -721,7 +755,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">30</span>
+    <span class="phpdocumentor-element-found-in__line">29</span>
 
     </aside>
 
@@ -767,7 +801,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">60</span>
+    <span class="phpdocumentor-element-found-in__line">62</span>
 
     </aside>
 
@@ -806,7 +840,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">36</span>
+    <span class="phpdocumentor-element-found-in__line">35</span>
 
     </aside>
 
@@ -843,7 +877,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">57</span>
+    <span class="phpdocumentor-element-found-in__line">59</span>
 
     </aside>
 
@@ -882,7 +916,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">42</span>
+    <span class="phpdocumentor-element-found-in__line">41</span>
 
     </aside>
 
@@ -919,7 +953,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">54</span>
+    <span class="phpdocumentor-element-found-in__line">56</span>
 
     </aside>
 
@@ -956,7 +990,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">63</span>
+    <span class="phpdocumentor-element-found-in__line">65</span>
 
     </aside>
 
@@ -1033,7 +1067,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">69</span>
+    <span class="phpdocumentor-element-found-in__line">71</span>
 
     </aside>
 
@@ -1072,7 +1106,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">72</span>
+    <span class="phpdocumentor-element-found-in__line">74</span>
 
     </aside>
 
@@ -1109,7 +1143,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -1186,7 +1220,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">66</span>
+    <span class="phpdocumentor-element-found-in__line">68</span>
 
     </aside>
 
@@ -1225,7 +1259,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">51</span>
+    <span class="phpdocumentor-element-found-in__line">50</span>
 
     </aside>
 
@@ -1252,6 +1286,45 @@ Provides methods to manage page properties, variables, and rendering.</p>
             -protected
                                                                     "
 >
+    <h4 class="phpdocumentor-element__name" id="property_sectionIndex">
+        $sectionIndex
+        <a href="classes/Cecil-Collection-Page-Page.html#property_sectionIndex" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                            </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">53</span>
+
+    </aside>
+
+    
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">protected</span>
+            <span class="phpdocumentor-signature__type">bool</span>
+    <span class="phpdocumentor-signature__name">$sectionIndex</span>
+     = <span class="phpdocumentor-signature__default-value">false</span></code>
+
+    
+        <section class="phpdocumentor-description"><p>True if page is a folder's index (created from an &quot;index.md&quot; file).</p>
+</section>
+
+    
+
+        
+        
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+                                                                    "
+>
     <h4 class="phpdocumentor-element__name" id="property_slug">
         $slug
         <a href="classes/Cecil-Collection-Page-Page.html#property_slug" class="headerlink"><i class="fas fa-link"></i></a>
@@ -1262,7 +1335,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">45</span>
+    <span class="phpdocumentor-element-found-in__line">44</span>
 
     </aside>
 
@@ -1299,7 +1372,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">75</span>
+    <span class="phpdocumentor-element-found-in__line">77</span>
 
     </aside>
 
@@ -1338,7 +1411,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">39</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
@@ -1377,7 +1450,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">33</span>
+    <span class="phpdocumentor-element-found-in__line">32</span>
 
     </aside>
 
@@ -1421,7 +1494,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">80</span>
+    <span class="phpdocumentor-element-found-in__line">82</span>
 
     </aside>
 
@@ -1474,7 +1547,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">119</span>
+    <span class="phpdocumentor-element-found-in__line">121</span>
 
     </aside>
 
@@ -1513,7 +1586,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">455</span>
+    <span class="phpdocumentor-element-found-in__line">506</span>
 
     </aside>
 
@@ -1554,6 +1627,45 @@ Provides methods to manage page properties, variables, and rendering.</p>
             -public
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_getAncestors">
+        getAncestors()
+        <a href="classes/Cecil-Collection-Page-Page.html#method_getAncestors" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">450</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Returns the collection of the page&#039;s ancestor sections, from the nearest to the farthest.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">getAncestors</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Collection-Page-Collection.html"><abbr title="\Cecil\Collection\Page\Collection">Collection</abbr></a></span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+    
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Collection-Page-Collection.html"><abbr title="\Cecil\Collection\Page\Collection">Collection</abbr></a></span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_getBody">
         getBody()
         <a href="classes/Cecil-Collection-Page-Page.html#method_getBody" class="headerlink"><i class="fas fa-link"></i></a>
@@ -1562,7 +1674,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">258</span>
+    <span class="phpdocumentor-element-found-in__line">261</span>
 
     </aside>
 
@@ -1601,7 +1713,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">439</span>
+    <span class="phpdocumentor-element-found-in__line">490</span>
 
     </aside>
 
@@ -1640,7 +1752,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">447</span>
+    <span class="phpdocumentor-element-found-in__line">498</span>
 
     </aside>
 
@@ -1692,7 +1804,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">213</span>
+    <span class="phpdocumentor-element-found-in__line">216</span>
 
     </aside>
 
@@ -1731,7 +1843,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">225</span>
+    <span class="phpdocumentor-element-found-in__line">228</span>
 
     </aside>
 
@@ -1770,7 +1882,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">672</span>
+    <span class="phpdocumentor-element-found-in__line">723</span>
 
     </aside>
 
@@ -1809,7 +1921,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">312</span>
+    <span class="phpdocumentor-element-found-in__line">315</span>
 
     </aside>
 
@@ -1848,7 +1960,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">250</span>
+    <span class="phpdocumentor-element-found-in__line">253</span>
 
     </aside>
 
@@ -1926,7 +2038,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">140</span>
+    <span class="phpdocumentor-element-found-in__line">139</span>
 
     </aside>
 
@@ -1965,7 +2077,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">483</span>
+    <span class="phpdocumentor-element-found-in__line">534</span>
 
     </aside>
 
@@ -2004,7 +2116,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">509</span>
+    <span class="phpdocumentor-element-found-in__line">560</span>
 
     </aside>
 
@@ -2043,7 +2155,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">501</span>
+    <span class="phpdocumentor-element-found-in__line">552</span>
 
     </aside>
 
@@ -2074,6 +2186,45 @@ Provides methods to manage page properties, variables, and rendering.</p>
             -public
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_getParent">
+        getParent()
+        <a href="classes/Cecil-Collection-Page-Page.html#method_getParent" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">440</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Returns the parent section&#039;s page (`null` if there is none).</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">getParent</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">self|null</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+    
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">self|null</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_getPath">
         getPath()
         <a href="classes/Cecil-Collection-Page-Page.html#method_getPath" class="headerlink"><i class="fas fa-link"></i></a>
@@ -2082,7 +2233,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">385</span>
+    <span class="phpdocumentor-element-found-in__line">388</span>
 
     </aside>
 
@@ -2121,7 +2272,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">393</span>
+    <span class="phpdocumentor-element-found-in__line">396</span>
 
     </aside>
 
@@ -2173,7 +2324,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">465</span>
+    <span class="phpdocumentor-element-found-in__line">516</span>
 
     </aside>
 
@@ -2212,7 +2363,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">411</span>
+    <span class="phpdocumentor-element-found-in__line">414</span>
 
     </aside>
 
@@ -2243,6 +2394,45 @@ Provides methods to manage page properties, variables, and rendering.</p>
             -public
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_getSections">
+        getSections()
+        <a href="classes/Cecil-Collection-Page-Page.html#method_getSections" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">470</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Returns the collection of the page&#039;s immediate descendant sections.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">getSections</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Collection-Page-Collection.html"><abbr title="\Cecil\Collection\Page\Collection">Collection</abbr></a></span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+    
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type"><a href="classes/Cecil-Collection-Page-Collection.html"><abbr title="\Cecil\Collection\Page\Collection">Collection</abbr></a></span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_getSlug">
         getSlug()
         <a href="classes/Cecil-Collection-Page-Page.html#method_getSlug" class="headerlink"><i class="fas fa-link"></i></a>
@@ -2251,7 +2441,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">337</span>
+    <span class="phpdocumentor-element-found-in__line">340</span>
 
     </aside>
 
@@ -2290,7 +2480,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">527</span>
+    <span class="phpdocumentor-element-found-in__line">578</span>
 
     </aside>
 
@@ -2329,7 +2519,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">294</span>
+    <span class="phpdocumentor-element-found-in__line">297</span>
 
     </aside>
 
@@ -2368,7 +2558,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">636</span>
+    <span class="phpdocumentor-element-found-in__line">687</span>
 
     </aside>
 
@@ -2428,7 +2618,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">553</span>
+    <span class="phpdocumentor-element-found-in__line">604</span>
 
     </aside>
 
@@ -2467,7 +2657,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">623</span>
+    <span class="phpdocumentor-element-found-in__line">674</span>
 
     </aside>
 
@@ -2510,6 +2700,45 @@ Provides methods to manage page properties, variables, and rendering.</p>
             -public
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_isSectionIndex">
+        isSectionIndex()
+        <a href="classes/Cecil-Collection-Page-Page.html#method_isSectionIndex" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">432</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Is the page a folder&#039;s index (created from an &quot;index.md&quot; file)?</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">isSectionIndex</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+    
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">bool</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_isVirtual">
         isVirtual()
         <a href="classes/Cecil-Collection-Page-Page.html#method_isVirtual" class="headerlink"><i class="fas fa-link"></i></a>
@@ -2518,7 +2747,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">276</span>
+    <span class="phpdocumentor-element-found-in__line">279</span>
 
     </aside>
 
@@ -2796,7 +3025,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">237</span>
+    <span class="phpdocumentor-element-found-in__line">240</span>
 
     </aside>
 
@@ -2835,7 +3064,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">429</span>
+    <span class="phpdocumentor-element-found-in__line">480</span>
 
     </aside>
 
@@ -2884,7 +3113,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">155</span>
+    <span class="phpdocumentor-element-found-in__line">154</span>
 
     </aside>
 
@@ -2942,7 +3171,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">662</span>
+    <span class="phpdocumentor-element-found-in__line">713</span>
 
     </aside>
 
@@ -2991,7 +3220,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">302</span>
+    <span class="phpdocumentor-element-found-in__line">305</span>
 
     </aside>
 
@@ -3040,7 +3269,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">109</span>
+    <span class="phpdocumentor-element-found-in__line">111</span>
 
     </aside>
 
@@ -3089,7 +3318,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">473</span>
+    <span class="phpdocumentor-element-found-in__line">524</span>
 
     </aside>
 
@@ -3138,7 +3367,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">491</span>
+    <span class="phpdocumentor-element-found-in__line">542</span>
 
     </aside>
 
@@ -3187,7 +3416,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">345</span>
+    <span class="phpdocumentor-element-found-in__line">348</span>
 
     </aside>
 
@@ -3236,7 +3465,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">401</span>
+    <span class="phpdocumentor-element-found-in__line">404</span>
 
     </aside>
 
@@ -3285,7 +3514,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">320</span>
+    <span class="phpdocumentor-element-found-in__line">323</span>
 
     </aside>
 
@@ -3334,7 +3563,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">517</span>
+    <span class="phpdocumentor-element-found-in__line">568</span>
 
     </aside>
 
@@ -3383,7 +3612,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">284</span>
+    <span class="phpdocumentor-element-found-in__line">287</span>
 
     </aside>
 
@@ -3432,7 +3661,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">566</span>
+    <span class="phpdocumentor-element-found-in__line">617</span>
 
     </aside>
 
@@ -3506,7 +3735,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">541</span>
+    <span class="phpdocumentor-element-found-in__line">592</span>
 
     </aside>
 
@@ -3569,7 +3798,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">266</span>
+    <span class="phpdocumentor-element-found-in__line">269</span>
 
     </aside>
 
@@ -3618,7 +3847,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">132</span>
+    <span class="phpdocumentor-element-found-in__line">131</span>
 
     </aside>
 
@@ -3713,7 +3942,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">419</span>
+    <span class="phpdocumentor-element-found-in__line">422</span>
 
     </aside>
 
@@ -3752,7 +3981,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">650</span>
+    <span class="phpdocumentor-element-found-in__line">701</span>
 
     </aside>
 
@@ -3803,7 +4032,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">683</span>
+    <span class="phpdocumentor-element-found-in__line">734</span>
 
     </aside>
 
@@ -3860,7 +4089,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Collection/Page/Page.php"><a href="files/src-collection-page-page.html"><abbr title="src/Collection/Page/Page.php">Page.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">715</span>
+    <span class="phpdocumentor-element-found-in__line">766</span>
 
     </aside>
 
@@ -3953,6 +4182,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
                                                     <li class=""><a href="classes/Cecil-Collection-Item.html#property_properties">$properties</a></li>
                                                     <li class=""><a href="classes/Cecil-Collection-Page-Page.html#property_rendered">$rendered</a></li>
                                                     <li class=""><a href="classes/Cecil-Collection-Page-Page.html#property_section">$section</a></li>
+                                                    <li class=""><a href="classes/Cecil-Collection-Page-Page.html#property_sectionIndex">$sectionIndex</a></li>
                                                     <li class=""><a href="classes/Cecil-Collection-Page-Page.html#property_slug">$slug</a></li>
                                                     <li class=""><a href="classes/Cecil-Collection-Page-Page.html#property_terms">$terms</a></li>
                                                     <li class=""><a href="classes/Cecil-Collection-Page-Page.html#property_type">$type</a></li>
@@ -3966,6 +4196,7 @@ Provides methods to manage page properties, variables, and rendering.</p>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method___construct">__construct()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method___toString">__toString()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_addRendered">addRendered()</a></li>
+                                            <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getAncestors">getAncestors()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getBody">getBody()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getBodyHtml">getBodyHtml()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getContent">getContent()</a></li>
@@ -3979,16 +4210,19 @@ Provides methods to manage page properties, variables, and rendering.</p>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getPages">getPages()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getPagination">getPagination()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getPaginator">getPaginator()</a></li>
+                                            <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getParent">getParent()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getPath">getPath()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getPathname">getPathname()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getRendered">getRendered()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getSection">getSection()</a></li>
+                                            <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getSections">getSections()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getSlug">getSlug()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getTerms">getTerms()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getType">getType()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getVariable">getVariable()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_getVariables">getVariables()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_hasVariable">hasVariable()</a></li>
+                                            <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_isSectionIndex">isSectionIndex()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Page-Page.html#method_isVirtual">isVirtual()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Item.html#method_offsetExists">offsetExists()</a></li>
                                             <li class=""><a href="classes/Cecil-Collection-Item.html#method_offsetGet">offsetGet()</a></li>

--- a/docs/api/classes/Cecil-Generator-Alias.html
+++ b/docs/api/classes/Cecil-Generator-Alias.html
@@ -175,7 +175,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Alias.php"><a href="files/src-generator-alias.html"><abbr title="src/Generator/Alias.php">Alias.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">24</span>
+    <span class="phpdocumentor-element-found-in__line">25</span>
 
     </aside>
 
@@ -462,7 +462,7 @@ Each alias will redirect to the original page.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Alias.php"><a href="files/src-generator-alias.html"><abbr title="src/Generator/Alias.php">Alias.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">29</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -536,7 +536,7 @@ Each alias will redirect to the original page.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Alias.php"><a href="files/src-generator-alias.html"><abbr title="src/Generator/Alias.php">Alias.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">61</span>
+    <span class="phpdocumentor-element-found-in__line">62</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Generator-Pagination.html
+++ b/docs/api/classes/Cecil-Generator-Pagination.html
@@ -175,7 +175,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Pagination.php"><a href="files/src-generator-pagination.html"><abbr title="src/Generator/Pagination.php">Pagination.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">27</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
@@ -456,7 +456,7 @@ and generates paginated pages accordingly.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Pagination.php"><a href="files/src-generator-pagination.html"><abbr title="src/Generator/Pagination.php">Pagination.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">32</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Generator-Section.html
+++ b/docs/api/classes/Cecil-Generator-Section.html
@@ -175,7 +175,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Section.php"><a href="files/src-generator-section.html"><abbr title="src/Generator/Section.php">Section.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">30</span>
+    <span class="phpdocumentor-element-found-in__line">35</span>
 
     </aside>
 
@@ -187,6 +187,10 @@ It identifies sections based on the 'section' variable in each page, and
 creates a new page for each section. The generated pages are added to the
 collection of generated pages. It also handles sorting of subpages and
 adding navigation links (next and previous) to the section pages.</p>
+<p>It also supports sub-sections: any nested folder that explicitly contains an
+&quot;index.md&quot; file becomes its own (sub-)section. Pages located in a sub-section
+belong to both their top level section and each of their ancestor sub-sections,
+while a sub-section index page itself is not listed in its parent section.</p>
 </section>
 
 
@@ -465,7 +469,7 @@ adding navigation links (next and previous) to the section pages.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Section.php"><a href="files/src-generator-section.html"><abbr title="src/Generator/Section.php">Section.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">35</span>
+    <span class="phpdocumentor-element-found-in__line">40</span>
 
     </aside>
 
@@ -539,7 +543,7 @@ adding navigation links (next and previous) to the section pages.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Section.php"><a href="files/src-generator-section.html"><abbr title="src/Generator/Section.php">Section.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">122</span>
+    <span class="phpdocumentor-element-found-in__line">182</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Generator-Taxonomy.html
+++ b/docs/api/classes/Cecil-Generator-Taxonomy.html
@@ -175,7 +175,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Taxonomy.php"><a href="files/src-generator-taxonomy.html"><abbr title="src/Generator/Taxonomy.php">Taxonomy.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">29</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -458,7 +458,7 @@ forms of the vocabulary.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Taxonomy.php"><a href="files/src-generator-taxonomy.html"><abbr title="src/Generator/Taxonomy.php">Taxonomy.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">35</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Generator-VirtualPages.html
+++ b/docs/api/classes/Cecil-Generator-VirtualPages.html
@@ -175,7 +175,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/VirtualPages.php"><a href="files/src-generator-virtualpages.html"><abbr title="src/Generator/VirtualPages.php">VirtualPages.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">33</span>
+    <span class="phpdocumentor-element-found-in__line">34</span>
 
     </aside>
 
@@ -388,7 +388,7 @@ The generated pages are added to the collection of generated pages for further p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/VirtualPages.php"><a href="files/src-generator-virtualpages.html"><abbr title="src/Generator/VirtualPages.php">VirtualPages.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">35</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -512,7 +512,7 @@ The generated pages are added to the collection of generated pages for further p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/VirtualPages.php"><a href="files/src-generator-virtualpages.html"><abbr title="src/Generator/VirtualPages.php">VirtualPages.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">41</span>
 
     </aside>
 
@@ -586,7 +586,7 @@ The generated pages are added to the collection of generated pages for further p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/VirtualPages.php"><a href="files/src-generator-virtualpages.html"><abbr title="src/Generator/VirtualPages.php">VirtualPages.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">83</span>
+    <span class="phpdocumentor-element-found-in__line">84</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Renderer-PostProcessor-MarkdownLink.html
+++ b/docs/api/classes/Cecil-Renderer-PostProcessor-MarkdownLink.html
@@ -173,7 +173,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Renderer/PostProcessor/MarkdownLink.php"><a href="files/src-renderer-postprocessor-markdownlink.html"><abbr title="src/Renderer/PostProcessor/MarkdownLink.php">MarkdownLink.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">26</span>
+    <span class="phpdocumentor-element-found-in__line">27</span>
 
     </aside>
 
@@ -397,7 +397,7 @@ It handles links that may include a section anchor and adjusts the href attribut
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Renderer/PostProcessor/MarkdownLink.php"><a href="files/src-renderer-postprocessor-markdownlink.html"><abbr title="src/Renderer/PostProcessor/MarkdownLink.php">MarkdownLink.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">33</span>
+    <span class="phpdocumentor-element-found-in__line">34</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-AbstractStep.html
+++ b/docs/api/classes/Cecil-Step-AbstractStep.html
@@ -174,7 +174,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">28</span>
+    <span class="phpdocumentor-element-found-in__line">27</span>
 
     </aside>
 
@@ -310,7 +310,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -347,7 +347,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -384,7 +384,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -421,7 +421,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -464,7 +464,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -509,7 +509,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 
@@ -550,7 +550,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">57</span>
+    <span class="phpdocumentor-element-found-in__line">56</span>
 
     </aside>
 
@@ -596,7 +596,7 @@ the step with necessary options and to determine if it can be executed.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">76</span>
+    <span class="phpdocumentor-element-found-in__line">75</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Assets-Save.html
+++ b/docs/api/classes/Cecil-Step-Assets-Save.html
@@ -323,7 +323,7 @@ Note: a file from `static/` with the same name will NOT be overridden.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -397,7 +397,7 @@ Note: a file from `static/` with the same name will NOT be overridden.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -434,7 +434,7 @@ Note: a file from `static/` with the same name will NOT be overridden.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -471,7 +471,7 @@ Note: a file from `static/` with the same name will NOT be overridden.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -514,7 +514,7 @@ Note: a file from `static/` with the same name will NOT be overridden.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -559,7 +559,7 @@ Note: a file from `static/` with the same name will NOT be overridden.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Data-Load.html
+++ b/docs/api/classes/Cecil-Step-Data-Load.html
@@ -317,7 +317,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -354,7 +354,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -391,7 +391,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -428,7 +428,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -471,7 +471,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -516,7 +516,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Menus-Create.html
+++ b/docs/api/classes/Cecil-Step-Menus-Create.html
@@ -324,7 +324,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -361,7 +361,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -398,7 +398,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -472,7 +472,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -515,7 +515,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -560,7 +560,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 
@@ -640,7 +640,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">57</span>
+    <span class="phpdocumentor-element-found-in__line">56</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Optimize-AbstractOptimize.html
+++ b/docs/api/classes/Cecil-Step-Optimize-AbstractOptimize.html
@@ -343,7 +343,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -380,7 +380,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -417,7 +417,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -454,7 +454,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -575,7 +575,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -620,7 +620,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Optimize-Css.html
+++ b/docs/api/classes/Cecil-Step-Optimize-Css.html
@@ -349,7 +349,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -386,7 +386,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -423,7 +423,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -460,7 +460,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -581,7 +581,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -626,7 +626,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Optimize-Html.html
+++ b/docs/api/classes/Cecil-Step-Optimize-Html.html
@@ -350,7 +350,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -387,7 +387,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -424,7 +424,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -461,7 +461,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -582,7 +582,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -627,7 +627,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Optimize-Images.html
+++ b/docs/api/classes/Cecil-Step-Optimize-Images.html
@@ -349,7 +349,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -386,7 +386,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -423,7 +423,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -460,7 +460,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -581,7 +581,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -626,7 +626,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Optimize-Js.html
+++ b/docs/api/classes/Cecil-Step-Optimize-Js.html
@@ -349,7 +349,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -386,7 +386,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -423,7 +423,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -460,7 +460,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -581,7 +581,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -626,7 +626,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Pages-Convert.html
+++ b/docs/api/classes/Cecil-Step-Pages-Convert.html
@@ -318,7 +318,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -355,7 +355,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -392,7 +392,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -429,7 +429,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -472,7 +472,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -517,7 +517,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Pages-Create.html
+++ b/docs/api/classes/Cecil-Step-Pages-Create.html
@@ -173,7 +173,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Pages/Create.php"><a href="files/src-step-pages-create.html"><abbr title="src/Step/Pages/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">30</span>
+    <span class="phpdocumentor-element-found-in__line">31</span>
 
     </aside>
 
@@ -311,7 +311,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -348,7 +348,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -385,7 +385,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -422,7 +422,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -465,7 +465,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -510,7 +510,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 
@@ -551,7 +551,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Pages/Create.php"><a href="files/src-step-pages-create.html"><abbr title="src/Step/Pages/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">35</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -590,7 +590,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Pages/Create.php"><a href="files/src-step-pages-create.html"><abbr title="src/Step/Pages/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">44</span>
 
     </aside>
 
@@ -636,7 +636,7 @@ the step with necessary options and to determine if it can be executed.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Pages/Create.php"><a href="files/src-step-pages-create.html"><abbr title="src/Step/Pages/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">55</span>
+    <span class="phpdocumentor-element-found-in__line">56</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Pages-Generate.html
+++ b/docs/api/classes/Cecil-Step-Pages-Generate.html
@@ -308,7 +308,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -345,7 +345,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -382,7 +382,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -419,7 +419,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -462,7 +462,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -507,7 +507,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Pages-Load.html
+++ b/docs/api/classes/Cecil-Step-Pages-Load.html
@@ -316,7 +316,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -353,7 +353,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -390,7 +390,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -427,7 +427,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -507,7 +507,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -552,7 +552,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Pages-Render.html
+++ b/docs/api/classes/Cecil-Step-Pages-Render.html
@@ -372,7 +372,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -409,7 +409,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -446,7 +446,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -483,7 +483,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -564,7 +564,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -609,7 +609,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Pages-Save.html
+++ b/docs/api/classes/Cecil-Step-Pages-Save.html
@@ -318,7 +318,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -355,7 +355,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -392,7 +392,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -429,7 +429,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -472,7 +472,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -517,7 +517,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-StaticFiles-Copy.html
+++ b/docs/api/classes/Cecil-Step-StaticFiles-Copy.html
@@ -324,7 +324,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -361,7 +361,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -398,7 +398,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -472,7 +472,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -515,7 +515,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -560,7 +560,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-StaticFiles-Load.html
+++ b/docs/api/classes/Cecil-Step-StaticFiles-Load.html
@@ -312,7 +312,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -349,7 +349,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -386,7 +386,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -423,7 +423,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -466,7 +466,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -511,7 +511,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Step-Taxonomies-Create.html
+++ b/docs/api/classes/Cecil-Step-Taxonomies-Create.html
@@ -173,7 +173,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">32</span>
 
     </aside>
 
@@ -336,7 +336,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -373,7 +373,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 
@@ -410,7 +410,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 
@@ -447,7 +447,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -485,7 +485,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">35</span>
 
     </aside>
 
@@ -527,7 +527,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -572,7 +572,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/AbstractStep.php"><a href="files/src-step-abstractstep.html"><abbr title="src/Step/AbstractStep.php">AbstractStep.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 
@@ -613,7 +613,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">39</span>
+    <span class="phpdocumentor-element-found-in__line">40</span>
 
     </aside>
 
@@ -652,7 +652,7 @@ the step with necessary options and to determine if it can be executed.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">47</span>
+    <span class="phpdocumentor-element-found-in__line">48</span>
 
     </aside>
 
@@ -698,7 +698,7 @@ the step with necessary options and to determine if it can be executed.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">57</span>
+    <span class="phpdocumentor-element-found-in__line">58</span>
 
     </aside>
 
@@ -733,7 +733,7 @@ the step with necessary options and to determine if it can be executed.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">98</span>
+    <span class="phpdocumentor-element-found-in__line">99</span>
 
     </aside>
 
@@ -768,7 +768,7 @@ the step with necessary options and to determine if it can be executed.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">72</span>
+    <span class="phpdocumentor-element-found-in__line">73</span>
 
     </aside>
 
@@ -803,7 +803,7 @@ the step with necessary options and to determine if it can be executed.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Step/Taxonomies/Create.php"><a href="files/src-step-taxonomies-create.html"><abbr title="src/Step/Taxonomies/Create.php">Create.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">149</span>
+    <span class="phpdocumentor-element-found-in__line">151</span>
 
     </aside>
 

--- a/docs/api/classes/Cecil-Util.html
+++ b/docs/api/classes/Cecil-Util.html
@@ -309,7 +309,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">186</span>
+    <span class="phpdocumentor-element-found-in__line">191</span>
 
     </aside>
 
@@ -361,7 +361,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">112</span>
+    <span class="phpdocumentor-element-found-in__line">117</span>
 
     </aside>
 
@@ -410,7 +410,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">99</span>
+    <span class="phpdocumentor-element-found-in__line">104</span>
 
     </aside>
 
@@ -459,7 +459,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">124</span>
+    <span class="phpdocumentor-element-found-in__line">129</span>
 
     </aside>
 
@@ -508,7 +508,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -521,9 +521,7 @@ joining paths, converting memory sizes, and more.</p>
     <div class="phpdocumentor-label-line">
         </div>
     
-        <section class="phpdocumentor-description"><p>ie: &quot;Cecil\Step\OptimizeHtml&quot; become &quot;OptimizeHtml&quot;</p>
-</section>
-
+    
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
@@ -538,7 +536,13 @@ joining paths, converting memory sizes, and more.</p>
                 : <span class="phpdocumentor-argument-list__argument__type">array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-argument-list__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                
+                    <section class="phpdocumentor-description"><p>Options for formatting. Supported options:</p>
+<ul>
+<li>'lowercase' (bool): Whether to convert the class name to lowercase. Default is false.</li>
+</ul>
+<p>ie: &quot;Cecil\Step\OptimizeHtml&quot; become &quot;OptimizeHtml&quot;</p>
+</section>
+
             </dd>
             </dl>
 
@@ -566,7 +570,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">54</span>
+    <span class="phpdocumentor-element-found-in__line">59</span>
 
     </aside>
 
@@ -617,7 +621,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">134</span>
+    <span class="phpdocumentor-element-found-in__line">139</span>
 
     </aside>
 
@@ -656,7 +660,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">81</span>
+    <span class="phpdocumentor-element-found-in__line">86</span>
 
     </aside>
 
@@ -705,7 +709,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">64</span>
+    <span class="phpdocumentor-element-found-in__line">69</span>
 
     </aside>
 
@@ -754,7 +758,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">213</span>
+    <span class="phpdocumentor-element-found-in__line">218</span>
 
     </aside>
 
@@ -811,7 +815,7 @@ joining paths, converting memory sizes, and more.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Util.php"><a href="files/src-util.html"><abbr title="src/Util.php">Util.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">174</span>
+    <span class="phpdocumentor-element-found-in__line">179</span>
 
     </aside>
 

--- a/docs/api/js/searchIndex.js
+++ b/docs/api/js/searchIndex.js
@@ -1576,6 +1576,26 @@ Search.appendIndex(
             "summary": "Unset\u0020section.",
             "url": "classes/Cecil-Collection-Page-Page.html#method_unSection"
         },                {
+            "fqsen": "\\Cecil\\Collection\\Page\\Page\u003A\u003AisSectionIndex\u0028\u0029",
+            "name": "isSectionIndex",
+            "summary": "Is\u0020the\u0020page\u0020a\u0020folder\u0027s\u0020index\u0020\u0028created\u0020from\u0020an\u0020\u0022index.md\u0022\u0020file\u0029\u003F",
+            "url": "classes/Cecil-Collection-Page-Page.html#method_isSectionIndex"
+        },                {
+            "fqsen": "\\Cecil\\Collection\\Page\\Page\u003A\u003AgetParent\u0028\u0029",
+            "name": "getParent",
+            "summary": "Returns\u0020the\u0020parent\u0020section\u0027s\u0020page\u0020\u0028\u0060null\u0060\u0020if\u0020there\u0020is\u0020none\u0029.",
+            "url": "classes/Cecil-Collection-Page-Page.html#method_getParent"
+        },                {
+            "fqsen": "\\Cecil\\Collection\\Page\\Page\u003A\u003AgetAncestors\u0028\u0029",
+            "name": "getAncestors",
+            "summary": "Returns\u0020the\u0020collection\u0020of\u0020the\u0020page\u0027s\u0020ancestor\u0020sections,\u0020from\u0020the\u0020nearest\u0020to\u0020the\u0020farthest.",
+            "url": "classes/Cecil-Collection-Page-Page.html#method_getAncestors"
+        },                {
+            "fqsen": "\\Cecil\\Collection\\Page\\Page\u003A\u003AgetSections\u0028\u0029",
+            "name": "getSections",
+            "summary": "Returns\u0020the\u0020collection\u0020of\u0020the\u0020page\u0027s\u0020immediate\u0020descendant\u0020sections.",
+            "url": "classes/Cecil-Collection-Page-Page.html#method_getSections"
+        },                {
             "fqsen": "\\Cecil\\Collection\\Page\\Page\u003A\u003AsetBodyHtml\u0028\u0029",
             "name": "setBodyHtml",
             "summary": "Set\u0020body\u0020as\u0020HTML.",
@@ -1725,6 +1745,11 @@ Search.appendIndex(
             "name": "section",
             "summary": "",
             "url": "classes/Cecil-Collection-Page-Page.html#property_section"
+        },                {
+            "fqsen": "\\Cecil\\Collection\\Page\\Page\u003A\u003A\u0024sectionIndex",
+            "name": "sectionIndex",
+            "summary": "",
+            "url": "classes/Cecil-Collection-Page-Page.html#property_sectionIndex"
         },                {
             "fqsen": "\\Cecil\\Collection\\Page\\Page\u003A\u003A\u0024frontmatter",
             "name": "frontmatter",

--- a/docs/api/reports/deprecated.html
+++ b/docs/api/reports/deprecated.html
@@ -195,7 +195,7 @@
                         <th class="phpdocumentor-heading">Reason</th>
                     </tr>
                                                                         <tr>
-                                <td class="phpdocumentor-cell">132</td>
+                                <td class="phpdocumentor-cell">131</td>
                                 <td class="phpdocumentor-cell"><a href="classes/Cecil-Collection-Page-Page.html#method_slugify"><abbr title="\Cecil\Collection\Page\Page::slugify()">Page::slugify()</abbr></a></td>
                                 <td class="phpdocumentor-cell"><p>Use Slugifier::slugify() instead.</p>
 </td>

--- a/resources/layouts/_default/page.html.twig
+++ b/resources/layouts/_default/page.html.twig
@@ -29,13 +29,12 @@
       }
       body>header {
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         justify-content: space-between;
         flex-direction: column;
       }
       @media (width >= 48rem) {
         body>header {
-          align-items: center;
           flex-direction: row;
           align-items: flex-start;
           gap: calc(var(--pico-spacing) * 1);

--- a/resources/layouts/_default/page.html.twig
+++ b/resources/layouts/_default/page.html.twig
@@ -13,10 +13,12 @@
     <style>{% apply minify_css ~%}
       {{- include('partials/pico.css.twig') ~}}
       /* Pico CSS overrides */
-      body > header,
-      body > main,
-      body > footer {
-        max-width: 700px;
+      @media (min-width: 1024px) {
+        body > header,
+        body > main,
+        body > footer {
+          max-width: 768px;
+        }
       }
       nav, nav ul {
         display: flex;
@@ -24,6 +26,20 @@
       }
       img {
         margin-bottom: calc(var(--pico-spacing) / 2);
+      }
+      body>header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        flex-direction: column;
+      }
+      @media (width >= 48rem) {
+        body>header {
+          align-items: center;
+          flex-direction: row;
+          align-items: flex-start;
+          gap: calc(var(--pico-spacing) * 1);
+        }
       }
       .site-title {
         --pico-font-weight: 700;
@@ -123,12 +139,13 @@
         <div class="site-title">{{ site.title }}</div>
         {%- endif ~%}
         <p>{{ site.baseline }}</p>
-        {{- include('partials/theme-selector.html.twig', {}, with_context = false) ~}}
       </hgroup>
       {{- include('partials/navigation.html.twig', {menu: site.menus.main}, with_context = false) ~}}
+      {{- include('partials/theme-selector.html.twig', {}, with_context = false) ~}}
       {%- endblock header ~%}
     </header>
     <main>
+      {{- include('partials/breadcrumb.html.twig') ~}}
       {%- block content ~%}
       {{- page.content ~}}
       {%- endblock content ~%}

--- a/resources/layouts/partials/breadcrumb.html.twig
+++ b/resources/layouts/partials/breadcrumb.html.twig
@@ -1,0 +1,14 @@
+{#- breadcrumb navigation ~#}
+{% if page.type != 'homepage' %}
+<nav aria-label="breadcrumb">
+  <ul>
+    <li><a href="{{ url(site.home) }}">{% trans %}Home{% endtrans %}</a></li>
+    {%- for section in page.ancestors|reverse ~%}
+    <li><a href="{{ url(section) }}">{{ section.title }}</a></li>
+    {%- endfor ~%}
+    {%- if page.id != site.home ~%}
+    <li><a href="{{ url(page) }}" aria-current="page">{{ page.title }}</a></li>
+    {%- endif ~%}
+  </ul>
+</nav>
+{% endif %}

--- a/src/Collection/Page/Page.php
+++ b/src/Collection/Page/Page.php
@@ -49,6 +49,9 @@ class Page extends Item
     /** @var string */
     protected $section;
 
+    /** @var bool True if page is a folder's index (created from an "index.md" file). */
+    protected $sectionIndex = false;
+
     /** @var string */
     protected $frontmatter;
 
@@ -164,6 +167,10 @@ class Page extends Item
         // case of "index" = home page
         if (empty($this->file->getRelativePath()) && PrefixSuffix::sub($fileName, $separators) == 'index') {
             $this->setType(Type::HOMEPAGE->value);
+        }
+        // case of a folder's "index" = section index (i.e.: "section/index.md")
+        if (!empty($this->file->getRelativePath()) && PrefixSuffix::sub($fileName, $separators) == 'index') {
+            $this->sectionIndex = true;
         }
         /*
          * Set page properties and variables
@@ -417,6 +424,54 @@ class Page extends Item
         $this->section = null;
 
         return $this;
+    }
+
+    /**
+     * Is the page a folder's index (created from an "index.md" file)?
+     */
+    public function isSectionIndex(): bool
+    {
+        return $this->sectionIndex;
+    }
+
+    /**
+     * Returns the parent section's page (`null` if there is none).
+     */
+    public function getParent(): ?self
+    {
+        $parent = $this->getVariable('parent');
+
+        return $parent instanceof self ? $parent : null;
+    }
+
+    /**
+     * Returns the collection of the page's ancestor sections, from the nearest to the farthest.
+     */
+    public function getAncestors(): Collection
+    {
+        $ancestors = new Collection($this->getId() . '-ancestors');
+        $page = $this;
+        $seen = [$this->getId() => true];
+        while (($parent = $page->getParent()) !== null) {
+            if (isset($seen[$parent->getId()])) {
+                break;
+            }
+            $seen[$parent->getId()] = true;
+            $ancestors->add($parent);
+            $page = $parent;
+        }
+
+        return $ancestors;
+    }
+
+    /**
+     * Returns the collection of the page's immediate descendant sections.
+     */
+    public function getSections(): Collection
+    {
+        $sections = $this->getVariable('sections');
+
+        return $sections instanceof Collection ? $sections : new Collection($this->getId() . '-sections');
     }
 
     /**

--- a/src/Generator/Homepage.php
+++ b/src/Generator/Homepage.php
@@ -73,6 +73,12 @@ class Homepage extends AbstractGenerator implements GeneratorInterface
             if (!$page->getVariable('menu')) {
                 $page->setVariable('menu', ['main' => ['weight' => 0]]);
             }
+            // set immediate descendant sections (i.e.: top level sections)
+            $page->setVariable('sections', $this->builder->getPages()->filter(function (Page $section) use ($language) {
+                return $section->getType() == Type::SECTION->value
+                    && $section->getVariable('toplevel') === true
+                    && $section->getVariable('language') == $language;
+            }));
             // add an alias redirection from the root directory if language path prefix is enabled for the default language
             if ($language == $this->config->getLanguageDefault() && $this->config->isEnabled('language.prefix')) {
                 $page->setVariable('alias', '../');

--- a/src/Generator/Section.php
+++ b/src/Generator/Section.php
@@ -26,6 +26,11 @@ use Cecil\Util;
  * creates a new page for each section. The generated pages are added to the
  * collection of generated pages. It also handles sorting of subpages and
  * adding navigation links (next and previous) to the section pages.
+ *
+ * It also supports sub-sections: any nested folder that explicitly contains an
+ * "index.md" file becomes its own (sub-)section. Pages located in a sub-section
+ * belong to both their top level section and each of their ancestor sub-sections,
+ * while a sub-section index page itself is not listed in its parent section.
  */
 class Section extends AbstractGenerator implements GeneratorInterface
 {
@@ -36,25 +41,57 @@ class Section extends AbstractGenerator implements GeneratorInterface
     {
         $sections = [];
 
+        // identifying explicit sub-sections: nested folders containing an "index.md" file
+        $subSections = [];
+        /** @var Page $page */
+        foreach ($this->builder->getPages() ?? [] as $page) {
+            if ($page->isVirtual() || !$page->isSectionIndex()) {
+                continue;
+            }
+            $path = (string) $page->getPath();
+            // a sub-section is a section index located in a nested folder (its path contains a "/")
+            if (str_contains($path, '/')) {
+                $subSections[$path] = true;
+            }
+        }
+
         // identifying sections from all pages
         /** @var Page $page */
         foreach ($this->builder->getPages() ?? [] as $page) {
-            // top level (root) sections
-            if ($page->getSection()) {
-                // do not add "not published" and "not excluded" pages to its section
-                if (
-                    $page->getVariable('published') !== true
-                    || ($page->getVariable('excluded') || $page->getVariable('exclude'))
-                ) {
-                    continue;
+            if (!$page->getSection()) {
+                continue;
+            }
+            // do not add "not published" and "not excluded" pages to its section
+            if (
+                $page->getVariable('published') !== true
+                || ($page->getVariable('excluded') || $page->getVariable('exclude'))
+            ) {
+                continue;
+            }
+            // a sub-section index page is not listed in its parent section(s)
+            if ($page->isSectionIndex() && isset($subSections[(string) $page->getPath()])) {
+                continue;
+            }
+            $language = $page->getVariable('language', $this->config->getLanguageDefault());
+            // the page belongs to its top level (root) section...
+            $sectionsPaths = [explode('/', (string) $page->getPath())[0]];
+            // ...and to each of its ancestor sub-sections
+            $prefix = '';
+            foreach (explode('/', (string) $page->getFolder()) as $ancestor) {
+                $prefix = $prefix === '' ? $ancestor : "$prefix/$ancestor";
+                if (isset($subSections[$prefix])) {
+                    $sectionsPaths[] = $prefix;
                 }
-                $sections[$page->getSection()][$page->getVariable('language', $this->config->getLanguageDefault())][] = $page;
+            }
+            foreach (array_unique($sectionsPaths) as $sectionPath) {
+                $sections[$sectionPath][$language][] = $page;
             }
         }
 
         // adds each section to pages collection
         if (\count($sections) > 0) {
             $menuWeight = 100;
+            $sectionPages = []; // registry of created section pages, by language then path
 
             foreach ($sections as $section => $languages) {
                 foreach ($languages as $language => $pagesAsArray) {
@@ -90,20 +127,43 @@ class Section extends AbstractGenerator implements GeneratorInterface
                         $this->addNavigationLinks($pages, $sortBy, $page->getVariable('circular') ?? false);
                     }
                     // creates page for each section
+                    $toplevel = !str_contains($path, '/');
                     $page->setType(Type::SECTION->value)
                         ->setSection($path)
                         ->setPages($pages)
                         ->setVariable('language', $language)
                         ->setVariable('date', $pages->first()->getVariable('date'))
-                        ->setVariable('langref', $path);
+                        ->setVariable('langref', $path)
+                        ->setVariable('toplevel', $toplevel);
                     // human readable title
                     if ($page->getVariable('title') == 'index') {
                         $page->setVariable('title', $section);
                     }
-                    // default menu
-                    if (!$page->getVariable('menu')) {
+                    // default menu (only top level sections are added to the "main" menu)
+                    if ($toplevel && !$page->getVariable('menu')) {
                         $page->setVariable('menu', ['main' => ['weight' => $menuWeight]]);
                     }
+
+                    // sets parent references:
+                    // the section's parent is its nearest ancestor section (if any),
+                    // and each of its pages' parent is the section itself (deepest wins).
+                    $sectionPages[$language][$path] = $page;
+                    $parentPath = $path;
+                    while (($pos = strrpos($parentPath, '/')) !== false) {
+                        $parentPath = substr($parentPath, 0, $pos);
+                        if (isset($sectionPages[$language][$parentPath])) {
+                            $parentSection = $sectionPages[$language][$parentPath];
+                            $page->setVariable('parent', $parentSection);
+                            // registers the section as an immediate descendant section of its parent
+                            $childSections = $parentSection->getVariable('sections') ?? new PagesCollection("sections-{$parentSection->getId()}");
+                            $childSections->add($page);
+                            $parentSection->setVariable('sections', $childSections);
+                            break;
+                        }
+                    }
+                    $pages->map(function (Page $subPage) use ($page) {
+                        $subPage->setVariable('parent', $page);
+                    });
 
                     try {
                         $this->generatedPages->add($page);
@@ -156,7 +216,11 @@ class Section extends AbstractGenerator implements GeneratorInterface
                         ]);
                         break;
                 }
-                $this->generatedPages->add($page);
+                try {
+                    $this->generatedPages->add($page);
+                } catch (\DomainException) {
+                    $this->generatedPages->replace($page->getId(), $page);
+                }
             }
         }
     }

--- a/tests/Unit/Collection/Page/PageTest.php
+++ b/tests/Unit/Collection/Page/PageTest.php
@@ -210,6 +210,39 @@ class PageTest extends TestCase
         self::assertSame('index', $page->getId());
     }
 
+    public function testIsSectionIndexTrueForFolderIndex(): void
+    {
+        $file = $this->createFileInfo('blog', 'index.md', 'Hello');
+        $page = new Page($file);
+
+        self::assertTrue($page->isSectionIndex());
+    }
+
+    public function testIsSectionIndexTrueForNestedFolderIndex(): void
+    {
+        $file = $this->createFileInfo('blog/2024', 'index.md', 'Hello');
+        $page = new Page($file);
+
+        self::assertTrue($page->isSectionIndex());
+        self::assertSame('blog/2024', $page->getPath());
+    }
+
+    public function testIsSectionIndexFalseForRegularPage(): void
+    {
+        $file = $this->createFileInfo('blog', 'post.md', 'Hello');
+        $page = new Page($file);
+
+        self::assertFalse($page->isSectionIndex());
+    }
+
+    public function testIsSectionIndexFalseForHomepage(): void
+    {
+        $file = $this->createFileInfo('', 'index.md', 'Hello');
+        $page = new Page($file);
+
+        self::assertFalse($page->isSectionIndex());
+    }
+
     public function testGetPathnameIsAliasOfGetPath(): void
     {
         $page = new Page('alias');

--- a/tests/Unit/Generator/SectionTest.php
+++ b/tests/Unit/Generator/SectionTest.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * This file is part of Cecil.
+ *
+ * (c) Arnaud Ligny <arnaud@ligny.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cecil\Test\Unit\Generator;
+
+use Cecil\Builder;
+use Cecil\Collection\Page\Collection as PagesCollection;
+use Cecil\Collection\Page\Page;
+use Cecil\Generator\Homepage;
+use Cecil\Generator\Section;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo;
+
+class SectionTest extends TestCase
+{
+    private string $tmpDir;
+
+    private Filesystem $filesystem;
+
+    private Builder $builder;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cecil-section-test-' . uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+        $this->builder = new Builder();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    public function testSubSectionIsCreatedFromNestedIndex(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'deep-post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        // both the section and the sub-section pages are generated
+        self::assertTrue($generated->has('blog'));
+        self::assertTrue($generated->has('blog/2024'));
+        self::assertSame('section', $generated->get('blog')->getType());
+        self::assertSame('section', $generated->get('blog/2024')->getType());
+        self::assertSame('blog/2024', $generated->get('blog/2024')->getSection());
+    }
+
+    public function testSubSectionPageBelongsToBothSections(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'deep-post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        $section = $this->pagesIds($generated->get('blog')->getPages());
+        $subSection = $this->pagesIds($generated->get('blog/2024')->getPages());
+
+        // the sub-section content page belongs to both the section and the sub-section
+        self::assertContains('blog/2024/deep-post', $section);
+        self::assertContains('blog/post', $section);
+        self::assertContains('blog/2024/deep-post', $subSection);
+    }
+
+    public function testSubSectionIndexIsNotListedInParent(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'deep-post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        // the sub-section index page is not listed as a child of its parent section
+        self::assertNotContains('blog/2024', $this->pagesIds($generated->get('blog')->getPages()));
+    }
+
+    public function testNestedFolderWithoutIndexIsNotASubSection(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog/2024', 'deep-post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        // no "index.md" in "blog/2024": no sub-section is created
+        self::assertFalse($generated->has('blog/2024'));
+        self::assertContains('blog/2024/deep-post', $this->pagesIds($generated->get('blog')->getPages()));
+    }
+
+    public function testPageParentIsItsSection(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+        ]));
+
+        (new Section($this->builder))->runGenerate();
+
+        $post = $this->builder->getPages()->get('blog/post');
+        self::assertInstanceOf(Page::class, $post->getParent());
+        self::assertSame('blog', $post->getParent()->getId());
+    }
+
+    public function testPageParentIsItsDeepestSubSection(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'deep-post.md'),
+        ]));
+
+        (new Section($this->builder))->runGenerate();
+
+        // a sub-section page's parent is its most specific (deepest) section
+        $deepPost = $this->builder->getPages()->get('blog/2024/deep-post');
+        self::assertSame('blog/2024', $deepPost->getParent()->getId());
+    }
+
+    public function testSubSectionParentIsItsParentSection(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'deep-post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        // the sub-section's parent is its parent section
+        self::assertSame('blog', $generated->get('blog/2024')->getParent()->getId());
+    }
+
+    public function testTopSectionHasNoParent(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        self::assertNull($generated->get('blog')->getParent());
+    }
+
+    public function testPageAncestorsAreItsSectionsFromNearestToFarthest(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024/06', 'index.md'),
+            $this->page('blog/2024/06', 'deep-post.md'),
+        ]));
+
+        (new Section($this->builder))->runGenerate();
+
+        $deepPost = $this->builder->getPages()->get('blog/2024/06/deep-post');
+        $ancestors = $this->pagesIds($deepPost->getAncestors());
+
+        // from the nearest to the farthest section
+        self::assertSame(['blog/2024/06', 'blog/2024', 'blog'], $ancestors);
+    }
+
+    public function testTopSectionHasNoAncestors(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        self::assertCount(0, $generated->get('blog')->getAncestors());
+    }
+
+    public function testTopLevelSectionIsFlaggedAndAddedToMainMenu(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        $blog = $generated->get('blog');
+        self::assertTrue($blog->getVariable('toplevel'));
+        self::assertArrayHasKey('main', (array) $blog->getVariable('menu'));
+    }
+
+    public function testSubSectionIsNotTopLevelAndNotInMainMenu(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'deep-post.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        $subSection = $generated->get('blog/2024');
+        self::assertFalse($subSection->getVariable('toplevel'));
+        self::assertNull($subSection->getVariable('menu'));
+    }
+
+    public function testSectionImmediateChildSections(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'post.md'),
+            $this->page('blog/2024/06', 'index.md'),
+            $this->page('blog/2024/06', 'deep.md'),
+        ]));
+
+        $generated = (new Section($this->builder))->runGenerate();
+
+        // only immediate descendant sections are returned
+        self::assertSame(['blog/2024'], $this->pagesIds($generated->get('blog')->getSections()));
+        self::assertSame(['blog/2024/06'], $this->pagesIds($generated->get('blog/2024')->getSections()));
+        self::assertCount(0, $generated->get('blog/2024/06')->getSections());
+    }
+
+    public function testHomepageImmediateChildSectionsAreTopLevel(): void
+    {
+        $this->builder->setPages(new PagesCollection('all-pages', [
+            $this->page('blog', 'index.md'),
+            $this->page('blog', 'post.md'),
+            $this->page('projects', 'index.md'),
+            $this->page('projects', 'a.md'),
+            $this->page('blog/2024', 'index.md'),
+            $this->page('blog/2024', 'deep.md'),
+        ]));
+
+        // runs the Section generator and merges its pages into the collection
+        foreach ((new Section($this->builder))->runGenerate() as $page) {
+            try {
+                $this->builder->getPages()->add($page);
+            } catch (\DomainException) {
+                $this->builder->getPages()->replace($page->getId(), $page);
+            }
+        }
+
+        $home = (new Homepage($this->builder))->runGenerate()->get('index');
+        $homeSections = $this->pagesIds($home->getSections());
+        sort($homeSections);
+
+        self::assertSame(['blog', 'projects'], $homeSections);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function pagesIds(PagesCollection $pages): array
+    {
+        return array_map(fn (Page $page): string => $page->getId(), $pages->toArray());
+    }
+
+    private function page(string $relativePath, string $filename): Page
+    {
+        $dir = $this->tmpDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $this->filesystem->mkdir($dir);
+        $filePath = $dir . DIRECTORY_SEPARATOR . $filename;
+        file_put_contents($filePath, "---\ntitle: Test\n---\nBody");
+        $file = new SplFileInfo($filePath, $relativePath, $relativePath . '/' . $filename);
+
+        return (new Page($file))->parse();
+    }
+}


### PR DESCRIPTION
This pull request introduces full support for nested sections (sub-sections) in the content structure, along with new template variables and navigation helpers to improve content organization and navigation. The documentation and templates are updated to explain and demonstrate these new features, and several code changes implement the underlying logic for sub-sections, parent/ancestor section tracking, and main navigation improvements.

**Support for nested sections and navigation enhancements:**

* Added sub-section support: Any nested folder with an `index.md` file is now treated as a sub-section, with pages belonging to both their immediate sub-section and all ancestor sections. Sub-section index pages are not listed in their parent section.
* New template variables: Introduced `page.parent`, `page.ancestors`, `page.sections`, and `page.toplevel` for use in templates, enabling breadcrumb trails, sub-section menus, and top-level section navigation.
* Breadcrumb navigation: Added a ready-to-use `partials/breadcrumb.html.twig` partial and included it by default in the page layout for improved navigation.
* Documentation updates: Expanded both English and French documentation to explain sub-sections, new template variables, and navigation patterns with code examples.
* Layout and style improvements: Adjusted main content width and header layout for better display, especially with the new breadcrumb navigation.

These changes make it easier to organize large sites with deeply nested content, and provide out-of-the-box navigation helpers for complex section hierarchies.