### PR TITLE
feat: use Nette schema for config validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "jolicode/jolinotif": "^3.3",
     "laravel-zero/phar-updater": "^1.4",
     "matthiasmullie/minify": "^1.3",
+    "nette/schema": "^1.3",
     "performing/twig-components": "^0.7",
     "psr/log": "^3.0",
     "psr/simple-cache": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "288162e8efd76f93d19c7e5efe6c73eb",
+    "content-hash": "1c9869ee0d3892d7a897378fdf0bd35a",
     "packages": [
         {
             "name": "benjaminhoegh/parsedown-toc",
@@ -1158,6 +1158,164 @@
                 "source": "https://github.com/matthiasmullie/path-converter/tree/1.1.3"
             },
             "time": "2019-02-05T23:41:09+00:00"
+        },
+        {
+            "name": "nette/schema",
+            "version": "v1.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "c54350438cd6914616f790a49cb424605f421562"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/c54350438cd6914616f790a49cb424605f421562",
+                "reference": "c54350438cd6914616f790a49cb424605f421562",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.5"
+            },
+            "require-dev": {
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
+                "tracy/tracy": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.3.6"
+            },
+            "time": "2026-08-16T21:58:41+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.2 - 8.5"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.5",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
+            },
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "performing/twig-components",

--- a/docs/api/classes/Cecil-Config.html
+++ b/docs/api/classes/Cecil-Config.html
@@ -168,7 +168,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">28</span>
+    <span class="phpdocumentor-element-found-in__line">32</span>
 
     </aside>
 
@@ -567,6 +567,13 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
 <dd>Casts boolean value given to set() as string.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a class="" href="classes/Cecil-Config.html#method_getSchemas">getSchemas()</a>
+    <span>
+                                &nbsp;: array&lt;string, <abbr title="\Nette\Schema\Schema">Schema</abbr>&gt;    </span>
+</dt>
+<dd>Returns the validation schemas indexed by configuration key.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a class="" href="classes/Cecil-Config.html#method_setFromEnv">setFromEnv()</a>
     <span>
                                 &nbsp;: void    </span>
@@ -581,18 +588,11 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
 <dd>Validate the configuration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
-    <a class="" href="classes/Cecil-Config.html#method_validateCacheConfiguration">validateCacheConfiguration()</a>
+    <a class="" href="classes/Cecil-Config.html#method_validateSchema">validateSchema()</a>
     <span>
                                 &nbsp;: void    </span>
 </dt>
-<dd>Validate cache-related options.</dd>
-
-            <dt class="phpdocumentor-table-of-contents__entry -method -private">
-    <a class="" href="classes/Cecil-Config.html#method_validateOutputFormats">validateOutputFormats()</a>
-    <span>
-                                &nbsp;: void    </span>
-</dt>
-<dd>Validate output format configuration.</dd>
+<dd>Validates well-defined configuration sections against a schema.</dd>
 
     </dl>
 
@@ -615,7 +615,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">32</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -645,7 +645,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">30</span>
+    <span class="phpdocumentor-element-found-in__line">34</span>
 
     </aside>
 
@@ -675,7 +675,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">35</span>
 
     </aside>
 
@@ -705,7 +705,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">33</span>
+    <span class="phpdocumentor-element-found-in__line">37</span>
 
     </aside>
 
@@ -735,7 +735,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">34</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
@@ -781,7 +781,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</d
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">42</span>
+    <span class="phpdocumentor-element-found-in__line">46</span>
 
     </aside>
 
@@ -822,7 +822,7 @@ For example: $config-&gt;get('key.subkey') or $config-&gt;has('key.subkey').</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">46</span>
+    <span class="phpdocumentor-element-found-in__line">50</span>
 
     </aside>
 
@@ -860,7 +860,7 @@ For example: $config-&gt;get('key.subkey') or $config-&gt;has('key.subkey').</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">62</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 
@@ -902,7 +902,7 @@ If not set, it defaults to the source directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">71</span>
+    <span class="phpdocumentor-element-found-in__line">75</span>
 
     </aside>
 
@@ -961,7 +961,7 @@ It is initialized to null and will be populated when the languages are requested
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">54</span>
+    <span class="phpdocumentor-element-found-in__line">58</span>
 
     </aside>
 
@@ -1008,7 +1008,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">76</span>
+    <span class="phpdocumentor-element-found-in__line">80</span>
 
     </aside>
 
@@ -1053,7 +1053,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">109</span>
+    <span class="phpdocumentor-element-found-in__line">113</span>
 
     </aside>
 
@@ -1092,7 +1092,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">172</span>
+    <span class="phpdocumentor-element-found-in__line">176</span>
 
     </aside>
 
@@ -1161,7 +1161,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">460</span>
+    <span class="phpdocumentor-element-found-in__line">464</span>
 
     </aside>
 
@@ -1200,7 +1200,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">452</span>
+    <span class="phpdocumentor-element-found-in__line">456</span>
 
     </aside>
 
@@ -1239,7 +1239,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">444</span>
+    <span class="phpdocumentor-element-found-in__line">448</span>
 
     </aside>
 
@@ -1278,7 +1278,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">359</span>
+    <span class="phpdocumentor-element-found-in__line">363</span>
 
     </aside>
 
@@ -1317,7 +1317,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">369</span>
+    <span class="phpdocumentor-element-found-in__line">373</span>
 
     </aside>
 
@@ -1356,7 +1356,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">413</span>
+    <span class="phpdocumentor-element-found-in__line">417</span>
 
     </aside>
 
@@ -1395,7 +1395,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">379</span>
+    <span class="phpdocumentor-element-found-in__line">383</span>
 
     </aside>
 
@@ -1448,7 +1448,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">397</span>
+    <span class="phpdocumentor-element-found-in__line">401</span>
 
     </aside>
 
@@ -1487,7 +1487,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">405</span>
+    <span class="phpdocumentor-element-found-in__line">409</span>
 
     </aside>
 
@@ -1526,7 +1526,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">291</span>
+    <span class="phpdocumentor-element-found-in__line">295</span>
 
     </aside>
 
@@ -1565,7 +1565,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">259</span>
+    <span class="phpdocumentor-element-found-in__line">263</span>
 
     </aside>
 
@@ -1604,7 +1604,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">544</span>
+    <span class="phpdocumentor-element-found-in__line">548</span>
 
     </aside>
 
@@ -1657,7 +1657,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">565</span>
+    <span class="phpdocumentor-element-found-in__line">569</span>
 
     </aside>
 
@@ -1720,7 +1720,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">580</span>
+    <span class="phpdocumentor-element-found-in__line">584</span>
 
     </aside>
 
@@ -1790,7 +1790,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">523</span>
+    <span class="phpdocumentor-element-found-in__line">527</span>
 
     </aside>
 
@@ -1843,7 +1843,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">319</span>
 
     </aside>
 
@@ -1892,7 +1892,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">307</span>
+    <span class="phpdocumentor-element-found-in__line">311</span>
 
     </aside>
 
@@ -1931,7 +1931,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">299</span>
+    <span class="phpdocumentor-element-found-in__line">303</span>
 
     </aside>
 
@@ -1970,7 +1970,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">427</span>
+    <span class="phpdocumentor-element-found-in__line">431</span>
 
     </aside>
 
@@ -2040,7 +2040,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">283</span>
+    <span class="phpdocumentor-element-found-in__line">287</span>
 
     </aside>
 
@@ -2079,7 +2079,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">275</span>
+    <span class="phpdocumentor-element-found-in__line">279</span>
 
     </aside>
 
@@ -2118,7 +2118,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">232</span>
+    <span class="phpdocumentor-element-found-in__line">236</span>
 
     </aside>
 
@@ -2157,7 +2157,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">351</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -2196,7 +2196,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">472</span>
+    <span class="phpdocumentor-element-found-in__line">476</span>
 
     </aside>
 
@@ -2235,7 +2235,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">509</span>
+    <span class="phpdocumentor-element-found-in__line">513</span>
 
     </aside>
 
@@ -2293,7 +2293,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">343</span>
+    <span class="phpdocumentor-element-found-in__line">347</span>
 
     </aside>
 
@@ -2332,7 +2332,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">335</span>
+    <span class="phpdocumentor-element-found-in__line">339</span>
 
     </aside>
 
@@ -2371,7 +2371,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">327</span>
+    <span class="phpdocumentor-element-found-in__line">331</span>
 
     </aside>
 
@@ -2410,7 +2410,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">142</span>
+    <span class="phpdocumentor-element-found-in__line">146</span>
 
     </aside>
 
@@ -2479,7 +2479,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">490</span>
+    <span class="phpdocumentor-element-found-in__line">494</span>
 
     </aside>
 
@@ -2532,7 +2532,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">99</span>
+    <span class="phpdocumentor-element-found-in__line">103</span>
 
     </aside>
 
@@ -2595,7 +2595,7 @@ If not set, it defaults to the current working directory.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">599</span>
+    <span class="phpdocumentor-element-found-in__line">603</span>
 
     </aside>
 
@@ -2635,7 +2635,7 @@ or relative to project destination?</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">196</span>
+    <span class="phpdocumentor-element-found-in__line">200</span>
 
     </aside>
 
@@ -2699,7 +2699,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">117</span>
+    <span class="phpdocumentor-element-found-in__line">121</span>
 
     </aside>
 
@@ -2755,7 +2755,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">246</span>
+    <span class="phpdocumentor-element-found-in__line">250</span>
 
     </aside>
 
@@ -2818,7 +2818,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">219</span>
+    <span class="phpdocumentor-element-found-in__line">223</span>
 
     </aside>
 
@@ -2881,7 +2881,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">633</span>
+    <span class="phpdocumentor-element-found-in__line">637</span>
 
     </aside>
 
@@ -2922,6 +2922,45 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
             -private
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_getSchemas">
+        getSchemas()
+        <a href="classes/Cecil-Config.html#method_getSchemas" class="headerlink"><i class="fas fa-link"></i></a>
+
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">711</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Returns the validation schemas indexed by configuration key.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">getSchemas</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string, <abbr title="\Nette\Schema\Schema">Schema</abbr>&gt;</span></code>
+
+    <div class="phpdocumentor-label-line">
+        </div>
+    
+    
+    
+    
+
+        
+    
+            <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">array&lt;string, <abbr title="\Nette\Schema\Schema">Schema</abbr>&gt;</span>
+            </section>
+
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_setFromEnv">
         setFromEnv()
         <a href="classes/Cecil-Config.html#method_setFromEnv" class="headerlink"><i class="fas fa-link"></i></a>
@@ -2930,7 +2969,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">616</span>
+    <span class="phpdocumentor-element-found-in__line">620</span>
 
     </aside>
 
@@ -2965,7 +3004,7 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">649</span>
+    <span class="phpdocumentor-element-found-in__line">653</span>
 
     </aside>
 
@@ -3006,82 +3045,36 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
             -private
                                                         "
 >
-    <h4 class="phpdocumentor-element__name" id="method_validateCacheConfiguration">
-        validateCacheConfiguration()
-        <a href="classes/Cecil-Config.html#method_validateCacheConfiguration" class="headerlink"><i class="fas fa-link"></i></a>
+    <h4 class="phpdocumentor-element__name" id="method_validateSchema">
+        validateSchema()
+        <a href="classes/Cecil-Config.html#method_validateSchema" class="headerlink"><i class="fas fa-link"></i></a>
 
     </h4>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">694</span>
+    <span class="phpdocumentor-element-found-in__line">691</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Validate cache-related options.</p>
+        <p class="phpdocumentor-summary">Validates well-defined configuration sections against a schema.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-                    <span class="phpdocumentor-signature__name">validateCacheConfiguration</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+                    <span class="phpdocumentor-signature__name">validateSchema</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
     
+        <section class="phpdocumentor-description"><p>Only targeted sections are processed: the rest of the configuration stays open
+(menus, taxonomies, custom variables, etc.).</p>
+</section>
+
     
     
-    
-    <h5 class="phpdocumentor-tag-list__heading" id="method_validateCacheConfiguration_tags">
+    <h5 class="phpdocumentor-tag-list__heading" id="method_validateSchema_tags">
         Tags
-        <a href="classes/Cecil-Config.html#method_validateCacheConfiguration_tags" class="headerlink"><i class="fas fa-link"></i></a>
-
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                    <dt class="phpdocumentor-tag-list__entry">
-                <span class="phpdocumentor-tag__name">throws</span>
-            </dt>
-                            <dd class="phpdocumentor-tag-list__definition">
-                                                                <span class="phpdocumentor-tag-link"><a href="classes/Cecil-Exception-ConfigException.html"><abbr title="\Cecil\Exception\ConfigException">ConfigException</abbr></a></span>
-                                                                                    
-                                    </dd>
-                        </dl>
-
-        
-    
-    
-</article>
-                    <article
-        class="phpdocumentor-element
-            -method
-            -private
-                                                        "
->
-    <h4 class="phpdocumentor-element__name" id="method_validateOutputFormats">
-        validateOutputFormats()
-        <a href="classes/Cecil-Config.html#method_validateOutputFormats" class="headerlink"><i class="fas fa-link"></i></a>
-
-    </h4>
-    <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="src/Config.php"><a href="files/src-config.html"><abbr title="src/Config.php">Config.php</abbr></a></abbr>
-    :
-    <span class="phpdocumentor-element-found-in__line">706</span>
-
-    </aside>
-
-        <p class="phpdocumentor-summary">Validate output format configuration.</p>
-
-    <code class="phpdocumentor-code phpdocumentor-signature ">
-    <span class="phpdocumentor-signature__visibility">private</span>
-                    <span class="phpdocumentor-signature__name">validateOutputFormats</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
-
-    <div class="phpdocumentor-label-line">
-        </div>
-    
-    
-    
-    
-    <h5 class="phpdocumentor-tag-list__heading" id="method_validateOutputFormats_tags">
-        Tags
-        <a href="classes/Cecil-Config.html#method_validateOutputFormats_tags" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/Cecil-Config.html#method_validateSchema_tags" class="headerlink"><i class="fas fa-link"></i></a>
 
     </h5>
     <dl class="phpdocumentor-tag-list">
@@ -3182,10 +3175,10 @@ Checks if the key is set to `false` or if subkey `enabled` is set to `false`.</p
                                             <li class=""><a href="classes/Cecil-Config.html#method_setDestinationDir">setDestinationDir()</a></li>
                                             <li class=""><a href="classes/Cecil-Config.html#method_setSourceDir">setSourceDir()</a></li>
                                             <li class=""><a href="classes/Cecil-Config.html#method_castSetValue">castSetValue()</a></li>
+                                            <li class=""><a href="classes/Cecil-Config.html#method_getSchemas">getSchemas()</a></li>
                                             <li class=""><a href="classes/Cecil-Config.html#method_setFromEnv">setFromEnv()</a></li>
                                             <li class=""><a href="classes/Cecil-Config.html#method_validate">validate()</a></li>
-                                            <li class=""><a href="classes/Cecil-Config.html#method_validateCacheConfiguration">validateCacheConfiguration()</a></li>
-                                            <li class=""><a href="classes/Cecil-Config.html#method_validateOutputFormats">validateOutputFormats()</a></li>
+                                            <li class=""><a href="classes/Cecil-Config.html#method_validateSchema">validateSchema()</a></li>
                                     </ul>
             </li>
                     </ul>

--- a/docs/api/classes/Cecil-Generator-Section.html
+++ b/docs/api/classes/Cecil-Generator-Section.html
@@ -543,7 +543,7 @@ while a sub-section index page itself is not listed in its parent section.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Generator/Section.php"><a href="files/src-generator-section.html"><abbr title="src/Generator/Section.php">Section.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">182</span>
+    <span class="phpdocumentor-element-found-in__line">183</span>
 
     </aside>
 

--- a/docs/api/js/searchIndex.js
+++ b/docs/api/js/searchIndex.js
@@ -3111,15 +3111,15 @@ Search.appendIndex(
             "summary": "Validate\u0020the\u0020configuration.",
             "url": "classes/Cecil-Config.html#method_validate"
         },                {
-            "fqsen": "\\Cecil\\Config\u003A\u003AvalidateCacheConfiguration\u0028\u0029",
-            "name": "validateCacheConfiguration",
-            "summary": "Validate\u0020cache\u002Drelated\u0020options.",
-            "url": "classes/Cecil-Config.html#method_validateCacheConfiguration"
+            "fqsen": "\\Cecil\\Config\u003A\u003AvalidateSchema\u0028\u0029",
+            "name": "validateSchema",
+            "summary": "Validates\u0020well\u002Ddefined\u0020configuration\u0020sections\u0020against\u0020a\u0020schema.",
+            "url": "classes/Cecil-Config.html#method_validateSchema"
         },                {
-            "fqsen": "\\Cecil\\Config\u003A\u003AvalidateOutputFormats\u0028\u0029",
-            "name": "validateOutputFormats",
-            "summary": "Validate\u0020output\u0020format\u0020configuration.",
-            "url": "classes/Cecil-Config.html#method_validateOutputFormats"
+            "fqsen": "\\Cecil\\Config\u003A\u003AgetSchemas\u0028\u0029",
+            "name": "getSchemas",
+            "summary": "Returns\u0020the\u0020validation\u0020schemas\u0020indexed\u0020by\u0020configuration\u0020key.",
+            "url": "classes/Cecil-Config.html#method_getSchemas"
         },                {
             "fqsen": "\\Cecil\\Config\u003A\u003AIMPORT_PRESERVE",
             "name": "IMPORT_PRESERVE",

--- a/src/Config.php
+++ b/src/Config.php
@@ -717,7 +717,7 @@ class Config
                 Expect::structure([
                     'dir' => Expect::string(),
                 ])->otherItems(Expect::mixed())->assert(
-                    fn($cache) => !$this->isEnabled('cache') || trim((string) ($cache->dir ?? '')) !== '',
+                    fn ($cache) => !$this->isEnabled('cache') || trim((string) ($cache->dir ?? '')) !== '',
                     'The cache directory (`cache.dir`) must not be empty when cache is enabled.'
                 )
             ),

--- a/src/Config.php
+++ b/src/Config.php
@@ -15,6 +15,10 @@ namespace Cecil;
 
 use Cecil\Exception\ConfigException;
 use Dflydev\DotAccessData\Data;
+use Nette\Schema\Expect;
+use Nette\Schema\Processor;
+use Nette\Schema\Schema;
+use Nette\Schema\ValidationException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -648,22 +652,13 @@ class Config
      */
     private function validate(): void
     {
+        // structural validation of well-defined sections
+        $this->validateSchema();
+
         // default language must be valid
         if (!preg_match('/^' . Config::LANG_CODE_PATTERN . '$/', $this->getLanguageDefault())) {
             throw new ConfigException(\sprintf('Default language code "%s" is not valid (e.g.: "language: fr-FR").', $this->getLanguageDefault()));
         }
-        // if language is set then the locale is required and must be valid
-        foreach ((array) $this->get('languages') as $lang) {
-            if (!isset($lang['locale'])) {
-                throw new ConfigException('A language locale is not defined.');
-            }
-            if (!preg_match('/^' . Config::LANG_LOCALE_PATTERN . '$/', $lang['locale'])) {
-                throw new ConfigException(\sprintf('The language locale "%s" is not valid (e.g.: "locale: fr_FR").', $lang['locale']));
-            }
-        }
-
-        $this->validateCacheConfiguration();
-        $this->validateOutputFormats();
 
         // check for deprecated options
         $deprecatedConfigFile = Util\File::getRealPath('../config/deprecated.php');
@@ -687,42 +682,70 @@ class Config
     }
 
     /**
-     * Validate cache-related options.
+     * Validates well-defined configuration sections against a schema.
+     * Only targeted sections are processed: the rest of the configuration stays open
+     * (menus, taxonomies, custom variables, etc.).
      *
      * @throws ConfigException
      */
-    private function validateCacheConfiguration(): void
+    private function validateSchema(): void
     {
-        if ($this->isEnabled('cache') && trim((string) $this->get('cache.dir')) === '') {
-            throw new ConfigException('The cache directory (`cache.dir`) must not be empty when cache is enabled.');
+        $processor = new Processor();
+        foreach ($this->getSchemas() as $key => $schema) {
+            if (!$this->has($key)) {
+                continue;
+            }
+            try {
+                $processor->process($schema, $this->get($key));
+            } catch (ValidationException $e) {
+                throw new ConfigException($e->getMessage());
+            }
         }
     }
 
     /**
-     * Validate output format configuration.
+     * Returns the validation schemas indexed by configuration key.
      *
-     * @throws ConfigException
+     * @return array<string, Schema>
      */
-    private function validateOutputFormats(): void
+    private function getSchemas(): array
     {
-        $formats = $this->get('output.formats');
-        if (!\is_array($formats)) {
-            throw new ConfigException('The "output.formats" configuration must be an array.');
-        }
-
-        foreach ($formats as $index => $format) {
-            $position = $index + 1;
-            if (!\is_array($format)) {
-                throw new ConfigException(\sprintf('Output format #%d must be an array.', $position));
-            }
-
-            foreach (['name', 'mediatype'] as $property) {
-                if (!isset($format[$property]) || !\is_string($format[$property]) || trim($format[$property]) === '') {
-                    $label = $format['name'] ?? \sprintf('#%d', $position);
-
-                    throw new ConfigException(\sprintf('Output format "%s" is missing "%s".', $label, $property));
-                }
-            }
-        }
+        return [
+            // `cache: true|false` shorthand or a structure with a non-empty `dir` when enabled
+            'cache' => Expect::anyOf(
+                Expect::bool(),
+                Expect::structure([
+                    'dir' => Expect::string(),
+                ])->otherItems(Expect::mixed())->assert(
+                    fn($cache) => !$this->isEnabled('cache') || trim((string) ($cache->dir ?? '')) !== '',
+                    'The cache directory (`cache.dir`) must not be empty when cache is enabled.'
+                )
+            ),
+            // each output format must define a `name` and a `mediatype`
+            'output.formats' => Expect::arrayOf(
+                Expect::structure([
+                    'name'      => Expect::string()->required(),
+                    'mediatype' => Expect::string()->required(),
+                ])->otherItems(Expect::mixed())
+            ),
+            // each language must define a `code` and a valid `locale`
+            'languages' => Expect::listOf(
+                Expect::structure([
+                    'code'   => Expect::string()->required(),
+                    'locale' => Expect::string()->required()->pattern(Config::LANG_LOCALE_PATTERN),
+                ])->otherItems(Expect::mixed())
+            ),
+            // date formatting options
+            'date' => Expect::structure([
+                'format'   => Expect::string(),
+                'timezone' => Expect::string(),
+            ])->otherItems(Expect::mixed()),
+            // pages management options
+            'pages' => Expect::structure([
+                'dir'         => Expect::string(),
+                'ext'         => Expect::listOf('string'),
+                'frontmatter' => Expect::anyOf('yaml', 'ini', 'toml', 'json'),
+            ])->otherItems(Expect::mixed()),
+        ];
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -735,8 +735,8 @@ class Config
             // each output format must define a `name` and a `mediatype`
             'output.formats' => Expect::arrayOf(
                 Expect::structure([
-                    'name'      => Expect::string()->required(),
-                    'mediatype' => Expect::string()->required(),
+                    'name'      => Expect::string()->required()->assert(fn ($value) => \trim((string) $value) !== '', 'Output format "name" must not be empty.'),
+                    'mediatype' => Expect::string()->required()->assert(fn ($value) => \trim((string) $value) !== '', 'Output format "mediatype" must not be empty.'),
                 ])->otherItems(Expect::mixed())
             ),
             // formats applied by page type (each type accepts a list of format names)

--- a/src/Config.php
+++ b/src/Config.php
@@ -698,7 +698,7 @@ class Config
             try {
                 $processor->process($schema, $this->get($key));
             } catch (ValidationException $e) {
-                throw new ConfigException($e->getMessage());
+                throw new ConfigException($e->getMessage(), previous: $e);
             }
         }
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -711,6 +711,17 @@ class Config
     private function getSchemas(): array
     {
         return [
+            // main site options
+            'title'        => Expect::string(),
+            'baseline'     => Expect::string(),
+            'baseurl'      => Expect::string(),
+            'canonicalurl' => Expect::bool(),
+            'description'  => Expect::string(),
+            // `theme: <name>` shorthand or a list of theme names
+            'theme' => Expect::anyOf(
+                Expect::string(),
+                Expect::listOf('string')
+            ),
             // `cache: true|false` shorthand or a structure with a non-empty `dir` when enabled
             'cache' => Expect::anyOf(
                 Expect::bool(),
@@ -728,6 +739,14 @@ class Config
                     'mediatype' => Expect::string()->required(),
                 ])->otherItems(Expect::mixed())
             ),
+            // formats applied by page type (each type accepts a list of format names)
+            'output.pagetypeformats' => Expect::structure([
+                'page'       => Expect::listOf('string'),
+                'homepage'   => Expect::listOf('string'),
+                'section'    => Expect::listOf('string'),
+                'vocabulary' => Expect::listOf('string'),
+                'term'       => Expect::listOf('string'),
+            ])->otherItems(Expect::mixed()),
             // each language must define a `code` and a valid `locale`
             'languages' => Expect::listOf(
                 Expect::structure([
@@ -746,6 +765,53 @@ class Config
                 'ext'         => Expect::listOf('string'),
                 'frontmatter' => Expect::anyOf('yaml', 'ini', 'toml', 'json'),
             ])->otherItems(Expect::mixed()),
+            // data files options
+            'data' => Expect::structure([
+                'dir'  => Expect::string(),
+                'ext'  => Expect::listOf('string'),
+                'load' => Expect::bool(),
+            ])->otherItems(Expect::mixed()),
+            // static files options
+            'static' => Expect::structure([
+                'dir'    => Expect::string(),
+                'target' => Expect::string(),
+                'load'   => Expect::bool(),
+            ])->otherItems(Expect::mixed()),
+            // `optimize: true|false` shorthand or a structure enabling optimization by file type
+            'optimize' => Expect::anyOf(
+                Expect::bool(),
+                Expect::structure([
+                    'enabled' => Expect::bool(),
+                    'html'    => Expect::structure([
+                        'enabled' => Expect::bool(),
+                        'ext'     => Expect::listOf('string'),
+                    ])->otherItems(Expect::mixed()),
+                    'css' => Expect::structure([
+                        'enabled' => Expect::bool(),
+                        'ext'     => Expect::listOf('string'),
+                    ])->otherItems(Expect::mixed()),
+                    'js' => Expect::structure([
+                        'enabled' => Expect::bool(),
+                        'ext'     => Expect::listOf('string'),
+                    ])->otherItems(Expect::mixed()),
+                    'images' => Expect::structure([
+                        'enabled' => Expect::bool(),
+                        'ext'     => Expect::listOf('string'),
+                    ])->otherItems(Expect::mixed()),
+                ])->otherItems(Expect::mixed())
+            ),
+            // local preview server custom HTTP headers
+            'server.headers' => Expect::listOf(
+                Expect::structure([
+                    'path'    => Expect::string()->required(),
+                    'headers' => Expect::listOf(
+                        Expect::structure([
+                            'key'   => Expect::string()->required(),
+                            'value' => Expect::scalar()->required(),
+                        ])->otherItems(Expect::mixed())
+                    )->required(),
+                ])->otherItems(Expect::mixed())
+            ),
         ];
     }
 }

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -51,7 +51,7 @@ class ConfigTest extends TestCase
     public function testInvalidOutputFormatsStructureIsRejected(): void
     {
         $this->expectException(ConfigException::class);
-        $this->expectExceptionMessage('Output format #16 must be an array.');
+        $this->expectExceptionMessage('expects to be array');
 
         new Config([
             'output' => [
@@ -346,7 +346,8 @@ class ConfigTest extends TestCase
             ]);
             self::fail('Expected missing locale exception.');
         } catch (ConfigException $e) {
-            self::assertStringContainsString('locale is not defined', $e->getMessage());
+            self::assertStringContainsString('locale', $e->getMessage());
+            self::assertStringContainsString('is missing', $e->getMessage());
         }
 
         try {
@@ -357,7 +358,8 @@ class ConfigTest extends TestCase
             ]);
             self::fail('Expected invalid locale exception.');
         } catch (ConfigException $e) {
-            self::assertStringContainsString('language locale', $e->getMessage());
+            self::assertStringContainsString('locale', $e->getMessage());
+            self::assertStringContainsString('pattern', $e->getMessage());
         }
     }
 
@@ -577,11 +579,12 @@ class ConfigTest extends TestCase
             ]);
             self::fail('Expected missing name validation exception.');
         } catch (ConfigException $e) {
-            self::assertStringContainsString('missing "name"', $e->getMessage());
+            self::assertStringContainsString('name', $e->getMessage());
+            self::assertStringContainsString('is missing', $e->getMessage());
         }
 
         $this->expectException(ConfigException::class);
-        $this->expectExceptionMessage('missing "mediatype"');
+        $this->expectExceptionMessage('mediatype');
 
         new Config([
             'output' => [

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -609,4 +609,108 @@ class ConfigTest extends TestCase
             putenv('CECIL_LANGUAGE');
         }
     }
+
+    public function testThemeAcceptsStringAndListOfStrings(): void
+    {
+        $config = new Config();
+        $config->import(['theme' => 'hyde']);
+        self::assertSame(['hyde'], $config->getTheme());
+
+        $config->import(['theme' => ['serviceworker', 'hyde']]);
+        self::assertSame(['serviceworker', 'hyde'], $config->getTheme());
+    }
+
+    public function testInvalidThemeStructureIsRejected(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        new Config([
+            'theme' => ['name' => 'hyde'],
+        ]);
+    }
+
+    public function testDataStructureRejectsInvalidLoadType(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        new Config([
+            'data' => ['load' => 'yes'],
+        ]);
+    }
+
+    public function testStaticStructureRejectsInvalidLoadType(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        new Config([
+            'static' => ['load' => 'yes'],
+        ]);
+    }
+
+    public function testOptimizeAcceptsBooleanShorthand(): void
+    {
+        $config = new Config();
+        $config->import(['optimize' => true]);
+
+        self::assertTrue($config->isEnabled('optimize'));
+    }
+
+    public function testOptimizeRejectsInvalidExtType(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        new Config([
+            'optimize' => [
+                'html' => ['ext' => 'html'],
+            ],
+        ]);
+    }
+
+    public function testOutputPageTypeFormatsRejectsNonListValue(): void
+    {
+        $this->expectException(ConfigException::class);
+
+        new Config([
+            'output' => [
+                'pagetypeformats' => ['page' => 'html'],
+            ],
+        ]);
+    }
+
+    public function testServerHeadersAcceptValidStructure(): void
+    {
+        $config = new Config();
+        $config->import([
+            'server' => [
+                'headers' => [
+                    [
+                        'path' => '/*',
+                        'headers' => [
+                            ['key' => 'X-Frame-Options', 'value' => 'SAMEORIGIN'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame('/*', $config->get('server.headers')[0]['path']);
+    }
+
+    public function testServerHeadersRequirePath(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('path');
+
+        new Config([
+            'server' => [
+                'headers' => [
+                    [
+                        'headers' => [
+                            ['key' => 'X-Frame-Options', 'value' => 'SAMEORIGIN'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new schema-based configuration validation system using the `nette/schema` library. The main configuration options are now validated structurally, improving error reporting and maintainability. Several custom validation methods were removed in favor of this unified schema approach. The test suite was updated and expanded to cover the new validation behaviors and error messages.

**Configuration validation improvements:**

* Added `nette/schema` as a dependency in `composer.json` to enable schema-based configuration validation.
* Replaced custom validation logic in `Config.php` with a single `validateSchema()` method that uses `nette/schema` schemas for key configuration sections, improving error messages and maintainability. Custom validation methods for cache, output formats, and languages were removed. [[1]](diffhunk://#diff-9727fe62ad60c6637a7def31b06f908a39f99f118a78280469d7a62eb67a9d68R655-L666) [[2]](diffhunk://#diff-9727fe62ad60c6637a7def31b06f908a39f99f118a78280469d7a62eb67a9d68L690-R815)
* Defined schemas for main configuration sections (e.g., `theme`, `cache`, `output.formats`, `languages`, `date`, `pages`, `data`, `static`, `optimize`, `server.headers`) in a new `getSchemas()` method. This ensures that only well-defined sections are strictly validated, while custom sections remain open.

**Testing updates and additions:**

* Updated existing tests in `ConfigTest.php` to match new error messages and validation logic (e.g., language and output format validation errors now check for schema-based messages). [[1]](diffhunk://#diff-0cc5256bd8d5ed0687c6e793a59946d3b16ff360473c498bc263e08b14d59e1eL54-R54) [[2]](diffhunk://#diff-0cc5256bd8d5ed0687c6e793a59946d3b16ff360473c498bc263e08b14d59e1eL349-R350) [[3]](diffhunk://#diff-0cc5256bd8d5ed0687c6e793a59946d3b16ff360473c498bc263e08b14d59e1eL360-R362) [[4]](diffhunk://#diff-0cc5256bd8d5ed0687c6e793a59946d3b16ff360473c498bc263e08b14d59e1eL580-R587)
* Added new tests to verify that schemas accept or reject valid/invalid structures for `theme`, `data`, `static`, `optimize`, `output.pagetypeformats`, and `server.headers`. These tests ensure the new schema validation is robust and covers a variety of cases.

**Dependency and import changes:**

* Imported `Nette\Schema` classes in `Config.php` to support schema definition and validation.